### PR TITLE
CI: Pin Github actions hash

### DIFF
--- a/.github/workflows/athena-s3vector-connector.yml
+++ b/.github/workflows/athena-s3vector-connector.yml
@@ -23,9 +23,9 @@ jobs:
       AWS_REGION: us-west-2
       AWS_DEFAULT_REGION: us-west-2
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'corretto'
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install project for developers
@@ -39,8 +39,8 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run license-check
@@ -54,8 +54,8 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install project for developers
@@ -72,9 +72,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload HTML coverage report
         id: artifact-upload-step
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: coverage-report
@@ -99,7 +99,7 @@ jobs:
 
       - name: Comment PR with artifact link 
         if: ${{ failure() && steps.unit-test.outcome == 'failure' && github.event_name == 'pull_request'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const artifactId = ${{ steps.artifact-upload-step.outputs.artifact-id }}
@@ -123,8 +123,8 @@ jobs:
 #        os: [macos-latest]
 #    runs-on: ${{ matrix.os }}
 #    steps:
-#      - uses: actions/checkout@v6
-#      - uses: actions/setup-python@v6
+#      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 #        with:
 #          python-version: ${{ matrix.python-version }}
 #      - name: Install project for developers
@@ -142,8 +142,8 @@ jobs:
 #        os: [windows-latest]
 #    runs-on: ${{ matrix.os }}
 #    steps:
-#      - uses: actions/checkout@v6
-#      - uses: actions/setup-python@v6
+#      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 #        with:
 #          python-version: ${{ matrix.python-version }}
 #      - name: Install Pip

--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 
@@ -38,7 +38,7 @@ jobs:
           make dist
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 
@@ -38,7 +38,7 @@ jobs:
           make dist
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: release-dists
           path: dist/
@@ -59,12 +59,12 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: dist/


### PR DESCRIPTION
### Summary :memo:

Pin all GitHub Actions in CI workflows to full commit SHAs instead of mutable version tags. This prevents supply chain attacks where a compromised tag could inject malicious code into our CI pipelines.

**Pinned actions:**

| Action | Hash | Version | Verify |
|--------|------|---------|--------|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 | [release](https://github.com/actions/checkout/releases/tag/v6.0.2) |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | v6.2.0 | [release](https://github.com/actions/setup-python/releases/tag/v6.2.0) |
| `actions/setup-java` | `be666c2fcd27ec809703dec50e508c2fdc7f6654` | v5.2.0 | [release](https://github.com/actions/setup-java/releases/tag/v5.2.0) |
| `actions/upload-artifact` | `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` | v7.0.0 | [release](https://github.com/actions/upload-artifact/releases/tag/v7.0.0) |
| `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8.0.1 | [release](https://github.com/actions/download-artifact/releases/tag/v8.0.1) |
| `pypa/gh-action-pypi-publish` | `ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e` | v1.13.0 | [release](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.13.0) |
| `actions/github-script` | `ed597411d8f924073f98dfc5c65a23a2325f34cd` | v8.0.0 | [release](https://github.com/actions/github-script/releases/tag/v8.0.0) |

Each hash can be verified by clicking the release link and confirming the commit SHA matches.

### Test plan:
- No functional changes — only `uses:` references updated
- CI workflows will behave identically since the hashes point to the same code as the previous version tags

### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.