### PR TITLE
Misc: Bump aws-athena-query-federation submodule to v2026.17.1

### DIFF
--- a/connectors/athena-databricks-connector/pom.xml
+++ b/connectors/athena-databricks-connector/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <athena-sdk.version>2026.13.1</athena-sdk.version>
+        <athena-sdk.version>2026.17.1</athena-sdk.version>
         <databricks.version>3.3.1</databricks.version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.25.4</log4j.version>

--- a/connectors/athena-s3vector-connector/pom.xml
+++ b/connectors/athena-s3vector-connector/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-athena-federation-sdk</artifactId>
-            <version>2026.13.1</version>
+            <version>2026.17.1</version>
             <classifier>withdep</classifier>
             <exclusions>
                 <!-- replaced with jcl-over-slf4j -->

--- a/tests/test_reset_graph.py
+++ b/tests/test_reset_graph.py
@@ -41,7 +41,7 @@ async def test_reset_graph_success():
         },
         "id": "xxx",
         "name": "andy-test-graph",
-        "arn": "arn:aws:neptune-graph:us-west-2:613481987977:graph/xxx",
+        "arn": "arn:aws:neptune-graph:us-west-2:123456789000:graph/xxx",
         "status": "RESETTING",
         "createTime": "xxx",
         "provisionedMemory": 16,


### PR DESCRIPTION
### Summary
  
  Update the aws-athena-query-federation submodule from v2026.10.1 to v2026.17.1 and align
  connector SDK references from 2026.13.1 to 2026.17.1.
  
### Changes
  
  - Submodule connectors/aws-athena-query-federation: v2026.10.1 → v2026.17.1
  - connectors/athena-databricks-connector/pom.xml: SDK 2026.13.1 → 2026.17.1
  - connectors/athena-s3vector-connector/pom.xml: SDK 2026.13.1 → 2026.17.1
  -  Use placeholder values in test fixtures
  
  Notable upstream changes
  
  - Dependency bumps: BouncyCastle 1.84, Netty 4.2.12.Final, httpclient5 5.6.1, Guava
  33.6.0-jre, AWS SDK v2 2.42.39, protobuf 4.34.1

https://github.com/awslabs/aws-athena-query-federation/releases/tag/v2026.17.1  

### Testing
  
  - [x] mvn compile on connectors
  - [x] Unit tests pass for athena-databricks-connector
  - [ ] Unit tests pass for athena-s3vector-connector