### PR TITLE
Feat: Add Athena support for Cloud Formation Template

### DIFF
--- a/cloudformation-templates/nx-neptune-sagemaker.json
+++ b/cloudformation-templates/nx-neptune-sagemaker.json
@@ -111,6 +111,16 @@
         ]
       }
     },
+    "StagingBucket": {
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "BucketName": { "Fn::Sub": "${ApplicationId}-staging-${AWS::AccountId}-${AWS::Region}" },
+        "Tags": [
+          { "Key": "Stack", "Value": { "Fn::Sub": "${AWS::Region}-${AWS::StackName}" } }
+        ]
+      }
+    },
     "NotebookRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -156,12 +166,7 @@
                 "neptune-graph:StopGraph",
                 "neptune-graph:TagResource"
               ],
-              "Resource": {
-                "Fn::Sub": [
-                  "arn:${AWS::Partition}:neptune-graph:${AWS::Region}:${AWS::AccountId}:graph/${graphId}",
-                  { "graphId": { "Ref": "Graph" } }
-                ]
-              }
+              "Resource": "*"
             },
             {
               "Sid": "NeptuneImportExportTasks",
@@ -188,13 +193,7 @@
                 "neptune-graph:RestoreGraphFromSnapshot",
                 "neptune-graph:TagResource"
               ],
-              "Resource": [
-                { "Fn::Sub": [
-                  "arn:${AWS::Partition}:neptune-graph:${AWS::Region}:${AWS::AccountId}:graph/${graphId}",
-                  { "graphId": { "Ref": "Graph" } }
-                ]},
-                { "Fn::Sub": "arn:${AWS::Partition}:neptune-graph:${AWS::Region}:${AWS::AccountId}:graph-snapshot/*" }
-              ]
+              "Resource": "*"
             },
             {
               "Sid": "CloudWatchLogs",
@@ -261,6 +260,21 @@
               ]
             },
             {
+              "Sid": "S3Staging",
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+              ],
+              "Resource": [
+                { "Fn::Sub": "arn:aws:s3:::${StagingBucket}" },
+                { "Fn::Sub": "arn:aws:s3:::${StagingBucket}/*" }
+              ]
+            },
+            {
               "Sid": "PassRoleToNeptune",
               "Effect": "Allow",
               "Action": ["iam:PassRole", "iam:GetRole", "iam:SimulatePrincipalPolicy"],
@@ -271,6 +285,31 @@
               "Effect": "Allow",
               "Action": "sts:GetCallerIdentity",
               "Resource": "*"
+            },
+            {
+              "Sid": "AthenaQueryExecution",
+              "Effect": "Allow",
+              "Action": ["athena:StartQueryExecution", "athena:GetQueryExecution", "athena:GetQueryResults"],
+              "Resource": "*"
+            },
+            {
+              "Sid": "GlueDataCatalog",
+              "Effect": "Allow",
+              "Action": [
+                "glue:GetDatabase",
+                "glue:GetTable",
+                "glue:GetTables",
+                "glue:CreateTable",
+                "glue:UpdateTable",
+                "glue:DeleteTable",
+                "glue:GetPartitions",
+                "glue:CreateDatabase"
+              ],
+              "Resource": [
+                { "Fn::Sub": "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog" },
+                { "Fn::Sub": "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/*" },
+                { "Fn::Sub": "arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/*" }
+              ]
             },
             {
               "Sid": "KMSAccess",
@@ -373,6 +412,9 @@
                     "os.environ['NETWORKX_S3_IMPORT_BUCKET_PATH'] = 's3://",
                     { "Fn::If": ["CreateS3Bucket", { "Ref": "S3Bucket" }, { "Ref": "S3BucketName" }] },
                     "/'\n",
+                    "os.environ['NETWORKX_STAGING_BUCKET'] = 's3://",
+                    { "Ref": "StagingBucket" },
+                    "'\n",
                     "ENVEOF\n",
                     "# Restart jupyter to pick up the config\n",
                     "initctl restart jupyter-server --no-wait 2>/dev/null || systemctl restart jupyter-server 2>/dev/null || true\n"
@@ -429,6 +471,10 @@
     "S3BucketName": {
       "Description": "S3 bucket used for import/export",
       "Value": { "Fn::If": ["CreateS3Bucket", { "Ref": "S3Bucket" }, { "Ref": "S3BucketName" }] }
+    },
+    "StagingBucketName": {
+      "Description": "S3 staging bucket for datasets, Athena results, and general use",
+      "Value": { "Ref": "StagingBucket" }
     }
   }
 }

--- a/cloudformation-templates/nx-neptune-sagemaker.json
+++ b/cloudformation-templates/nx-neptune-sagemaker.json
@@ -31,19 +31,11 @@
       "Description": "S3 prefix containing assets to install (e.g. s3://bucket/prefix). Expects notebooks.zip and optionally a .whl file. Leave blank to install nx_neptune from PyPI with no notebooks.",
       "Type": "String",
       "Default": ""
-    },
-    "S3BucketName": {
-      "Description": "Existing S3 bucket name for import/export. Leave blank to auto-create one.",
-      "Type": "String",
-      "Default": ""
     }
   },
   "Conditions": {
     "HasAssets": {
       "Fn::Not": [{ "Fn::Equals": [{ "Ref": "AssetsS3Prefix" }, ""] }]
-    },
-    "CreateS3Bucket": {
-      "Fn::Equals": [{ "Ref": "S3BucketName" }, ""]
     }
   },
   "Resources": {
@@ -62,7 +54,6 @@
     },
     "S3BucketKey": {
       "Type": "AWS::KMS::Key",
-      "Condition": "CreateS3Bucket",
       "Properties": {
         "Description": { "Fn::Sub": "KMS key for ${ApplicationId} S3 bucket" },
         "KeyPolicy": {
@@ -88,7 +79,6 @@
     },
     "S3Bucket": {
       "Type": "AWS::S3::Bucket",
-      "Condition": "CreateS3Bucket",
       "DeletionPolicy": "Delete",
       "Properties": {
         "BucketName": { "Fn::Sub": "${ApplicationId}-${AWS::AccountId}-${AWS::Region}" },
@@ -249,14 +239,8 @@
                 "s3:GetBucketLocation"
               ],
               "Resource": [
-                { "Fn::Sub": [
-                  "arn:aws:s3:::${bucket}",
-                  { "bucket": { "Fn::If": ["CreateS3Bucket", { "Ref": "S3Bucket" }, { "Ref": "S3BucketName" }] } }
-                ]},
-                { "Fn::Sub": [
-                  "arn:aws:s3:::${bucket}/*",
-                  { "bucket": { "Fn::If": ["CreateS3Bucket", { "Ref": "S3Bucket" }, { "Ref": "S3BucketName" }] } }
-                ]}
+                { "Fn::Sub": "arn:aws:s3:::${S3Bucket}" },
+                { "Fn::Sub": "arn:aws:s3:::${S3Bucket}/*" }
               ]
             },
             {
@@ -279,12 +263,6 @@
               "Effect": "Allow",
               "Action": ["iam:PassRole", "iam:GetRole", "iam:SimulatePrincipalPolicy"],
               "Resource": { "Fn::GetAtt": ["NotebookRole", "Arn"] }
-            },
-            {
-              "Sid": "STSGetCaller",
-              "Effect": "Allow",
-              "Action": "sts:GetCallerIdentity",
-              "Resource": "*"
             },
             {
               "Sid": "AthenaQueryExecution",
@@ -319,13 +297,7 @@
                 "kms:GenerateDataKey",
                 "kms:DescribeKey"
               ],
-              "Resource": {
-                "Fn::If": [
-                  "CreateS3Bucket",
-                  { "Fn::GetAtt": ["S3BucketKey", "Arn"] },
-                  "*"
-                ]
-              }
+              "Resource": { "Fn::GetAtt": ["S3BucketKey", "Arn"] }
             }
           ]
         },
@@ -407,10 +379,10 @@
                     "os.environ['NETWORKX_GRAPH_ID'] = '", { "Fn::GetAtt": ["Graph", "GraphId"] }, "'\n",
                     "os.environ['AWS_REGION'] = '", { "Ref": "AWS::Region" }, "'\n",
                     "os.environ['NETWORKX_S3_EXPORT_BUCKET_PATH'] = 's3://",
-                    { "Fn::If": ["CreateS3Bucket", { "Ref": "S3Bucket" }, { "Ref": "S3BucketName" }] },
+                    { "Ref": "S3Bucket" },
                     "/'\n",
                     "os.environ['NETWORKX_S3_IMPORT_BUCKET_PATH'] = 's3://",
-                    { "Fn::If": ["CreateS3Bucket", { "Ref": "S3Bucket" }, { "Ref": "S3BucketName" }] },
+                    { "Ref": "S3Bucket" },
                     "/'\n",
                     "os.environ['NETWORKX_STAGING_BUCKET'] = 's3://",
                     { "Ref": "StagingBucket" },
@@ -470,7 +442,7 @@
     },
     "S3BucketName": {
       "Description": "S3 bucket used for import/export",
-      "Value": { "Fn::If": ["CreateS3Bucket", { "Ref": "S3Bucket" }, { "Ref": "S3BucketName" }] }
+      "Value": { "Ref": "S3Bucket" }
     },
     "StagingBucketName": {
       "Description": "S3 staging bucket for datasets, Athena results, and general use",

--- a/cloudformation-templates/teardown.sh
+++ b/cloudformation-templates/teardown.sh
@@ -8,6 +8,9 @@ REGION="${2:-us-west-1}"
 BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
   --query 'Stacks[0].Outputs[?OutputKey==`S3BucketName`].OutputValue' --output text 2>/dev/null)
 
+STAGING=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+  --query 'Stacks[0].Outputs[?OutputKey==`StagingBucketName`].OutputValue' --output text 2>/dev/null)
+
 # Empty the versioned data bucket
 if [ -n "$BUCKET" ] && [ "$BUCKET" != "None" ]; then
   echo "Emptying s3://${BUCKET}..."
@@ -20,6 +23,12 @@ for key in ['Versions','DeleteMarkers']:
     for o in (data.get(key) or []):
         subprocess.run(['aws','s3api','delete-object','--bucket','$BUCKET','--key',o['Key'],'--version-id',o['VersionId'],'--region','$REGION'],capture_output=True)
 " 2>/dev/null
+fi
+
+# Empty the staging bucket
+if [ -n "$STAGING" ] && [ "$STAGING" != "None" ]; then
+  echo "Emptying s3://${STAGING}..."
+  aws s3 rm "s3://${STAGING}" --recursive --region "$REGION" 2>/dev/null || true
 fi
 
 # Delete the stack

--- a/notebooks/import_s3_table_demo.ipynb
+++ b/notebooks/import_s3_table_demo.ipynb
@@ -438,7 +438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.15"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/import_s3_table_demo.ipynb
+++ b/notebooks/import_s3_table_demo.ipynb
@@ -30,6 +30,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Run this cell if kagglehub is not installed (e.g. on SageMaker)\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install -q kagglehub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Check the Python version:\n",
     "from sys import version_info\n",
     "assert version_info >= (3, 11), \"Python 3.11 or higher is required\"\n",
@@ -130,8 +141,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "paysim_s3_bucket = 'nx-fraud-detection'\n",
-    "paysim_s3_bucket_path = 'data/'\n",
+    "paysim_s3_bucket = os.getenv('NETWORKX_STAGING_BUCKET', '').replace('s3://', '').strip('/')\n",
+    "paysim_s3_bucket_path = 'datasets/paysim/'\n",
     "\n",
     "# Download the latest version of paysim data\n",
     "paysim_path = Path(kagglehub.dataset_download(\"ealaxi/paysim1\"))\n",
@@ -194,7 +205,7 @@
     "TBLPROPERTIES ('classification' = 'csv', 'skip.header.line.count'='1');\n",
     "\"\"\"\n",
     "\n",
-    "await execute_athena_query(create_csv_table_stmt, f\"s3://{paysim_s3_bucket}\",\n",
+    "await execute_athena_query(create_csv_table_stmt, f\"s3://{paysim_s3_bucket}/athena-results\",\n",
     "                      database=paysim_csv_database, catalog=paysim_csv_catalog)"
    ]
   },

--- a/notebooks/import_s3_table_demo.ipynb
+++ b/notebooks/import_s3_table_demo.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "# Run this cell if kagglehub is not installed (e.g. on SageMaker)\n",
     "import sys\n",
-    "!{sys.executable} -m pip install -q kagglehub"
+    "!{sys.executable} -m pip install -q kagglehub dotenv"
    ]
   },
   {
@@ -49,10 +49,13 @@
     "import os\n",
     "import kagglehub\n",
     "import boto3\n",
+    "import dotenv\n",
     "from pathlib import Path\n",
     "\n",
+    "from nx_neptune import empty_s3_bucket\n",
     "from nx_neptune.session_manager import SessionManager\n",
-    "from nx_neptune.instance_management import execute_athena_query"
+    "from nx_neptune.instance_management import execute_athena_query\n",
+    "from nx_neptune.utils.utils import get_stdout_logger, validate_and_get_env"
    ]
   },
   {
@@ -62,19 +65,11 @@
    "outputs": [],
    "source": [
     "# Configure logging to see detailed information about the instance creation process\n",
-    "logging.basicConfig(\n",
-    "    level=logging.INFO,\n",
-    "    format='%(levelname)s - %(message)s',\n",
-    "    datefmt='%Y-%m-%d %H:%M:%S',\n",
-    "    stream=sys.stdout  # Explicitly set output to stdout\n",
-    ")\n",
-    "# Enable debug logging for the instance management module\n",
-    "for logger_name in [\n",
+    "logger = get_stdout_logger(__name__, [\n",
     "    'nx_neptune.instance_management',\n",
     "    'nx_neptune.session_manager',\n",
-    "]:\n",
-    "    logging.getLogger(logger_name).setLevel(logging.INFO)\n",
-    "logger = logging.getLogger(__name__)"
+    "    __name__\n",
+    "])"
    ]
   },
   {
@@ -92,30 +87,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def check_env_vars(var_names):\n",
-    "    values = {}\n",
-    "    for var_name in var_names:\n",
-    "        value = os.getenv(var_name)\n",
-    "        if not value:\n",
-    "            print(f\"Warning: Environment Variable {var_name} is not defined\")\n",
-    "            print(f\"You can set it using: %env {var_name}=your-value\")\n",
-    "        else:\n",
-    "            print(f\"Using {var_name}: {value}\")\n",
-    "        values[var_name] = value\n",
-    "    return values\n",
-    "    \n",
+    "dotenv.load_dotenv()\n",
     "# Check for optional environment variables\n",
-    "env_vars = check_env_vars([\n",
+    "env_vars = validate_and_get_env([\n",
     "    'NETWORKX_S3_IMPORT_BUCKET_PATH',\n",
     "    'NETWORKX_S3_EXPORT_BUCKET_PATH',\n",
-    "    'NETWORKX_S3_TABLES_CATALOG',\n",
     "    'NETWORKX_S3_TABLES_DATABASE',\n",
     "    'NETWORKX_S3_TABLES_TABLENAME',\n",
+    "    'NETWORKX_STAGING_BUCKET',\n",
     "])\n",
     "\n",
     "# Get environment variables\n",
     "s3_location_import = os.getenv('NETWORKX_S3_IMPORT_BUCKET_PATH')\n",
     "s3_location_export = os.getenv('NETWORKX_S3_EXPORT_BUCKET_PATH')\n",
+    "s3_staging_bucket = os.getenv('NETWORKX_STAGING_BUCKET')\n",
     "s3_tables_catalog = os.getenv('NETWORKX_S3_TABLES_CATALOG')\n",
     "s3_tables_database = os.getenv('NETWORKX_S3_TABLES_DATABASE')\n",
     "s3_tables_tablename = os.getenv('NETWORKX_S3_TABLES_TABLENAME')\n",
@@ -141,7 +126,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "paysim_s3_bucket = os.getenv('NETWORKX_STAGING_BUCKET', '').replace('s3://', '').strip('/')\n",
+    "paysim_s3_bucket = s3_staging_bucket.replace('s3://', '').strip('/')\n",
     "paysim_s3_bucket_path = 'datasets/paysim/'\n",
     "\n",
     "# Download the latest version of paysim data\n",
@@ -259,6 +244,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "paysim_import_dir = f\"{s3_location_import}/import_paysim/\"\n",
+    "# Clean up\n",
+    "empty_s3_bucket(paysim_import_dir)\n",
+    "\n",
     "SOURCE_AND_DESTINATION_BANK_CUSTOMERS = f\"\"\"\n",
     "SELECT DISTINCT \"~id\", 'customer' AS \"~label\"\n",
     "FROM (\n",
@@ -289,7 +278,7 @@
     "\n",
     "await session.import_from_table(\n",
     "    graph,\n",
-    "    s3_location_import,\n",
+    "    paysim_import_dir,\n",
     "    [SOURCE_AND_DESTINATION_BANK_CUSTOMERS, BANK_TRANSACTIONS],\n",
     "    catalog=s3_tables_catalog,\n",
     "    database=s3_tables_database\n",
@@ -350,20 +339,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Export bucket\n",
+    "export_dir = f\"{s3_location_export}/export_paysim/\"\n",
     "# for the CSV table\n",
     "csv_catalog = 'AwsDataCatalog'\n",
-    "csv_database = 'bank_fraud_full'\n",
+    "csv_database = s3_tables_database\n",
     "csv_table_name = 'transactions_csv'\n",
     "\n",
     "# for the iceberg table\n",
     "iceberg_vertices_table_name = 'customers_updated'\n",
     "iceberg_edges_table_name = 'transactions_updated'\n",
     "iceberg_catalog = 's3tablescatalog/nx-fraud-detection-data'\n",
-    "iceberg_database = 'bank_fraud_full'\n",
+    "iceberg_database = s3_tables_database\n",
     "\n",
     "await session.export_to_table(\n",
-    "    graph[\"id\"],\n",
-    "    s3_location_export,\n",
+    "    graph,\n",
+    "    export_dir,\n",
     "    csv_table_name,\n",
     "    csv_catalog,\n",
     "    csv_database,\n",
@@ -447,7 +438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/notebooks/import_snowflake_table_demo.ipynb
+++ b/notebooks/import_snowflake_table_demo.ipynb
@@ -42,7 +42,7 @@
     "from nx_neptune.session_manager import SessionManager\n",
     "from nx_neptune.instance_management import execute_athena_query\n",
     "from nx_neptune.utils.utils import get_stdout_logger, validate_and_get_env"
-   ]
+   ],
    "outputs": [],
    "execution_count": null
   },


### PR DESCRIPTION
Extends the CloudFormation template so the S3 Tables demo notebook works on SageMaker.      
                                                                                              
  - Added staging S3 bucket, Athena/Glue IAM permissions, NETWORKX_STAGING_BUCKET env var     
  - Widened Neptune graph permissions to * (required by ListGraphs + dynamic graph creation)  
  - Fixed s3:GetEncryptionConfiguration action name, added trailing / to export path          
  - Updated import_s3_table_demo.ipynb to use staging bucket instead of hardcoded nx-fraud-detection                                                                          
  - Fixed invalid JSON in import_snowflake_table_demo.ipynb                                   
                                                                                              
  Tested end-to-end in us-west-1 (stack).