### PR TITLE
Feat: Set boto3 read_timeout from timeout_seconds to prevent client-side timeouts

### DIFF
--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import boto3
 from botocore.client import BaseClient
@@ -57,7 +57,7 @@ class NeptuneAnalyticsClient:
         if client:
             self.client = client
         else:
-            config_kwargs = {"user_agent_appid": APP_ID_NX}
+            config_kwargs: dict[str, Any] = {"user_agent_appid": APP_ID_NX}
             if timeout_seconds:
                 config_kwargs["read_timeout"] = timeout_seconds
             self.client = boto3.client(

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -54,9 +54,15 @@ class NeptuneAnalyticsClient:
         with optional custom logger and boto client.
         """
         self.graph_id = graph_id
-        self.client = client or boto3.client(
-            service_name=SERVICE_NA, config=Config(user_agent_appid=APP_ID_NX)
-        )
+        if client:
+            self.client = client
+        else:
+            config_kwargs = {"user_agent_appid": APP_ID_NX}
+            if timeout_seconds:
+                config_kwargs["read_timeout"] = timeout_seconds
+            self.client = boto3.client(
+                service_name=SERVICE_NA, config=Config(**config_kwargs)
+            )
         self.logger = logger or logging.getLogger(__name__)
         self.name = name or ""
         self.status = status or ""

--- a/tests/clients/test_na_client.py
+++ b/tests/clients/test_na_client.py
@@ -222,6 +222,8 @@ class TestNeptuneAnalyticsClient:
     def test_init_with_client_ignores_timeout_seconds(self, mock_boto3):
         """Test that providing a client uses it directly; timeout_seconds does not create a new client."""
         mock_client = MagicMock()
-        na = NeptuneAnalyticsClient(graph_id="g-123", client=mock_client, timeout_seconds=120)
+        na = NeptuneAnalyticsClient(
+            graph_id="g-123", client=mock_client, timeout_seconds=120
+        )
         assert na.client == mock_client
         mock_boto3.client.assert_not_called()

--- a/tests/clients/test_na_client.py
+++ b/tests/clients/test_na_client.py
@@ -199,3 +199,29 @@ class TestNeptuneAnalyticsClient:
 
         call_kwargs = mock_na_client.client.execute_query.call_args[1]
         assert "queryTimeoutMilliseconds" not in call_kwargs
+
+    @patch("nx_neptune.clients.na_client.boto3")
+    def test_init_with_timeout_sets_read_timeout(self, mock_boto3):
+        """Test that timeout_seconds sets read_timeout on the boto3 Config."""
+        NeptuneAnalyticsClient(graph_id="g-123", timeout_seconds=120)
+
+        mock_boto3.client.assert_called_once()
+        config = mock_boto3.client.call_args[1]["config"]
+        assert config.read_timeout == 120
+
+    @patch("nx_neptune.clients.na_client.boto3")
+    def test_init_without_timeout_uses_default(self, mock_boto3):
+        """Test that no timeout_seconds leaves read_timeout at boto3 default (60s)."""
+        NeptuneAnalyticsClient(graph_id="g-123")
+
+        mock_boto3.client.assert_called_once()
+        config = mock_boto3.client.call_args[1]["config"]
+        assert config.read_timeout == 60
+
+    @patch("nx_neptune.clients.na_client.boto3")
+    def test_init_with_client_ignores_timeout_seconds(self, mock_boto3):
+        """Test that providing a client uses it directly; timeout_seconds does not create a new client."""
+        mock_client = MagicMock()
+        na = NeptuneAnalyticsClient(graph_id="g-123", client=mock_client, timeout_seconds=120)
+        assert na.client == mock_client
+        mock_boto3.client.assert_not_called()


### PR DESCRIPTION
### Summary

Configures the boto3 HTTP `read_timeout` using the existing `timeout_seconds` parameter on `NeptuneAnalyticsClient`. This prevents `ReadTimeoutError` on long-running queries where the server-side timeout hasn't been reached but boto3's default 60s HTTP timeout expires first.

Closes #30

### Problem

Two timeouts are involved in a query:
1. **Server-side** (`queryTimeoutMilliseconds`) — how long Neptune allows the query to run
2. **Client-side** (`read_timeout`) — how long boto3 waits for an HTTP response

Previously, `timeout_seconds` only set the server-side timeout. The client-side `read_timeout` was always boto3's default (60s). A query that takes 90s to compute would succeed on the server but fail on the client with `ReadTimeoutError`.

### Solution

Use the same `timeout_seconds` value for both:
- Server-side: `queryTimeoutMilliseconds = timeout_seconds * 1000` (already existed)
- Client-side: `Config(read_timeout=timeout_seconds)` (new)

One config knob controls both sides. If `timeout_seconds` is not set, boto3's default (60s) applies — no behavior change for existing users.

### Changes

- `nx_neptune/clients/na_client.py` — build boto3 `Config` with `read_timeout` when `timeout_seconds` is provided
- `tests/clients/test_na_client.py` — 3 new tests covering timeout set, default, and client-provided cases

### Usage

```python
# Query with 5-minute timeout (both server and client)
client = NeptuneAnalyticsClient(graph_id="g-123", timeout_seconds=300)

# Default behavior unchanged (60s client timeout, no server timeout)
client = NeptuneAnalyticsClient(graph_id="g-123")
```
