### PR TITLE
Release: Automate .whl / notebook release upload

### DIFF
--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -43,21 +43,28 @@ jobs:
           name: release-dists
           path: dist/
 
+
   github-release-upload:
     runs-on: ubuntu-latest
     needs: release-build
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Retrieve release distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/
 
-      - name: Upload wheel to GitHub Release
+      - name: Package notebooks
+        run: zip -j notebooks.zip notebooks/*.ipynb notebooks/README.md
+
+      - name: Upload assets to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl
-
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl notebooks.zip

--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -43,3 +43,21 @@ jobs:
           name: release-dists
           path: dist/
 
+  github-release-upload:
+    runs-on: ubuntu-latest
+    needs: release-build
+    permissions:
+      contents: write
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Upload wheel to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl
+

--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  release-build:
+  prerelease-build:
     runs-on: ubuntu-latest
 
     steps:
@@ -44,9 +44,9 @@ jobs:
           path: dist/
 
 
-  github-release-upload:
+  github-prerelease-upload:
     runs-on: ubuntu-latest
-    needs: release-build
+    needs: prerelease-build
     permissions:
       contents: write
     steps:
@@ -54,7 +54,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Retrieve release distributions
+      - name: Retrieve Prerelease distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
@@ -63,7 +63,7 @@ jobs:
       - name: Package notebooks
         run: zip -j notebooks.zip notebooks/*.ipynb notebooks/README.md
 
-      - name: Upload assets to GitHub Release
+      - name: Upload assets to GitHub Prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -75,14 +75,21 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Retrieve release distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-dists
           path: dist/
 
-      - name: Upload wheel to GitHub Release
+      - name: Package notebooks
+        run: zip -j notebooks.zip notebooks/*.ipynb notebooks/README.md
+
+      - name: Upload assets to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl notebooks.zip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -68,3 +68,21 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
+
+  github-release-upload:
+    runs-on: ubuntu-latest
+    needs: release-build
+    permissions:
+      contents: write
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Upload wheel to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl

--- a/cloudformation-templates/deploy.sh
+++ b/cloudformation-templates/deploy.sh
@@ -45,7 +45,7 @@ aws cloudformation deploy \
   --template-file "$SCRIPT_DIR/nx-neptune-sagemaker.json" \
   --capabilities CAPABILITY_NAMED_IAM \
   --region "$REGION" \
-  --parameter-overrides "ApplicationId=${STACK_NAME}" "AssetsS3Prefix=s3://${ASSETS_BUCKET}" "NotebookSource=s3"
+  --parameter-overrides "ApplicationId=${STACK_NAME}" "AssetsS3Prefix=s3://${ASSETS_BUCKET}" "CustomNotebooks=true"
 
 echo ""
 aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" --query 'Stacks[0].Outputs' --output table

--- a/cloudformation-templates/deploy.sh
+++ b/cloudformation-templates/deploy.sh
@@ -45,7 +45,7 @@ aws cloudformation deploy \
   --template-file "$SCRIPT_DIR/nx-neptune-sagemaker.json" \
   --capabilities CAPABILITY_NAMED_IAM \
   --region "$REGION" \
-  --parameter-overrides "ApplicationId=${STACK_NAME}" "AssetsS3Prefix=s3://${ASSETS_BUCKET}"
+  --parameter-overrides "ApplicationId=${STACK_NAME}" "AssetsS3Prefix=s3://${ASSETS_BUCKET}" "NotebookSource=s3"
 
 echo ""
 aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" --query 'Stacks[0].Outputs' --output table

--- a/cloudformation-templates/nx-neptune-sagemaker.json
+++ b/cloudformation-templates/nx-neptune-sagemaker.json
@@ -27,10 +27,20 @@
       "Default": "ml.t3.medium"
     },
     "AssetsS3Prefix": {
-      "Description": "S3 prefix containing notebooks.zip and optionally a .whl file (e.g. s3://bucket/prefix)",
+      "Description": "S3 prefix containing notebooks.zip and optionally a .whl file (e.g. s3://bucket/prefix). Required when NotebookSource is s3.",
       "Type": "String",
-      "AllowedPattern": "s3://.+"
+      "Default": "",
+      "AllowedPattern": "(s3://.+|)"
+    },
+    "NotebookSource": {
+      "Description": "Where to fetch notebooks from: s3 (requires AssetsS3Prefix) or release (downloads from GitHub Releases)",
+      "Type": "String",
+      "Default": "release",
+      "AllowedValues": ["s3", "release"]
     }
+  },
+  "Conditions": {
+    "UseS3Source": { "Fn::Equals": [{ "Ref": "NotebookSource" }, "s3"] }
   },
   "Resources": {
     "Graph": {
@@ -194,13 +204,19 @@
               "Effect": "Allow",
               "Action": ["s3:GetObject", "s3:ListBucket"],
               "Resource": [
-                { "Fn::Sub": [
-                  "arn:aws:s3:::${bucket}",
-                  { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
+                { "Fn::If": ["UseS3Source",
+                  { "Fn::Sub": [
+                    "arn:aws:s3:::${bucket}",
+                    { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
+                  ]},
+                  { "Ref": "AWS::NoValue" }
                 ]},
-                { "Fn::Sub": [
-                  "arn:aws:s3:::${bucket}/*",
-                  { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
+                { "Fn::If": ["UseS3Source",
+                  { "Fn::Sub": [
+                    "arn:aws:s3:::${bucket}/*",
+                    { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
+                  ]},
+                  { "Ref": "AWS::NoValue" }
                 ]},
                 { "Fn::Sub": "arn:aws:s3:::aws-neptune-notebook-${AWS::Region}" },
                 { "Fn::Sub": "arn:aws:s3:::aws-neptune-notebook-${AWS::Region}/*" }
@@ -284,23 +300,30 @@
                     "set -e\n",
                     "sudo -u ec2-user -i <<'EOF'\n",
                     "source /home/ec2-user/anaconda3/bin/activate python3\n",
+                    "NOTEBOOK_SOURCE=\"", { "Ref": "NotebookSource" }, "\"\n",
                     "ASSETS_PREFIX=\"", { "Ref": "AssetsS3Prefix" }, "\"\n",
                     "mkdir -p /home/ec2-user/SageMaker/.nx-neptune\n",
-                    "aws s3 cp \"${ASSETS_PREFIX%/}/\" /tmp/nx-assets/ --recursive --exclude '*' --include '*.whl' --include 'notebooks.zip'\n",
-                    "if ls /tmp/nx-assets/*.whl 1>/dev/null 2>&1; then\n",
-                    "  cp /tmp/nx-assets/*.whl /home/ec2-user/SageMaker/.nx-neptune/\n",
-                    "  pip install /home/ec2-user/SageMaker/.nx-neptune/*.whl\n",
+                    "if [ \"$NOTEBOOK_SOURCE\" = \"s3\" ]; then\n",
+                    "  aws s3 cp \"${ASSETS_PREFIX%/}/\" /tmp/nx-assets/ --recursive --exclude '*' --include '*.whl' --include 'notebooks.zip'\n",
+                    "  if ls /tmp/nx-assets/*.whl 1>/dev/null 2>&1; then\n",
+                    "    cp /tmp/nx-assets/*.whl /home/ec2-user/SageMaker/.nx-neptune/\n",
+                    "    pip install /home/ec2-user/SageMaker/.nx-neptune/*.whl\n",
+                    "  else\n",
+                    "    pip install nx_neptune\n",
+                    "  fi\n",
+                    "  if [ -f /tmp/nx-assets/notebooks.zip ]; then\n",
+                    "    unzip -o /tmp/nx-assets/notebooks.zip -d /home/ec2-user/SageMaker\n",
+                    "  fi\n",
+                    "  rm -rf /tmp/nx-assets\n",
                     "else\n",
                     "  pip install nx_neptune\n",
+                    "  curl -sL https://github.com/awslabs/nx-neptune/releases/latest/download/notebooks.zip -o /tmp/notebooks.zip\n",
+                    "  unzip -o /tmp/notebooks.zip -d /home/ec2-user/SageMaker/notebooks\n",
+                    "  rm -f /tmp/notebooks.zip\n",
                     "fi\n",
                     "pip install graph-notebook\n",
                     "python -m ipykernel install --user --name python3 --display-name 'Python 3 (ipykernel)'\n",
                     "conda deactivate\n",
-                    "cd /home/ec2-user/SageMaker\n",
-                    "if [ -f /tmp/nx-assets/notebooks.zip ]; then\n",
-                    "  unzip -o /tmp/nx-assets/notebooks.zip -d .\n",
-                    "fi\n",
-                    "rm -rf /tmp/nx-assets\n",
                     "EOF"
                   ]
                 ]

--- a/cloudformation-templates/nx-neptune-sagemaker.json
+++ b/cloudformation-templates/nx-neptune-sagemaker.json
@@ -27,20 +27,19 @@
       "Default": "ml.t3.medium"
     },
     "AssetsS3Prefix": {
-      "Description": "S3 prefix containing notebooks.zip and optionally a .whl file (e.g. s3://bucket/prefix). Required when NotebookSource is s3.",
+      "Description": "S3 prefix containing notebooks.zip and optionally a .whl file (e.g. s3://bucket/prefix)",
       "Type": "String",
-      "Default": "",
-      "AllowedPattern": "(s3://.+|)"
+      "AllowedPattern": "s3://.+"
     },
-    "NotebookSource": {
-      "Description": "Where to fetch notebooks from: s3 (requires AssetsS3Prefix) or release (downloads from GitHub Releases)",
+    "CustomNotebooks": {
+      "Description": "If true, load notebooks from AssetsS3Prefix. If false, download from the latest GitHub Release.",
       "Type": "String",
-      "Default": "release",
-      "AllowedValues": ["s3", "release"]
+      "Default": "false",
+      "AllowedValues": ["true", "false"]
     }
   },
   "Conditions": {
-    "UseS3Source": { "Fn::Equals": [{ "Ref": "NotebookSource" }, "s3"] }
+    "UseCustomNotebooks": { "Fn::Equals": [{ "Ref": "CustomNotebooks" }, "true"] }
   },
   "Resources": {
     "Graph": {
@@ -204,19 +203,13 @@
               "Effect": "Allow",
               "Action": ["s3:GetObject", "s3:ListBucket"],
               "Resource": [
-                { "Fn::If": ["UseS3Source",
-                  { "Fn::Sub": [
-                    "arn:aws:s3:::${bucket}",
-                    { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
-                  ]},
-                  { "Ref": "AWS::NoValue" }
+                { "Fn::Sub": [
+                  "arn:aws:s3:::${bucket}",
+                  { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
                 ]},
-                { "Fn::If": ["UseS3Source",
-                  { "Fn::Sub": [
-                    "arn:aws:s3:::${bucket}/*",
-                    { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
-                  ]},
-                  { "Ref": "AWS::NoValue" }
+                { "Fn::Sub": [
+                  "arn:aws:s3:::${bucket}/*",
+                  { "bucket": { "Fn::Select": [0, { "Fn::Split": ["/", { "Fn::Select": [1, { "Fn::Split": ["s3://", { "Ref": "AssetsS3Prefix" }] }] }] }] } }
                 ]},
                 { "Fn::Sub": "arn:aws:s3:::aws-neptune-notebook-${AWS::Region}" },
                 { "Fn::Sub": "arn:aws:s3:::aws-neptune-notebook-${AWS::Region}/*" }
@@ -300,29 +293,27 @@
                     "set -e\n",
                     "sudo -u ec2-user -i <<'EOF'\n",
                     "source /home/ec2-user/anaconda3/bin/activate python3\n",
-                    "NOTEBOOK_SOURCE=\"", { "Ref": "NotebookSource" }, "\"\n",
                     "ASSETS_PREFIX=\"", { "Ref": "AssetsS3Prefix" }, "\"\n",
+                    "CUSTOM_NOTEBOOKS=\"", { "Ref": "CustomNotebooks" }, "\"\n",
                     "mkdir -p /home/ec2-user/SageMaker/.nx-neptune\n",
-                    "if [ \"$NOTEBOOK_SOURCE\" = \"s3\" ]; then\n",
-                    "  aws s3 cp \"${ASSETS_PREFIX%/}/\" /tmp/nx-assets/ --recursive --exclude '*' --include '*.whl' --include 'notebooks.zip'\n",
-                    "  if ls /tmp/nx-assets/*.whl 1>/dev/null 2>&1; then\n",
-                    "    cp /tmp/nx-assets/*.whl /home/ec2-user/SageMaker/.nx-neptune/\n",
-                    "    pip install /home/ec2-user/SageMaker/.nx-neptune/*.whl\n",
-                    "  else\n",
-                    "    pip install nx_neptune\n",
-                    "  fi\n",
-                    "  if [ -f /tmp/nx-assets/notebooks.zip ]; then\n",
-                    "    unzip -o /tmp/nx-assets/notebooks.zip -d /home/ec2-user/SageMaker\n",
-                    "  fi\n",
-                    "  rm -rf /tmp/nx-assets\n",
+                    "aws s3 cp \"${ASSETS_PREFIX%/}/\" /tmp/nx-assets/ --recursive --exclude '*' --include '*.whl' --include 'notebooks.zip'\n",
+                    "if ls /tmp/nx-assets/*.whl 1>/dev/null 2>&1; then\n",
+                    "  cp /tmp/nx-assets/*.whl /home/ec2-user/SageMaker/.nx-neptune/\n",
+                    "  pip install /home/ec2-user/SageMaker/.nx-neptune/*.whl\n",
                     "else\n",
                     "  pip install nx_neptune\n",
-                    "  curl -sL https://github.com/awslabs/nx-neptune/releases/latest/download/notebooks.zip -o /tmp/notebooks.zip\n",
-                    "  unzip -o /tmp/notebooks.zip -d /home/ec2-user/SageMaker/notebooks\n",
-                    "  rm -f /tmp/notebooks.zip\n",
                     "fi\n",
                     "pip install graph-notebook\n",
                     "python -m ipykernel install --user --name python3 --display-name 'Python 3 (ipykernel)'\n",
+                    "cd /home/ec2-user/SageMaker\n",
+                    "if [ \"$CUSTOM_NOTEBOOKS\" = \"true\" ] && [ -f /tmp/nx-assets/notebooks.zip ]; then\n",
+                    "  unzip -o /tmp/nx-assets/notebooks.zip -d .\n",
+                    "else\n",
+                    "  curl -sL https://github.com/awslabs/nx-neptune/releases/latest/download/notebooks.zip -o /tmp/notebooks.zip\n",
+                    "  unzip -o /tmp/notebooks.zip -d notebooks\n",
+                    "  rm -f /tmp/notebooks.zip\n",
+                    "fi\n",
+                    "rm -rf /tmp/nx-assets\n",
                     "conda deactivate\n",
                     "EOF"
                   ]


### PR DESCRIPTION
### Summary

Adds a `github-release-upload` job to both `python-publish.yml` and `python-prerelease.yml` that attaches the built `.whl` and `notebooks.zip` to the GitHub Release page.
Also adds a `CustomNotebooks` parameter to the CloudFormation template so users can deploy without cloning the repo — notebooks are downloaded from the latest GitHub Release by default.

Closes #221

### Approach

Build once, upload the same artifact to both PyPI and GitHub Release. This is the same approach used by:

- **Flask** — [`create-release` job](https://github.com/pallets/flask/blob/main/.github/workflows/publish.yaml#L38-L49) downloads the build artifact and runs `gh release create ... dist/*`
- **urllib3** — [`publish-to-pypi-and-github` job](https://github.com/urllib3/urllib3/blob/main/.github/workflows/publish.yml#L51-L74) downloads the build artifact, creates a draft release, and runs `gh release upload "$GITHUB_REF_NAME" dist/*`

Both use the same CI build artifact for PyPI publish and GitHub Release upload — no round-trip to PyPI.

### Changes

- `.github/workflows/python-publish.yml` — added `github-release-upload` job (uploads `.whl` + `notebooks.zip`)
- `.github/workflows/python-prerelease.yml` — same
- `cloudformation-templates/nx-neptune-sagemaker.json` — added `CustomNotebooks` parameter (`true`/`false`, default `false`). When `false`, the lifecycle script downloads notebooks from the latest GitHub Release. When `true`, reads `notebooks.zip` from `AssetsS3Prefix` (existing behavior).
- `cloudformation-templates/deploy.sh` — passes `CustomNotebooks=true` since it uploads notebooks to S3

### CloudFormation usage

**Without cloning (new default):**
```bash
aws cloudformation deploy \
  --stack-name nx-neptune-demo \
  --template-file nx-neptune-sagemaker.json \
  --capabilities CAPABILITY_NAMED_IAM \
  --parameter-overrides "ApplicationId=nx-neptune" "AssetsS3Prefix=s3://my-bucket"
```
Notebooks are fetched from `https://github.com/awslabs/nx-neptune/releases/latest/download/notebooks.zip`.

**With custom notebooks (existing flow via deploy.sh):**
```bash
./deploy.sh nx-neptune-demo us-west-1
```
Passes `CustomNotebooks=true` — notebooks come from the S3 assets bucket.

### Testing

Verified wheel + notebook upload on a fork by creating a prerelease (`v0.7.0-rc1`). Workflow ran successfully, both assets appeared on the release page.

Tested over the fork copy: https://github.com/andy-k-improving/nx-neptune/releases/tag/v0.7.0-rc2