### PR TITLE
Fix label propagation and return a set

### DIFF
--- a/nx_neptune/algorithms/communities/label_propagation.py
+++ b/nx_neptune/algorithms/communities/label_propagation.py
@@ -358,6 +358,5 @@ def _label_propagation_communities(
 
         result = {}
         for item in json_result:
-            result[item["community"]] = item["members"]
-        # Return dict_value to match NX return type.
+            result[item["community"]] = set(item["members"])
         return result.values()

--- a/tests/algorithms/communities/test_label_propagation.py
+++ b/tests/algorithms/communities/test_label_propagation.py
@@ -44,9 +44,9 @@ class TestLabelPropagation:
     """Test suite for all three variants of labels propagation algorithms in nx_neptune."""
 
     PARSED_RESULT_SET = [
-        ["SLM", "IAA", "GRV", "ETZ", "MME", "ZAD"],
-        ["FAI", "HSL", "HUS", "LMA", "GAL", "KBC"],
-        ["FAT", "UII", "SJT", "VSA", "QBC", "LAM"],
+        {"SLM", "IAA", "GRV", "ETZ", "MME", "ZAD"},
+        {"FAI", "HSL", "HUS", "LMA", "GAL", "KBC"},
+        {"FAT", "UII", "SJT", "VSA", "QBC", "LAM"},
     ]
 
     @pytest.fixture


### PR DESCRIPTION
### Summary :memo:

Label propagation should return a `set`, instead of a `list`.  

### Test plan:



### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
