### PR TITLE
Misc: Validate SQL identifiers before interpolation in Athena queries

### DIFF
--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -55,6 +55,7 @@ from .utils.task_future import (
     TaskType,
     wait_until_all_complete,
 )
+from .utils.utils import _validate_sql_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -1329,6 +1330,7 @@ def _build_sql_statement(
             table_columns[field] = datatype.lower()
 
     table_schema = ",\n    ".join(f"`{k}` {v}" for k, v in table_columns.items())
+    _validate_sql_identifier(table_name, "table name")
     if bucket_folder:
         s3_location = f"s3://{bucket_name}/{bucket_folder}/{prefix}"
     else:
@@ -1392,6 +1394,8 @@ async def create_iceberg_table_from_table(
     if table_columns:
         select_columns = '"' + '","'.join(table_columns) + '"'
 
+    _validate_sql_identifier(table_name, "table name")
+    _validate_sql_identifier(csv_table_name, "table name")
     sql_statement = f"""
 CREATE TABLE {table_name}
   WITH (
@@ -1527,6 +1531,7 @@ async def drop_athena_table(
     # Check Athena and S3/KMS permissions
     iam_client_wrapper.has_athena_permissions(s3_bucket, key_arn)
 
+    _validate_sql_identifier(table, "table name")
     drop_table_sql_statement = f"DROP TABLE {table}"
     query_execution_id = _execute_athena_query(
         athena_client,

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -1330,7 +1330,7 @@ def _build_sql_statement(
             table_columns[field] = datatype.lower()
 
     table_schema = ",\n    ".join(f"`{k}` {v}" for k, v in table_columns.items())
-    _validate_sql_identifier(table_name, "table name")
+    _validate_sql_identifier(table_name)
     if bucket_folder:
         s3_location = f"s3://{bucket_name}/{bucket_folder}/{prefix}"
     else:
@@ -1394,8 +1394,8 @@ async def create_iceberg_table_from_table(
     if table_columns:
         select_columns = '"' + '","'.join(table_columns) + '"'
 
-    _validate_sql_identifier(table_name, "table name")
-    _validate_sql_identifier(csv_table_name, "table name")
+    _validate_sql_identifier(table_name)
+    _validate_sql_identifier(csv_table_name)
     sql_statement = f"""
 CREATE TABLE {table_name}
   WITH (
@@ -1531,7 +1531,7 @@ async def drop_athena_table(
     # Check Athena and S3/KMS permissions
     iam_client_wrapper.has_athena_permissions(s3_bucket, key_arn)
 
-    _validate_sql_identifier(table, "table name")
+    _validate_sql_identifier(table)
     drop_table_sql_statement = f"DROP TABLE {table}"
     query_execution_id = _execute_athena_query(
         athena_client,

--- a/nx_neptune/utils/utils.py
+++ b/nx_neptune/utils/utils.py
@@ -20,25 +20,6 @@ from itertools import islice
 from time import sleep
 from typing import List, Optional
 
-
-_SQL_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*\Z")
-
-
-def _validate_sql_identifier(value: str, label: str = "identifier") -> str:
-    """Validate that *value* is a safe SQL identifier (table or column name).
-
-    Accepts dotted names like ``catalog.database.table``.
-
-    Raises ``ValueError`` if the value contains characters that could
-    enable SQL injection.
-    """
-    if not value or not _SQL_IDENTIFIER_RE.match(value):
-        raise ValueError(
-            f"Invalid SQL {label}: {value!r}. "
-            "Only letters, digits, underscores, and dots are allowed."
-        )
-    return value
-
 import boto3
 
 
@@ -396,7 +377,7 @@ def generate_create_table_ddl(table_name, s3_location, columns):
         >>> columns = [("id", "string"), ("name", "string"), ("embedding", "array<float>")]
         >>> ddl = generate_create_table_ddl("my_table", "s3://bucket/path/", columns)
     """
-    _validate_sql_identifier(table_name, "table name")
+    _validate_sql_identifier(table_name)
     column_defs = ",\n    ".join([f"`{name}` {dtype}" for name, dtype in columns])
 
     return f"""CREATE EXTERNAL TABLE IF NOT EXISTS {table_name} (
@@ -478,7 +459,7 @@ def generate_projection_stmt(
         on u.id = p.user_id;
     """
     for part in base_table.split():
-        _validate_sql_identifier(part, "table name")
+        _validate_sql_identifier(part)
     selects = [f'{col_id} AS "~id"']
 
     if col_label:
@@ -521,3 +502,22 @@ def generate_projection_stmt(
           SELECT
               {select_clause}
           FROM {from_clause};"""
+
+
+def _validate_sql_identifier(value: str) -> str:
+    """Validate that *value* is a safe SQL identifier (table or column name).
+
+    Accepts dotted names like ``catalog.database.table``.
+
+    Raises ``ValueError`` if the value contains characters that could
+    enable SQL injection.
+    """
+    _SQL_IDENTIFIER_RE = re.compile(
+        r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*\Z"
+    )
+    if not value or not _SQL_IDENTIFIER_RE.match(value):
+        raise ValueError(
+            f"Invalid SQL identifier: {value!r}. "
+            "Only letters, digits, underscores, and dots are allowed."
+        )
+    return value

--- a/nx_neptune/utils/utils.py
+++ b/nx_neptune/utils/utils.py
@@ -14,10 +14,30 @@ import csv
 import json
 import logging
 import os
+import re
 import sys
 from itertools import islice
 from time import sleep
 from typing import List, Optional
+
+
+_SQL_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*\Z")
+
+
+def _validate_sql_identifier(value: str, label: str = "identifier") -> str:
+    """Validate that *value* is a safe SQL identifier (table or column name).
+
+    Accepts dotted names like ``catalog.database.table``.
+
+    Raises ``ValueError`` if the value contains characters that could
+    enable SQL injection.
+    """
+    if not value or not _SQL_IDENTIFIER_RE.match(value):
+        raise ValueError(
+            f"Invalid SQL {label}: {value!r}. "
+            "Only letters, digits, underscores, and dots are allowed."
+        )
+    return value
 
 import boto3
 
@@ -376,6 +396,7 @@ def generate_create_table_ddl(table_name, s3_location, columns):
         >>> columns = [("id", "string"), ("name", "string"), ("embedding", "array<float>")]
         >>> ddl = generate_create_table_ddl("my_table", "s3://bucket/path/", columns)
     """
+    _validate_sql_identifier(table_name, "table name")
     column_defs = ",\n    ".join([f"`{name}` {dtype}" for name, dtype in columns])
 
     return f"""CREATE EXTERNAL TABLE IF NOT EXISTS {table_name} (
@@ -456,6 +477,8 @@ def generate_projection_stmt(
         posts p
         on u.id = p.user_id;
     """
+    for part in base_table.split():
+        _validate_sql_identifier(part, "table name")
     selects = [f'{col_id} AS "~id"']
 
     if col_label:

--- a/nx_neptune/utils/utils.py
+++ b/nx_neptune/utils/utils.py
@@ -507,17 +507,16 @@ def generate_projection_stmt(
 def _validate_sql_identifier(value: str) -> str:
     """Validate that *value* is a safe SQL identifier (table or column name).
 
-    Accepts dotted names like ``catalog.database.table``.
+    Accepts dotted names like ``catalog.database.table`` and
+    double-quoted segments like ``"lambda:db-test"."default"."table"``.
 
     Raises ``ValueError`` if the value contains characters that could
     enable SQL injection.
     """
-    _SQL_IDENTIFIER_RE = re.compile(
-        r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*\Z"
-    )
+    # Each segment is either an unquoted identifier or a double-quoted identifier.
+    # Double-quoted segments reject ; and " to prevent injection.
+    _SEGMENT = r'(?:[a-zA-Z_][a-zA-Z0-9_]*|"[^";]+")'
+    _SQL_IDENTIFIER_RE = re.compile(rf"^{_SEGMENT}(\.{_SEGMENT})*\Z")
     if not value or not _SQL_IDENTIFIER_RE.match(value):
-        raise ValueError(
-            f"Invalid SQL identifier: {value!r}. "
-            "Only letters, digits, underscores, and dots are allowed."
-        )
+        raise ValueError(f"Invalid SQL identifier: {value!r}.")
     return value

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -151,3 +151,42 @@ class TestReadCsv:
                 assert rows == []
             finally:
                 os.unlink(f.name)
+
+
+class TestValidateSqlIdentifier:
+    """Tests for _validate_sql_identifier function"""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "my_table",
+            "Table1",
+            "_private",
+            "catalog.database.table",
+            "db.my_table",
+        ],
+    )
+    def test_valid_identifiers(self, value):
+        from nx_neptune.utils.utils import _validate_sql_identifier
+
+        assert _validate_sql_identifier(value, "table name") == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "table; DROP TABLE users--",
+            "table name",
+            "1table",
+            "",
+            "table\n",
+            "table'",
+            "table;",
+            ".leading_dot",
+            "trailing.",
+        ],
+    )
+    def test_invalid_identifiers(self, value):
+        from nx_neptune.utils.utils import _validate_sql_identifier
+
+        with pytest.raises(ValueError, match="Invalid SQL"):
+            _validate_sql_identifier(value, "table name")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -159,6 +159,8 @@ class TestValidateSqlIdentifier:
     @pytest.mark.parametrize(
         "value",
         [
+            '"lambda:db-test"."default"."paysim_transactions"',
+            '"my-catalog".my_db.my_table',
             "my_table",
             "Table1",
             "_private",
@@ -183,6 +185,7 @@ class TestValidateSqlIdentifier:
             "table;",
             ".leading_dot",
             "trailing.",
+            '"table;DROP TABLE x"',
         ],
     )
     def test_invalid_identifiers(self, value):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -169,7 +169,7 @@ class TestValidateSqlIdentifier:
     def test_valid_identifiers(self, value):
         from nx_neptune.utils.utils import _validate_sql_identifier
 
-        assert _validate_sql_identifier(value, "table name") == value
+        assert _validate_sql_identifier(value) == value
 
     @pytest.mark.parametrize(
         "value",
@@ -189,4 +189,4 @@ class TestValidateSqlIdentifier:
         from nx_neptune.utils.utils import _validate_sql_identifier
 
         with pytest.raises(ValueError, match="Invalid SQL"):
-            _validate_sql_identifier(value, "table name")
+            _validate_sql_identifier(value)


### PR DESCRIPTION

###  Description:
  
  Table names passed to Athena DDL/DML builders are interpolated via f-strings. This adds input validation to reject values that could enable SQL injection before they reach string construction.
  
  The validator accepts:
  
  - Simple identifiers: my_table
  - Dotted names: catalog.database.table
  - Double-quoted segments: "lambda:db-test"."default"."paysim_transactions"
  
  Semicolons are rejected in all cases, including inside quoted identifiers.
  
### Changes
  
  - Add _validate_sql_identifier() in utils/utils.py
  - Validate table name parameters in _build_sql_statement, create_iceberg_table_from_table,
  drop_athena_table, generate_create_table_ddl, and generate_projection_stmt
  - 17 new unit tests
