### PR TITLE
Format additional background docs

### DIFF
--- a/nx_plugin/__init__.py
+++ b/nx_plugin/__init__.py
@@ -42,41 +42,30 @@ _info = {
     },
     "additional_docs": {
         # BEGIN: additional_docs
-        "bfs_edges": f"For additional details, see {algorithms_url}#bfs_edges)",
-        "descendants_at_distance": f"For additional details, see {algorithms_url}#descendants_at_distance)",
-        "bfs_layers": f"For additional details, see {algorithms_url}#bfs_layers)",
-        "pagerank": f"""Neptune Analytics recommends using a max_iter value of 20 for PageRank
-            calculations, which balances computational efficiency with result accuracy. This
-            default setting is optimized for most graph workloads, though you can adjust it
-            based on your specific convergence requirements. Please note that the
-            personalization, nstart, weight, and dangling parameters are not supported at
-            the moment.
-            For additional parameters, see {algorithms_url}#pagerank)
-            """,
-        "degree_centrality": f"For additional details, see {algorithms_url}#degree_centrality)",
-        "in_degree_centrality": f"For additional details, see {algorithms_url}#in_degree_centrality)",
-        "out_degree_centrality": f"For additional details, see {algorithms_url}#out_degree_centrality)",
-        "asyn_lpa_communities": f"""
-        The seed parameter is not supported at the moment.
-        Also, label propagation in Neptune Analytics maps all NetworkX variants to the same algorithm,
-        using a fixed label update strategy.
-        Variant-specific control over the update method (e.g., synchronous vs. asynchronous) is not configurable.
-        For additional parameters, see {algorithms_url}#asyn_lpa_communities)
-        """,
-        "fast_label_propagation_communities": f"""
-        Please note that the seed parameter is not supported at the moment,
-        also label propagation in Neptune Analytics maps all NetworkX variants to the same algorithm,
-        using a fixed label update strategy.
-        Variant-specific control over the update method (e.g., synchronous vs. asynchronous) is not configurable.
-        For additional parameters, see {algorithms_url}#fast_label_propagation_communities)
-        """,
-        "closeness_centrality": f"For additional details, see {algorithms_url}#closeness_centrality)",
-        "label_propagation_communities": f"For additional details, "
-        f"see {algorithms_url}#label_propagation_communities)",
-        "louvain_communities": f"""
-        Please note that the resolution and seed parameters are not supported at the moment.
-        For additional parameters, see {algorithms_url}#louvain_communities)
-        """,
+        "bfs_edges": f"For additional details, see {algorithms_url}#bfs_edges",
+        "descendants_at_distance": f"For additional details, see {algorithms_url}#descendants_at_distance",
+        "bfs_layers": f"For additional details, see {algorithms_url}#bfs_layers",
+        "pagerank": f"""- Neptune Analytics recommends using a `max_iter` value of `20` for PageRank calculations, \
+which balances computational efficiency with result accuracy. This default setting is optimized for most graph \
+workloads, though you can adjust it based on your specific convergence requirements. 
+- Please note that the `personalization`, `nstart`, `weight`, and `dangling` parameters are not supported at the moment.
+- For additional parameters, see {algorithms_url}#pagerank""",
+        "degree_centrality": f"For additional details, see {algorithms_url}#degree_centrality",
+        "in_degree_centrality": f"For additional details, see {algorithms_url}#in_degree_centrality",
+        "out_degree_centrality": f"For additional details, see {algorithms_url}#out_degree_centrality",
+        "asyn_lpa_communities": f"""- The `seed` parameter is not supported at the moment.
+- Label propagation in Neptune Analytics maps all NetworkX variants to the same algorithm, using a fixed label update \
+strategy. Variant-specific control over the update method (e.g., synchronous vs. asynchronous) is not configurable.  
+- For additional parameters, see {algorithms_url}#asyn_lpa_communities""",
+        "fast_label_propagation_communities": f"""- The `seed` parameter is not supported at the moment.
+- Label propagation in Neptune Analytics maps all NetworkX variants to the same algorithm, using a fixed label update \
+strategy. Variant-specific control over the update method (e.g., synchronous vs. asynchronous) is not configurable.
+- For additional parameters, see {algorithms_url}#fast_label_propagation_communities""",
+        "closeness_centrality": f"For additional details, see {algorithms_url}#closeness_centrality",
+        "label_propagation_communities": f"For additional details, see {algorithms_url}#label_propagation_communities",
+        "louvain_communities": f"""- Please note that the `resolution` and `seed` parameters are not supported at the \
+moment.
+- For additional parameters, see {algorithms_url}#louvain_communities""",
         # END: additional_docs
     },
     "additional_parameters": {


### PR DESCRIPTION
### Summary :memo:

Updated docs with formatting:  

asyn_lpa_communities: 
<img width="700" height="261" alt="image" src="https://github.com/user-attachments/assets/ac758ceb-2623-48f0-9364-5f7fd6852fbf" />

fast_label_propagation_communities/ 
<img width="700" height="257" alt="image" src="https://github.com/user-attachments/assets/cd41f79a-9a9c-4bee-a4b1-5ae724ca6d3c" />

pagerank
<img width="701" height="289" alt="image" src="https://github.com/user-attachments/assets/2f0e425a-e83c-4013-95fb-7f6dfa63a8ad" />

louvain
<img width="697" height="177" alt="image" src="https://github.com/user-attachments/assets/32ef2119-ce7d-4852-bfcd-fd8e7be00c1b" />

The rest of the affected algorithms look like: 
<img width="703" height="122" alt="image" src="https://github.com/user-attachments/assets/cbfdb9fc-7ff6-4d52-9f20-28431f6b6dfd" />

### Test plan:

Manual verification

### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
