### PR TITLE
Misc: Bump pytest-order to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ developer = [
 test = [
     'pytest>=7.2',
     'pytest-asyncio>=0.26.0',
-    'pytest-order>=1.3.0',
+    'pytest-order>=1.4.0',
     'numpy>=1.23',
     'scipy>=1.9,!=1.11.0,!=1.11.1',
     "pytest-cov",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -135,7 +135,7 @@ pytest-asyncio==1.3.0
     # via nx-neptune (pyproject.toml)
 pytest-cov==7.1.0
     # via nx-neptune (pyproject.toml)
-pytest-order==1.3.0
+pytest-order==1.4.0
     # via nx-neptune (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via


### PR DESCRIPTION
### Summary :memo:

Follow up of https://github.com/awslabs/nx-neptune/pull/188 as the change should happen on pyporject.toml instead. 



### Test plan:

```
make test
```

### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
