### PR TITLE
Misc: Add --upgrade flag to make lock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         run: pip install pip-tools
       - name: Check lock files are in sync
         run: |
-          make lock
+          make lock-check
           git diff --exit-code requirements.txt requirements-dev.txt || \
             (echo "Lock files are out of sync with pyproject.toml. Run 'make lock' and commit." && exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,14 @@ install-dev: install          ## Install the project in dev mode.
 
 
 .PHONY: lock
-lock:             ## Regenerate lock files from pyproject.toml.
+lock:             ## Regenerate lock files from pyproject.toml (fetches latest versions).
 	$(ENV_PREFIX)pip-compile pyproject.toml -o requirements.txt --strip-extras --upgrade
 	$(ENV_PREFIX)pip-compile pyproject.toml --extra test --extra developer -o requirements-dev.txt --strip-extras --upgrade
+
+.PHONY: lock-check
+lock-check:       ## Verify lock files are in sync with pyproject.toml (used by CI).
+	$(ENV_PREFIX)pip-compile pyproject.toml -o requirements.txt --strip-extras
+	$(ENV_PREFIX)pip-compile pyproject.toml --extra test --extra developer -o requirements-dev.txt --strip-extras
 
 
 .PHONY: dist

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ install-dev: install          ## Install the project in dev mode.
 
 .PHONY: lock
 lock:             ## Regenerate lock files from pyproject.toml.
-	$(ENV_PREFIX)pip-compile pyproject.toml -o requirements.txt --strip-extras
-	$(ENV_PREFIX)pip-compile pyproject.toml --extra test --extra developer -o requirements-dev.txt --strip-extras
+	$(ENV_PREFIX)pip-compile pyproject.toml -o requirements.txt --strip-extras --upgrade
+	$(ENV_PREFIX)pip-compile pyproject.toml --extra test --extra developer -o requirements-dev.txt --strip-extras --upgrade
 
 
 .PHONY: dist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,15 +4,17 @@
 #
 #    pip-compile --extra=developer --extra=test --output-file=requirements-dev.txt --strip-extras pyproject.toml
 #
+ast-serialize==0.3.0
+    # via mypy
 black==26.3.1
     # via nx-neptune (pyproject.toml)
-boto3==1.42.87
+boto3==1.43.6
     # via nx-neptune (pyproject.toml)
-botocore==1.42.91
+botocore==1.43.6
     # via
     #   boto3
     #   s3transfer
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   opensearch-py
     #   requests
@@ -20,9 +22,9 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.3.2
+click==8.3.3
     # via black
-coverage==7.13.5
+coverage==7.14.0
     # via pytest-cov
 cymple==0.12.0
     # via nx-neptune (pyproject.toml)
@@ -32,7 +34,7 @@ dotenv==0.9.9
     # via nx-neptune (pyproject.toml)
 events==0.5
     # via opensearch-py
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   python-discovery
     #   virtualenv
@@ -44,7 +46,7 @@ grpcio==1.80.0
     # via opensearch-protobufs
 identify==2.6.19
     # via pre-commit
-idna==3.11
+idna==3.14
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -54,11 +56,11 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-librt==0.9.0
+librt==0.11.0
     # via mypy
 mccabe==0.7.0
     # via flake8
-mypy==1.20.0
+mypy==2.1.0
     # via nx-neptune (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -73,17 +75,17 @@ numpy==2.4.4
     #   nx-neptune (pyproject.toml)
     #   pandas
     #   scipy
-opensearch-protobufs==0.19.0
+opensearch-protobufs==1.2.0
     # via opensearch-py
-opensearch-py==3.1.0
+opensearch-py==3.2.0
     # via nx-neptune (pyproject.toml)
-packaging==26.0
+packaging==26.2
     # via
     #   black
     #   pytest
 pandas==3.0.2
     # via nx-neptune (pyproject.toml)
-pathspec==1.0.4
+pathspec==1.1.1
     # via
     #   black
     #   mypy
@@ -127,7 +129,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   opensearch-py
     #   pandas
-python-discovery==1.2.2
+python-discovery==1.3.0
     # via virtualenv
 python-dotenv==1.2.2
     # via dotenv
@@ -137,25 +139,25 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.33.1
     # via opensearch-py
-s3transfer==0.16.0
+s3transfer==0.17.0
     # via boto3
 scipy==1.17.1
     # via nx-neptune (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-sqlglot==30.4.3
+sqlglot==30.7.0
     # via nx-neptune (pyproject.toml)
 typing-extensions==4.15.0
     # via
     #   grpcio
     #   mypy
     #   pytest-asyncio
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   opensearch-py
     #   requests
-virtualenv==21.2.1
+virtualenv==21.3.1
     # via pre-commit
-wcwidth==0.6.0
+wcwidth==0.7.0
     # via prettytable

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras pyproject.toml
 #
-boto3==1.42.87
+boto3==1.43.6
     # via nx-neptune (pyproject.toml)
-botocore==1.42.91
+botocore==1.43.6
     # via
     #   boto3
     #   s3transfer
@@ -20,11 +20,11 @@ networkx==3.6.1
     # via nx-neptune (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
-s3transfer==0.16.0
+s3transfer==0.17.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-sqlglot==30.4.3
+sqlglot==30.7.0
     # via nx-neptune (pyproject.toml)
-urllib3==2.6.3
+urllib3==2.7.0
     # via botocore


### PR DESCRIPTION
### Summary

Adds `--upgrade` to the `pip-compile` commands in the `lock` Makefile target so `make lock` always resolves the latest versions within `pyproject.toml` constraints.

As the result of the initial run, this will also solve:
https://github.com/awslabs/nx-neptune/pull/206
https://github.com/awslabs/nx-neptune/pull/207
https://github.com/awslabs/nx-neptune/pull/204
https://github.com/awslabs/nx-neptune/pull/203

### Problem

Previously, `make lock` preserved existing pinned versions in the lock files unless a constraint changed. This meant running `make lock` after a fresh clone or after Dependabot PRs would produce no diff — even when newer compatible versions were available. Contributors had to manually pass `--upgrade-package` to bump individual deps.

### Changes

- Added `--upgrade` flag to both `pip-compile` invocations in the `lock` target

### Effect

- `make lock` now produces lock files with the latest versions satisfying `pyproject.toml` constraints
- Upper bounds (e.g., `<1.43`) are still respected
- Reduces noisy Dependabot PRs — if `make lock` is run before release, deps are already at latest