### PR TITLE
Databricks Connector - Metadatahandler

### DIFF
--- a/connectors/athena-databricks-connector/athena-databricks-connector.yaml
+++ b/connectors/athena-databricks-connector/athena-databricks-connector.yaml
@@ -37,6 +37,12 @@ Parameters:
   SecretName:
     Description: "The name of the secret in AWS Secrets Manager that contains the Databricks personal access token."
     Type: String
+  DatabricksHttpPath:
+    Description: "The HTTP path for the Databricks SQL warehouse (e.g., /sql/1.0/warehouses/abc123)."
+    Type: String
+  DatabricksConnCatalog:
+    Description: "The Databricks Unity Catalog name to connect to."
+    Type: String
   DatabricksDefaultDatabase:
     Description: "The default Databricks Unity Catalog database (catalog.schema) to use when not specified in the query."
     Default: default
@@ -60,6 +66,8 @@ Resources:
           spill_prefix: !Ref SpillPrefix
           secret_manager_databricks_token_name: !Ref SecretName
           databricks_default_database: !Ref DatabricksDefaultDatabase
+          databricks_http_path: !Ref DatabricksHttpPath
+          databricks_conn_catalog: !Ref DatabricksConnCatalog
       FunctionName: !Sub "${AthenaCatalogName}"
       PackageType: Image
       ImageConfig:

--- a/connectors/athena-databricks-connector/src/main/java/com/amazonaws/athena/connectors/databricks/DatabricksCompositeHandler.java
+++ b/connectors/athena-databricks-connector/src/main/java/com/amazonaws/athena/connectors/databricks/DatabricksCompositeHandler.java
@@ -31,8 +31,7 @@ public class DatabricksCompositeHandler
 {
     public DatabricksCompositeHandler()
     {
-
-        super(new DatabricksMetadataHandler("Databricks", new DatabricksEnvironmentProperties().createEnvironment()),
+        super(new DatabricksMetadataHandler(new DatabricksEnvironmentProperties().createEnvironment()),
                 new DatabricksRecordHandler("Databricks", new DatabricksEnvironmentProperties().createEnvironment()));
     }
 }

--- a/connectors/athena-databricks-connector/src/main/java/com/amazonaws/athena/connectors/databricks/DatabricksMetadataHandler.java
+++ b/connectors/athena-databricks-connector/src/main/java/com/amazonaws/athena/connectors/databricks/DatabricksMetadataHandler.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-jdbc
+ * athena-databricks
  * %%
  * Copyright (C) 2026 Amazon Web Services
  * %%
@@ -20,9 +20,15 @@
 package com.amazonaws.athena.connectors.databricks;
 
 import com.amazonaws.athena.connector.lambda.QueryStatusChecker;
+import com.amazonaws.athena.connector.lambda.data.Block;
 import com.amazonaws.athena.connector.lambda.data.BlockAllocator;
 import com.amazonaws.athena.connector.lambda.data.BlockWriter;
+import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
+import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.metadata.*;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.DataSourceOptimizations;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.OptimizationSubType;
+import com.amazonaws.athena.connector.lambda.metadata.optimizations.pushdown.FilterPushdownSubType;
 import com.amazonaws.athena.connectors.databricks.resolver.DataBricksJDBCCaseResolver;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionConfig;
 import com.amazonaws.athena.connectors.jdbc.connection.DatabaseConnectionInfo;
@@ -30,9 +36,14 @@ import com.amazonaws.athena.connectors.jdbc.connection.GenericJdbcConnectionFact
 import com.amazonaws.athena.connectors.jdbc.manager.JDBCUtil;
 import com.amazonaws.athena.connectors.jdbc.manager.JdbcMetadataHandler;
 import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Handles metadata operations for Databricks Unity Catalog via JDBC.
@@ -41,30 +52,43 @@ import java.util.*;
 public class DatabricksMetadataHandler
         extends JdbcMetadataHandler
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabricksMetadataHandler.class);
 
-    public static final String DATABRICKS_NAME = "postgres";
-    public static final String POSTGRESQL_DRIVER_CLASS = "org.postgresql.Driver";
-    public static final int POSTGRESQL_DEFAULT_PORT = 5432;
-    public static final String POSTGRES_QUOTE_CHARACTER = "\"";
-    public static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of("databaseTerm", "SCHEMA");
+    public static final String DATABRICKS_NAME = "databricks";
+    public static final String DATABRICKS_DRIVER_CLASS = "com.databricks.client.jdbc.Driver";
+    public static final int DATABRICKS_DEFAULT_PORT = 443;
 
-    protected DatabricksMetadataHandler(String sourceType, Map<String, String> configOptions) {
-        super(sourceType, configOptions);
-    }
+    private static final String BLOCK_PARTITION_COLUMN_NAME = "partition";
+    private static final String ALL_PARTITIONS = "*";
+
+    /** Environment variable key for the Databricks SQL warehouse HTTP path. */
+    static final String HTTP_PATH_CONFIG_KEY = "databricks_http_path";
+    /** Environment variable key for the Databricks Unity Catalog name. */
+    static final String CONN_CATALOG_CONFIG_KEY = "databricks_conn_catalog";
+
+    /** Default JDBC connection properties for Databricks. */
+    private static final Map<String, String> JDBC_PROPERTIES = ImmutableMap.of(
+            "databaseTerm", "SCHEMA",
+            "ssl", "1",
+            "AuthMech", "3",
+            "user", "token");
 
     /**
      * Instantiates handler to be used by Lambda function directly.
-     *
+     * Reads connection config from environment variables.
      */
-    public DatabricksMetadataHandler(java.util.Map<String, String> configOptions)
+    public DatabricksMetadataHandler(Map<String, String> configOptions)
     {
         this(JDBCUtil.getSingleDatabaseConfigFromEnv(DATABRICKS_NAME, configOptions), configOptions);
     }
 
-    public DatabricksMetadataHandler(DatabaseConnectionConfig databaseConnectionConfig, java.util.Map<String, String> configOptions)
+    /**
+     * Instantiates handler with explicit connection config.
+     */
+    public DatabricksMetadataHandler(DatabaseConnectionConfig databaseConnectionConfig, Map<String, String> configOptions)
     {
         super(databaseConnectionConfig,
-                new GenericJdbcConnectionFactory(databaseConnectionConfig, JDBC_PROPERTIES, new DatabaseConnectionInfo(POSTGRESQL_DRIVER_CLASS, POSTGRESQL_DEFAULT_PORT)),
+                new GenericJdbcConnectionFactory(databaseConnectionConfig, buildJdbcProperties(configOptions), new DatabaseConnectionInfo(DATABRICKS_DRIVER_CLASS, DATABRICKS_DEFAULT_PORT)),
                 configOptions,
                 new DataBricksJDBCCaseResolver(DATABRICKS_NAME));
     }
@@ -74,22 +98,53 @@ public class DatabricksMetadataHandler
      */
     @Override
     public Schema getPartitionSchema(String catalogName) {
-        return null;
+        return SchemaBuilder.newBuilder()
+                .addField(BLOCK_PARTITION_COLUMN_NAME, Types.MinorType.VARCHAR.getType())
+                .build();
     }
 
     /**
      * {@inheritDoc}
+     * Returns a single partition since Databricks partition pruning is not yet supported.
      */
     @Override
     public void getPartitions(BlockWriter blockWriter, GetTableLayoutRequest request, QueryStatusChecker queryStatusChecker) throws Exception {
+        blockWriter.writeRows((Block block, int rowNum) -> {
+            block.setValue(BLOCK_PARTITION_COLUMN_NAME, rowNum, ALL_PARTITIONS);
+            return 1;
+        });
+    }
 
+    /**
+     * {@inheritDoc}
+     * Returns a single split covering the entire table.
+     */
+    @Override
+    public GetSplitsResponse doGetSplits(BlockAllocator blockAllocator, GetSplitsRequest getSplitsRequest) {
+        return new GetSplitsResponse(getSplitsRequest.getCatalogName(),
+                Split.newBuilder(makeSpillLocation(getSplitsRequest), makeEncryptionKey()).build());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public GetSplitsResponse doGetSplits(BlockAllocator blockAllocator, GetSplitsRequest getSplitsRequest) {
-        return null;
+    public GetDataSourceCapabilitiesResponse doGetDataSourceCapabilities(BlockAllocator allocator, GetDataSourceCapabilitiesRequest request) {
+        ImmutableMap.Builder<String, List<OptimizationSubType>> capabilities = ImmutableMap.builder();
+        capabilities.put(DataSourceOptimizations.SUPPORTS_FILTER_PUSHDOWN.withSupportedSubTypes(
+                FilterPushdownSubType.SORTED_RANGE_SET, FilterPushdownSubType.NULLABLE_COMPARISON
+        ));
+        return new GetDataSourceCapabilitiesResponse(request.getCatalogName(), capabilities.build());
+    }
+
+    /**
+     * Builds JDBC properties by combining defaults with httpPath and ConnCatalog from environment config.
+     */
+    private static Map<String, String> buildJdbcProperties(Map<String, String> configOptions)
+    {
+        Map<String, String> props = new HashMap<>(JDBC_PROPERTIES);
+        props.put("httpPath", configOptions.getOrDefault(HTTP_PATH_CONFIG_KEY, ""));
+        props.put("ConnCatalog", configOptions.getOrDefault(CONN_CATALOG_CONFIG_KEY, ""));
+        return props;
     }
 }

--- a/connectors/athena-databricks-connector/src/main/java/com/amazonaws/athena/connectors/databricks/resolver/DataBricksJDBCCaseResolver.java
+++ b/connectors/athena-databricks-connector/src/main/java/com/amazonaws/athena/connectors/databricks/resolver/DataBricksJDBCCaseResolver.java
@@ -1,6 +1,6 @@
 /*-
  * #%L
- * athena-snowflake
+ * athena-databricks
  * %%
  * Copyright (C) 2019 - 2025 Amazon Web Services
  * %%
@@ -31,13 +31,12 @@ public class DataBricksJDBCCaseResolver
     private static final Logger LOGGER = LoggerFactory.getLogger(DataBricksJDBCCaseResolver.class);
     private static final String SCHEMA_NAME_QUERY_TEMPLATE = "SELECT schema_name FROM information_schema.schemata WHERE lower(schema_name) = ?";
     private static final String TABLE_NAME_QUERY_TEMPLATE = "SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND lower(table_name) = ?";
-    private static final String TABLE_NAME_QUERY_MATERIALIZED_VIEW = "select matviewname as \"table_name\" from pg_catalog.pg_matviews mv where schemaname = ? and lower(matviewname) = ?";
     private static final String SCHEMA_NAME_COLUMN_KEY = "schema_name";
     private static final String TABLE_NAME_COLUMN_KEY = "table_name";
 
     public DataBricksJDBCCaseResolver(String sourceType)
     {
-        super(sourceType, FederationSDKCasingMode.CASE_INSENSITIVE_SEARCH, FederationSDKCasingMode.NONE);
+        super(sourceType, FederationSDKCasingMode.NONE, FederationSDKCasingMode.NONE);
     }
 
     @Override
@@ -55,7 +54,7 @@ public class DataBricksJDBCCaseResolver
     @Override
     protected List<String> getCaseInsensitivelyTableNameQueryTemplate()
     {
-        return List.of(TABLE_NAME_QUERY_TEMPLATE, TABLE_NAME_QUERY_MATERIALIZED_VIEW);
+        return List.of(TABLE_NAME_QUERY_TEMPLATE);
     }
 
     @Override


### PR DESCRIPTION
### Summary :memo:
This PR aims to provide support for Metadata discovery, in order to help user to understand the database catalog before issuing an query. 



### Test plan:

Install it and test on Athena with queries:
* show databases in `lambda:databricks`;
* show tables in `lambda:databricks`.accuweather;



### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
