### PR TITLE
CI: Attach project binary to release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,21 +47,3 @@ jobs:
           body_path: release_message.md
           files: ./dist/nx_neptune-*.whl
 
-#  deploy:
-#    needs: release
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v4
-#
-#    - name: Set up Python
-#      uses: actions/setup-python@v5
-#      with:
-#        python-version: '3.x'
-
-#    - name: Build and publish
-#      env:
-#        TWINE_USERNAME: __token__
-#        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-#      run: |
-#        python -m pip wheel -w dist .
-#        twine upload dist/*


### PR DESCRIPTION
### Summary :memo:
This is the PR to update existing release pipeline to perform the following:
 - Attach project whl file as part of the release asset 
 - Comment out the Pypi publish job to avoid failure


### Test plan:
 - Create a test release tag on this branch and observe the release page and make sure .whl file is now one of the asset. 

