### PR TITLE
Integ Test: pt2 (Import and Export)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -98,8 +98,8 @@ export NETWORKX_S3_EXPORT_BUCKET_PATH=s3://your-bucket/path/  # for tier 2 (S3 b
 # Run tier 1 only (NeptuneGraph CRUD + SessionManager read ops, ~1 min)
 pytest integ_test/tier1_graph/ -v
 
-# Run tier 2 only (S3 import/export + IAM permissions, ~3 min)
-pytest integ_test/tier2_s3/ -v -s
+# Run tier 2 only (S3 import/export + snapshots + IAM permissions, ~5 min)
+pytest integ_test/tier2_export_import/ -v -s
 
 # Run all integration tests (algorithms + security + tier 1 + tier 2)
 make integ-test
@@ -112,8 +112,9 @@ make integ-test
 | Algorithms | `integ_test/test_algo_*.py` | PageRank, closeness, degree, Louvain, LPA, BFS |
 | Security | `integ_test/test_security_*.py` | Injection prevention, graph reset, S3 versioning |
 | Tier 1 — Graph CRUD | `integ_test/tier1_graph/` | add/update/delete nodes & edges, clear_graph, execute_call, SessionManager list/get graphs, validate_permissions |
-| Tier 2 — S3 Import/Export | `integ_test/tier2_s3/test_s3_import_export.py` | export_csv_to_s3, export with filter, round-trip import, empty_s3_bucket |
-| Tier 2 — IAM Permissions | `integ_test/tier2_s3/test_iam_permissions.py` | has_import/export/delete_s3_permissions, check_s3_versioning, S3 ARN parsing |
+| Tier 2 — S3 Import/Export | `integ_test/tier2_export_import/test_s3_import_export.py` | export_csv_to_s3, export with filter, round-trip import, empty_s3_bucket |
+| Tier 2 — Snapshots | `integ_test/tier2_export_import/test_snapshot.py` | create_graph_snapshot, delete_graph_snapshot |
+| Tier 2 — IAM Permissions | `integ_test/tier2_export_import/test_iam_permissions.py` | has_import/export/delete_s3_permissions, check_s3_versioning, S3 ARN parsing |
 
 ### Resource cleanup
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -85,10 +85,11 @@ Integration tests live in `integ_test/` and require a live Neptune Analytics gra
 
 ### Prerequisites
 
-Set the following environment variable:
+Set the following environment variables:
 
 ```bash
 export NETWORKX_GRAPH_ID=g-your-graph-id
+export NETWORKX_S3_EXPORT_BUCKET_PATH=s3://your-bucket/path/  # for tier 2 (S3 bucket must have KMS + versioning enabled)
 ```
 
 ### Running tests
@@ -97,7 +98,10 @@ export NETWORKX_GRAPH_ID=g-your-graph-id
 # Run tier 1 only (NeptuneGraph CRUD + SessionManager read ops, ~1 min)
 pytest integ_test/tier1_graph/ -v
 
-# Run all integration tests (algorithms + security + tier 1)
+# Run tier 2 only (S3 import/export + IAM permissions, ~3 min)
+pytest integ_test/tier2_s3/ -v -s
+
+# Run all integration tests (algorithms + security + tier 1 + tier 2)
 make integ-test
 ```
 
@@ -108,6 +112,8 @@ make integ-test
 | Algorithms | `integ_test/test_algo_*.py` | PageRank, closeness, degree, Louvain, LPA, BFS |
 | Security | `integ_test/test_security_*.py` | Injection prevention, graph reset, S3 versioning |
 | Tier 1 — Graph CRUD | `integ_test/tier1_graph/` | add/update/delete nodes & edges, clear_graph, execute_call, SessionManager list/get graphs, validate_permissions |
+| Tier 2 — S3 Import/Export | `integ_test/tier2_s3/test_s3_import_export.py` | export_csv_to_s3, export with filter, round-trip import, empty_s3_bucket |
+| Tier 2 — IAM Permissions | `integ_test/tier2_s3/test_iam_permissions.py` | has_import/export/delete_s3_permissions, check_s3_versioning, S3 ARN parsing |
 
 ### Resource cleanup
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,40 +81,48 @@ Refer to each connector's README for SAM deployment instructions.
 
 ## Integration tests
 
-Integration tests live in `integ_test/` and require a live Neptune Analytics graph instance. They are not run in CI and must be executed manually before each release.
+Integration tests live in `integ_test/` and are designed to be run incrementally — each tier adds more coverage as you provide more AWS resources. Tests auto-skip if the required environment variables are not set.
 
-### Prerequisites
+### Tiers
 
-Set the following environment variables:
+| Tier | What you provide | What you can test |
+|---|---|---|
+| Tier 1 | `NETWORKX_GRAPH_ID` | NeptuneGraph CRUD, SessionManager read ops, algorithms, security |
+| Tier 2 | Tier 1 + `NETWORKX_S3_EXPORT_BUCKET_PATH` | S3 export/import, snapshots, IAM permission checks |
+
+### Environment variables
 
 ```bash
+# Tier 1 — just a graph ID
 export NETWORKX_GRAPH_ID=g-your-graph-id
-export NETWORKX_S3_EXPORT_BUCKET_PATH=s3://your-bucket/path/  # for tier 2 (S3 bucket must have KMS + versioning enabled)
+
+# Tier 2 — add an S3 bucket (must have KMS encryption + versioning enabled)
+export NETWORKX_S3_EXPORT_BUCKET_PATH=s3://your-bucket/path/
 ```
 
 ### Running tests
 
 ```bash
-# Run tier 1 only (NeptuneGraph CRUD + SessionManager read ops, ~1 min)
+# Tier 1 only (~1 min, requires NETWORKX_GRAPH_ID)
 pytest integ_test/tier1_graph/ -v
 
-# Run tier 2 only (S3 import/export + snapshots + IAM permissions, ~5 min)
+# Tier 2 only (~5 min, requires NETWORKX_GRAPH_ID + NETWORKX_S3_EXPORT_BUCKET_PATH)
 pytest integ_test/tier2_export_import/ -v -s
 
-# Run all integration tests (algorithms + security + tier 1 + tier 2)
+# All integration tests
 make integ-test
 ```
 
 ### What is covered
 
-| Test suite | Directory | What it covers |
-|---|---|---|
-| Algorithms | `integ_test/test_algo_*.py` | PageRank, closeness, degree, Louvain, LPA, BFS |
-| Security | `integ_test/test_security_*.py` | Injection prevention, graph reset, S3 versioning |
-| Tier 1 — Graph CRUD | `integ_test/tier1_graph/` | add/update/delete nodes & edges, clear_graph, execute_call, SessionManager list/get graphs, validate_permissions |
-| Tier 2 — S3 Import/Export | `integ_test/tier2_export_import/test_s3_import_export.py` | export_csv_to_s3, export with filter, round-trip import, empty_s3_bucket |
-| Tier 2 — Snapshots | `integ_test/tier2_export_import/test_snapshot.py` | create_graph_snapshot, delete_graph_snapshot |
-| Tier 2 — IAM Permissions | `integ_test/tier2_export_import/test_iam_permissions.py` | has_import/export/delete_s3_permissions, check_s3_versioning, S3 ARN parsing |
+| Test suite | Directory | Tier | What it covers |
+|---|---|---|---|
+| Algorithms | `integ_test/test_algo_*.py` | 1 | PageRank, closeness, degree, Louvain, LPA, BFS |
+| Security | `integ_test/test_security_*.py` | 1 | Injection prevention, graph reset, S3 versioning |
+| Graph CRUD | `integ_test/tier1_graph/` | 1 | add/update/delete nodes & edges, clear_graph, execute_call, SessionManager list/get graphs, validate_permissions |
+| S3 Import/Export | `integ_test/tier2_export_import/test_s3_import_export.py` | 2 | export_csv_to_s3, export with filter, round-trip import, empty_s3_bucket |
+| Snapshots | `integ_test/tier2_export_import/test_snapshot.py` | 2 | create_graph_snapshot, delete_graph_snapshot |
+| IAM Permissions | `integ_test/tier2_export_import/test_iam_permissions.py` | 2 | has_import/export/delete_s3_permissions, check_s3_versioning, S3 ARN parsing |
 
 ### Resource cleanup
 

--- a/integ_test/tier2_export_import/conftest.py
+++ b/integ_test/tier2_export_import/conftest.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 fixtures — requires NETWORKX_GRAPH_ID + S3 bucket."""
+
+import logging
+import os
+import uuid
+
+import boto3
+import networkx as nx
+import pytest
+from botocore.exceptions import ClientError
+
+from nx_neptune import NeptuneGraph, NETWORKX_GRAPH_ID, Node, Edge
+from nx_neptune.clients.iam_client import IamClient
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("nx_neptune").setLevel(logging.INFO)
+
+S3_IMPORT_BUCKET = os.environ.get("NETWORKX_S3_IMPORT_BUCKET_PATH")
+S3_EXPORT_BUCKET = os.environ.get("NETWORKX_S3_EXPORT_BUCKET_PATH")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_s3_config():
+    if not NETWORKX_GRAPH_ID:
+        pytest.skip("NETWORKX_GRAPH_ID not set")
+    if not S3_EXPORT_BUCKET:
+        pytest.skip("NETWORKX_S3_EXPORT_BUCKET_PATH not set")
+
+
+@pytest.fixture(scope="module")
+def neptune_graph():
+    """NeptuneGraph instance with test data for export."""
+    g = nx.Graph()
+    na_graph = NeptuneGraph.from_config(graph=g)
+    na_graph.clear_graph()
+    yield na_graph
+    na_graph.clear_graph()
+
+
+@pytest.fixture(scope="module")
+def s3_client():
+    return boto3.client("s3")
+
+
+@pytest.fixture(scope="module")
+def iam_client():
+    sts_arn = boto3.client("sts").get_caller_identity()["Arn"]
+    return IamClient(role_arn=sts_arn, client=boto3.client("iam"))
+
+
+@pytest.fixture(scope="module")
+def seeded_graph(neptune_graph):
+    """Graph with a few nodes and edges for export testing."""
+    nodes = [
+        Node(id="s1", labels=["Person"], properties={"name": "Alice"}),
+        Node(id="s2", labels=["Person"], properties={"name": "Bob"}),
+        Node(id="s3", labels=["Person"], properties={"name": "Carol"}),
+    ]
+    neptune_graph.add_nodes(nodes)
+    neptune_graph.add_edges([
+        Edge(node_src=nodes[0], node_dest=nodes[1], label="KNOWS"),
+        Edge(node_src=nodes[1], node_dest=nodes[2], label="KNOWS"),
+    ])
+    return neptune_graph

--- a/integ_test/tier2_export_import/conftest.py
+++ b/integ_test/tier2_export_import/conftest.py
@@ -1,15 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tier 2 fixtures — requires NETWORKX_GRAPH_ID + S3 bucket."""
+"""Tier 2 fixtures — export/import tests (S3 + snapshots)."""
 
 import logging
 import os
-import uuid
 
 import boto3
 import networkx as nx
 import pytest
-from botocore.exceptions import ClientError
 
 from nx_neptune import NeptuneGraph, NETWORKX_GRAPH_ID, Node, Edge
 from nx_neptune.clients.iam_client import IamClient
@@ -17,20 +15,23 @@ from nx_neptune.clients.iam_client import IamClient
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("nx_neptune").setLevel(logging.INFO)
 
-S3_IMPORT_BUCKET = os.environ.get("NETWORKX_S3_IMPORT_BUCKET_PATH")
 S3_EXPORT_BUCKET = os.environ.get("NETWORKX_S3_EXPORT_BUCKET_PATH")
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _require_s3_config():
+def _require_graph_id():
     if not NETWORKX_GRAPH_ID:
         pytest.skip("NETWORKX_GRAPH_ID not set")
+
+
+@pytest.fixture(scope="module")
+def _require_s3():
     if not S3_EXPORT_BUCKET:
         pytest.skip("NETWORKX_S3_EXPORT_BUCKET_PATH not set")
 
 
 @pytest.fixture(scope="module")
-def neptune_graph():
+def neptune_graph(_require_s3):
     """NeptuneGraph instance with test data for export."""
     g = nx.Graph()
     na_graph = NeptuneGraph.from_config(graph=g)
@@ -40,12 +41,12 @@ def neptune_graph():
 
 
 @pytest.fixture(scope="module")
-def s3_client():
+def s3_client(_require_s3):
     return boto3.client("s3")
 
 
 @pytest.fixture(scope="module")
-def iam_client():
+def iam_client(_require_s3):
     sts_arn = boto3.client("sts").get_caller_identity()["Arn"]
     return IamClient(role_arn=sts_arn, client=boto3.client("iam"))
 

--- a/integ_test/tier2_export_import/test_iam_permissions.py
+++ b/integ_test/tier2_export_import/test_iam_permissions.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for IAM permission checks against real S3 buckets."""
+
+import os
+
+import pytest
+
+from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+
+S3_BUCKET = os.environ.get("NETWORKX_S3_EXPORT_BUCKET_PATH")
+
+
+class TestS3PermissionChecks:
+
+    def test_has_import_permissions(self, iam_client):
+        iam_client.has_import_from_s3_permissions(S3_BUCKET)
+
+    def test_has_export_permissions(self, iam_client):
+        iam_client.has_export_to_s3_permissions(S3_BUCKET)
+
+    def test_has_delete_permissions(self, iam_client):
+        iam_client.has_delete_s3_permissions(S3_BUCKET)
+
+    def test_s3_versioning_enabled(self, iam_client):
+        iam_client.check_s3_versioning_enabled(S3_BUCKET)
+
+
+class TestS3ArnParsing:
+
+    def test_split_s3_arn_bucket_and_path(self):
+        bucket, path = split_s3_arn_to_bucket_and_path("s3://my-bucket/some/prefix/")
+        assert bucket == "my-bucket"
+        assert path == "some/prefix/"
+
+    def test_split_s3_arn_no_path(self):
+        bucket, path = split_s3_arn_to_bucket_and_path("s3://my-bucket")
+        assert bucket == "my-bucket"
+        assert path == ""

--- a/integ_test/tier2_export_import/test_s3_import_export.py
+++ b/integ_test/tier2_export_import/test_s3_import_export.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for S3 import/export operations.
+
+Uses a single S3 path (NETWORKX_S3_EXPORT_BUCKET_PATH) for round-trip testing:
+export data → import it back → verify.
+
+Requirements:
+  - S3 bucket with KMS encryption (SSE-KMS) enabled
+  - S3 bucket with versioning enabled
+  - IAM permissions for import/export/delete
+"""
+
+import asyncio
+import os
+
+import pytest
+
+from nx_neptune import (
+    Node,
+    Edge,
+    export_csv_to_s3,
+    import_csv_from_s3,
+    empty_s3_bucket,
+)
+
+S3_BUCKET = os.environ.get("NETWORKX_S3_EXPORT_BUCKET_PATH")
+
+
+class TestExportCsvToS3:
+
+    def test_export_returns_task_id(self, seeded_graph, s3_client):
+        task_id = asyncio.get_event_loop().run_until_complete(
+            export_csv_to_s3(seeded_graph, S3_BUCKET)
+        )
+        assert task_id is not None
+        assert isinstance(task_id, str)
+
+        # Verify files were written to S3
+        from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+        bucket_name, prefix = split_s3_arn_to_bucket_and_path(S3_BUCKET)
+        response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
+        assert response.get("KeyCount", 0) > 0
+
+    def test_export_with_filter(self, seeded_graph):
+        export_filter = {
+            "vertexFilter": {"Person": {}},
+            "edgeFilter": {"KNOWS": {}},
+        }
+        task_id = asyncio.get_event_loop().run_until_complete(
+            export_csv_to_s3(seeded_graph, S3_BUCKET, export_filter=export_filter)
+        )
+        assert task_id is not None
+
+
+class TestImportCsvFromS3:
+
+    def test_round_trip_export_then_import(self, seeded_graph, neptune_graph):
+        """Export data, clear graph, import it back, verify."""
+
+        empty_s3_bucket(S3_BUCKET)
+
+        # Export
+        asyncio.get_event_loop().run_until_complete(
+            export_csv_to_s3(seeded_graph, S3_BUCKET)
+        )
+
+        # # Clear and import
+        task_id = asyncio.get_event_loop().run_until_complete(
+            import_csv_from_s3(neptune_graph, S3_BUCKET, reset_graph_ahead=True)
+        )
+        assert task_id is not None
+
+        # Verify data came back
+        nodes = neptune_graph.get_all_nodes()
+        assert len(nodes) >= 3
+        node_ids = {n["~id"] for n in nodes}
+        assert {"s1", "s2", "s3"}.issubset(node_ids)
+
+        edges = neptune_graph.get_all_edges()
+        assert len(edges) >= 2
+        edge_pairs = {(e["~start"], e["~end"]) for e in edges}
+        assert ("s1", "s2") in edge_pairs
+        assert ("s2", "s3") in edge_pairs
+
+
+class TestEmptyS3Bucket:
+
+    def test_empty_bucket_path(self, seeded_graph, s3_client):
+        """Export data then empty the path, verify nothing remains."""
+        asyncio.get_event_loop().run_until_complete(
+            export_csv_to_s3(seeded_graph, S3_BUCKET)
+        )
+
+        empty_s3_bucket(S3_BUCKET)
+
+        from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+        bucket_name, prefix = split_s3_arn_to_bucket_and_path(S3_BUCKET)
+        response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=prefix, MaxKeys=1)
+        assert response.get("KeyCount", 0) == 0

--- a/integ_test/tier2_export_import/test_snapshot.py
+++ b/integ_test/tier2_export_import/test_snapshot.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for snapshot create and delete operations.
+
+Uses the existing graph (NETWORKX_GRAPH_ID) to create a snapshot, verify it,
+then delete it. Does NOT create a new instance from the snapshot (that's tier 4).
+"""
+
+import asyncio
+
+import pytest
+
+from nx_neptune import NETWORKX_GRAPH_ID, create_graph_snapshot, delete_graph_snapshot
+
+
+class TestSnapshotCreateAndDelete:
+
+    def test_create_snapshot_then_delete(self, resource_tracker):
+        """Create a snapshot of the test graph, verify, then delete."""
+        snapshot_id = asyncio.get_event_loop().run_until_complete(
+            create_graph_snapshot(NETWORKX_GRAPH_ID, "integ-t2-snapshot")
+        )
+        resource_tracker.register_snapshot(snapshot_id)
+
+        assert snapshot_id is not None
+        assert isinstance(snapshot_id, str)
+
+        # Delete
+        deleted_id = asyncio.get_event_loop().run_until_complete(
+            delete_graph_snapshot(snapshot_id)
+        )
+        assert deleted_id == snapshot_id
+        resource_tracker.snapshots.remove(snapshot_id)


### PR DESCRIPTION
  Add Tier 2 integration tests: S3 export/import and snapshots                                
                                                                                              
  Builds on #(tier 1 PR number) — adds integration tests for S3 import/export, IAM permission checks, and snapshot create/delete.                                                         
                                                                                              
  ### Summary                                                                                     
                                                                                              
  Adds integ_test/tier2_export_import/ with 11 tests covering S3 round-trip export/import, IAM permission validation, and snapshot lifecycle. Snapshot tests run with just a graph ID; S3 tests auto-skip if NETWORKX_S3_EXPORT_BUCKET_PATH is not set.                               
                                                                                              
  ### Changes                                                                                     
                                                                                              
  - `integ_test/tier2_export_import/conftest.py` — Tier 2 fixtures: neptune_graph, seeded_graph (3 nodes + 2 edges), s3_client, iam_client. Graph ID required for all tests; S3 bucket required only for S3 tests.                                                          
  - `integ_test/tier2_export_import/test_s3_import_export.py` — 4 tests for S3 export/import  
  - `integ_test/tier2_export_import/test_iam_permissions.py` — 6 tests for IAM permission checks                                                                                      
  - `integ_test/tier2_export_import/test_snapshot.py` — 1 test for snapshot create/delete     
  - `RELEASE.md` — Updated tier 2 section with new directory name, snapshot coverage, and run 
  command                                                                                     
                                                                                              
  ### Test coverage (11 tests)                                                                    
                                                                                                                                                   
  | Class | # | What it covers |                                                              
  |---|---|---|                                                                               
  | TestExportCsvToS3 | 2 | Export returns task ID + verifies S3 files exist, export with vertex/edge filter |                                                                        
  | TestImportCsvFromS3 | 1 | Round-trip: export → clear → import → verify node IDs (s1, s2, s3) and edge pairs (s1→s2, s2→s3) |                                                         
  | TestEmptyS3Bucket | 1 | Export then empty path, verify zero objects remain |              
  | TestS3PermissionChecks | 4 | has_import/export/delete_s3_permissions,   check_s3_versioning_enabled |                                                               
  | TestS3ArnParsing | 2 | S3 ARN parsing with and without path (no AWS calls) |              
  | TestSnapshotCreateAndDelete | 1 | Create snapshot of test graph → verify ID → delete → verify deleted |  

                                                           
  ### Prerequisites                                                                               
                                                                                              
  export NETWORKX_GRAPH_ID=g-your-graph-id                                                    
  export NETWORKX_S3_EXPORT_BUCKET_PATH=s3://your-bucket/path/  # S3 bucket with KMS + versioning enabled                                                                          
                                                                                              
  Snapshot test runs with just NETWORKX_GRAPH_ID. S3 tests require the bucket.                
                                                                                              
  ### How to run                                                                                  
                                                                                              
  # All tier 2 tests (~5 min)                                                                 
  pytest integ_test/tier2_export_import/ -v -s                                                
                                                                                              
  # Snapshot only (~2 min, no S3 needed)                                                      
  pytest integ_test/tier2_export_import/test_snapshot.py -v -s                                
                                                                                              
  Testing                                                                                     
                                                                                              
  - [x] 11 tests pass against a live Neptune Analytics graph + S3 bucket                      
  - [x] Snapshot test passes with only NETWORKX_GRAPH_ID                                      
  - [x] S3 tests skip gracefully when NETWORKX_S3_EXPORT_BUCKET_PATH is not set               
                   