### PR TITLE
Doc: Update NetworkX backends URL to stable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The `SessionManager` API manages the full lifecycle of a Neptune Analytics graph
 
 ### NetworkX Backend
 
-nx-neptune also serves as a [NetworkX](https://networkx.org/)-compatible backend for Neptune Analytics, enabling you to offload graph algorithm workloads to AWS with no code changes. Use familiar NetworkX APIs to seamlessly scale graph computations on-demand. This combines the simplicity of local development with the performance and scalability of a fully managed AWS graph analytics service. For more on NetworkX backends, see the [NetworkX backends documentation](https://networkx.org/documentation/latest/backends.html).
+nx-neptune also serves as a [NetworkX](https://networkx.org/)-compatible backend for Neptune Analytics, enabling you to offload graph algorithm workloads to AWS with no code changes. Use familiar NetworkX APIs to seamlessly scale graph computations on-demand. This combines the simplicity of local development with the performance and scalability of a fully managed AWS graph analytics service. For more on NetworkX backends, see the [NetworkX backends documentation](https://networkx.org/documentation/stable/backends.html).
 
 ```python
 import networkx as nx

--- a/docs-site/src/content/docs/networkx-backend/interface.mdx
+++ b/docs-site/src/content/docs/networkx-backend/interface.mdx
@@ -6,7 +6,7 @@ import { Aside, Code } from '@astrojs/starlight/components';
 
 nx-neptune serves as a [NetworkX](https://networkx.org/)-compatible backend for Neptune Analytics. This enables you to offload graph algorithm workloads to AWS with **no code changes** — use familiar NetworkX APIs to seamlessly scale graph computations on-demand.
 
-For more on NetworkX backends, see the [NetworkX backends documentation](https://networkx.org/documentation/latest/backends.html).
+For more on NetworkX backends, see the [NetworkX backends documentation](https://networkx.org/documentation/stable/backends.html).
 
 ## How it works
 


### PR DESCRIPTION
**Body:**

### Summary

Updates the NetworkX backends documentation link from `/latest/` to `/stable/`. The backends feature has shipped in the stable NetworkX release, so we should reference the stable docs rather than the development version.

### Changes

- `README.md` — updated URL
- `docs-site/src/content/docs/networkx-backend/interface.mdx` — updated URL