### PR TITLE
Misc: Add documentation reference for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![CI](https://github.com/awslabs/nx-neptune/actions/workflows/main.yml/badge.svg)](https://github.com/awslabs/nx-neptune/actions/workflows/main.yml)
 [![Upload Python Package](https://github.com/awslabs/nx-neptune/actions/workflows/python-publish.yml/badge.svg)](https://github.com/awslabs/nx-neptune/actions/workflows/python-publish.yml)
 
+📖 **[Documentation](https://awslabs.github.io/nx-neptune/)**
+
 **nx-neptune** is a Python library that brings graph analytics to your data lake. Project your data from Amazon S3 Tables, S3 Vectors, Databricks, Snowflake, OpenSearch, and other sources into [Neptune Analytics](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/what-is-neptune-analytics.html) for graph analysis — with results exported back to S3 or persisted as Iceberg tables.
 
 ### Graph Over Data Lake


### PR DESCRIPTION
### Summary :memo:
Add github.io reference on readme to make it visible on Pypi page, in order to direct user to the up-to-date doc site.

Preview:
https://github.com/awslabs/nx-neptune/tree/ft-hf-readme-with-doc-sites

<img width="973" height="584" alt="image" src="https://github.com/user-attachments/assets/80caebde-7038-408d-9536-b81990b2b7e6" />



### Test plan:



### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
