### PR TITLE
Feature: Resource validation module with response utilities

### DIFF
--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -20,6 +20,7 @@ from botocore.config import Config
 
 from .client_factory import ClientFactory
 from .neptune_constants import APP_ID_NX, SERVICE_NA
+from .client_factory import ClientFactory
 
 
 class NeptuneAnalyticsClient:

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -20,7 +20,6 @@ from botocore.config import Config
 
 from .client_factory import ClientFactory
 from .neptune_constants import APP_ID_NX, SERVICE_NA
-from .client_factory import ClientFactory
 
 
 class NeptuneAnalyticsClient:

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 from botocore.exceptions import ClientError
 
-
 # --- Error classifiers ---
 
 
@@ -34,6 +33,7 @@ def is_entity_not_found(e: ClientError) -> bool:
     """Is this an Athena entity-not-found error?"""
     msg = str(e)
     return "EntityNotFoundException" in msg or "MetadataException" in msg
+
 
 # --- S3 ---
 

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -33,12 +33,6 @@ def is_entity_not_found(e: ClientError) -> bool:
 # --- S3 ---
 
 
-def get_bucket_region(resp: dict) -> str:
-    """Get bucket region from get_bucket_location response."""
-    # S3 API returns None for us-east-1
-    return resp.get("LocationConstraint") or "us-east-1"
-
-
 def is_kms_encrypted(resp: dict) -> bool:
     """Check if get_bucket_encryption response uses KMS."""
     for rule in resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", []):

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Response interpreters for boto3 API responses.
+
+Pure functions that translate raw boto3 response dicts into typed answers.
+No API calls — just dict parsing with purpose.
+"""
+
+from typing import Optional
+
+# --- S3 ---
+
+
+def get_bucket_region(resp: dict) -> str:
+    """Get bucket region from get_bucket_location response."""
+    # S3 API returns None for us-east-1
+    return resp.get("LocationConstraint") or "us-east-1"
+
+
+def is_kms_encrypted(resp: dict) -> bool:
+    """Check if get_bucket_encryption response uses KMS."""
+    for rule in resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", []):
+        sse = rule.get("ApplyServerSideEncryptionByDefault", {})
+        if sse.get("SSEAlgorithm") == "aws:kms":
+            return True
+    return False
+
+
+def get_kms_key_id(resp: dict) -> Optional[str]:
+    """Extract KMS key ID from get_bucket_encryption response."""
+    for rule in resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", []):
+        sse = rule.get("ApplyServerSideEncryptionByDefault", {})
+        if sse.get("SSEAlgorithm") == "aws:kms":
+            return sse.get("KMSMasterKeyID")
+    return None
+
+
+def is_versioning_enabled(resp: dict) -> bool:
+    """Check if get_bucket_versioning response shows enabled."""
+    return resp.get("Status") == "Enabled"
+
+
+def get_object_count(resp: dict) -> int:
+    """Get object count from list_objects_v2 response."""
+    return resp.get("KeyCount", 0)
+
+
+# --- Athena ---
+
+
+def get_table_columns(resp: dict) -> list[str]:
+    """Extract column names from get_table_metadata response."""
+    return [c["Name"] for c in resp.get("TableMetadata", {}).get("Columns", [])]
+
+
+def get_query_state(resp: dict) -> str:
+    """Get execution state from get_query_execution response."""
+    return resp["QueryExecution"]["Status"]["State"]
+
+
+def get_query_failure_reason(resp: dict) -> str:
+    """Get failure reason from get_query_execution response."""
+    return resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error")
+
+
+def get_query_result_columns(resp: dict) -> list[str]:
+    """Extract column names from get_query_results response."""
+    return [c["Name"] for c in resp["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
+
+
+# --- Neptune ---
+
+
+def get_graph_names(resp: dict) -> list[dict]:
+    """Get graph name/id pairs from list_graphs response."""
+    return [{"name": g["name"], "id": g["id"]} for g in resp.get("graphs", [])]
+
+
+# --- STS ---
+
+
+def get_caller_arn(resp: dict) -> str:
+    """Get caller ARN from get_caller_identity response."""
+    return resp["Arn"]

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -9,6 +9,32 @@ No API calls — just dict parsing with purpose.
 
 from typing import Optional
 
+from botocore.exceptions import ClientError
+
+
+# --- Error classifiers ---
+
+
+def get_error_code(e: ClientError) -> str:
+    """Get HTTP error code from a ClientError."""
+    return e.response["Error"]["Code"]
+
+
+def is_not_found(e: ClientError) -> bool:
+    """Is this a 404 / not-found error?"""
+    return get_error_code(e) == "404"
+
+
+def is_access_denied(e: ClientError) -> bool:
+    """Is this a 403 / access-denied error?"""
+    return get_error_code(e) == "403"
+
+
+def is_entity_not_found(e: ClientError) -> bool:
+    """Is this an Athena entity-not-found error?"""
+    msg = str(e)
+    return "EntityNotFoundException" in msg or "MetadataException" in msg
+
 # --- S3 ---
 
 

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -14,19 +14,14 @@ from botocore.exceptions import ClientError
 # --- Error classifiers ---
 
 
-def get_error_code(e: ClientError) -> str:
-    """Get HTTP error code from a ClientError."""
-    return e.response["Error"]["Code"]
-
-
 def is_not_found(e: ClientError) -> bool:
     """Is this a 404 / not-found error?"""
-    return get_error_code(e) == "404"
+    return e.response["Error"]["Code"] == "404"
 
 
 def is_access_denied(e: ClientError) -> bool:
     """Is this a 403 / access-denied error?"""
-    return get_error_code(e) == "403"
+    return e.response["Error"]["Code"] == "403"
 
 
 def is_entity_not_found(e: ClientError) -> bool:

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -7,9 +7,9 @@ Provides upfront checks for S3, Athena, and Neptune Analytics resources
 so configuration errors surface immediately — not minutes into a pipeline.
 """
 
+import asyncio
 import logging
 import re
-import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -32,6 +32,7 @@ from nx_neptune.clients.response_utils import (
     is_not_found,
     is_versioning_enabled,
 )
+from nx_neptune.utils.task_future import TaskType, wait_until_all_complete
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,9 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
         if is_not_found(e):
             return CheckResult.fail("s3_bucket_exists", f"Bucket '{bucket}' not found")
         if is_access_denied(e):
-            return CheckResult.fail("s3_bucket_exists", f"Access denied to bucket '{bucket}'")
+            return CheckResult.fail(
+                "s3_bucket_exists", f"Access denied to bucket '{bucket}'"
+            )
         return CheckResult.fail("s3_bucket_exists", str(e))
 
 
@@ -226,21 +229,20 @@ def check_athena_query(
                 ResultConfiguration={"OutputLocation": output_location},
             )["QueryExecutionId"]
 
-            while True:
-                resp = athena.get_query_execution(QueryExecutionId=exec_id)
-                state = get_query_state(resp)
-                if state == "SUCCEEDED":
-                    results = athena.get_query_results(
-                        QueryExecutionId=exec_id, MaxResults=1
-                    )
-                    all_columns.append(get_query_result_columns(results))
-                    break
-                if state in ("FAILED", "CANCELLED"):
-                    reason = get_query_failure_reason(resp)
-                    return CheckResult.fail(
-                        "athena_query", f"Query {i+1} failed: {reason}"
-                    )
-                time.sleep(1)
+            asyncio.run(
+                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena)
+            )
+
+            resp = athena.get_query_execution(QueryExecutionId=exec_id)
+            state = get_query_state(resp)
+            if state != "SUCCEEDED":
+                return CheckResult.fail(
+                    "athena_query",
+                    f"Query {i+1} failed: {get_query_failure_reason(resp)}",
+                )
+
+            results = athena.get_query_results(QueryExecutionId=exec_id, MaxResults=1)
+            all_columns.append(get_query_result_columns(results))
 
         for i, columns in enumerate(all_columns):
             if "~id" not in columns:

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -16,6 +16,19 @@ from typing import Optional
 from botocore.exceptions import ClientError
 
 from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune.clients.response_utils import (
+    get_bucket_region,
+    get_caller_arn,
+    get_graph_names,
+    get_kms_key_id,
+    get_object_count,
+    get_query_failure_reason,
+    get_query_result_columns,
+    get_query_state,
+    get_table_columns,
+    is_kms_encrypted,
+    is_versioning_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +87,7 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
-        location = (
-            resp.get("LocationConstraint") or "us-east-1"
-        )  # S3 API returns None for us-east-1
+        location = get_bucket_region(resp)
         if location == expected_region:
             return CheckResult.ok(
                 "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"
@@ -94,12 +105,10 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_encryption(Bucket=bucket)
-        rules = resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", [])
-        for rule in rules:
-            sse = rule.get("ApplyServerSideEncryptionByDefault", {})
-            if sse.get("SSEAlgorithm") == "aws:kms":
-                key = sse.get("KMSMasterKeyID", "AWS managed key")
-                return CheckResult.ok("s3_bucket_encryption", f"KMS encryption: {key}")
+        if is_kms_encrypted(resp):
+            return CheckResult.ok(
+                "s3_bucket_encryption", f"KMS encryption: {get_kms_key_id(resp)}"
+            )
         return CheckResult.fail(
             "s3_bucket_encryption", f"Bucket '{bucket}' does not use KMS encryption"
         )
@@ -116,8 +125,7 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
-        status = resp.get("Status", "Disabled")
-        if status == "Enabled":
+        if is_versioning_enabled(resp):
             return CheckResult.ok(
                 "s3_bucket_versioning", f"Versioning enabled on '{bucket}'"
             )
@@ -138,7 +146,7 @@ def check_path_empty(s3_uri: str) -> CheckResult:
             .s3()
             .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         )
-        if resp.get("KeyCount", 0) == 0:
+        if get_object_count(resp) == 0:
             return CheckResult.ok("s3_path_empty", f"Path '{s3_uri}' is empty")
         return CheckResult.fail(
             "s3_path_empty",
@@ -183,11 +191,10 @@ def check_athena_table(
                 CatalogName=catalog, DatabaseName=database, TableName=table
             )
         )
-        columns = resp["TableMetadata"].get("Columns", [])
-        col_names = [c["Name"] for c in columns]
+        col_names = get_table_columns(resp)
         return CheckResult.ok(
             "athena_table",
-            f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
+            f"Table '{table}' found with {len(col_names)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
@@ -221,21 +228,15 @@ def check_athena_query(
 
             while True:
                 resp = athena.get_query_execution(QueryExecutionId=exec_id)
-                state = resp["QueryExecution"]["Status"]["State"]
+                state = get_query_state(resp)
                 if state == "SUCCEEDED":
                     results = athena.get_query_results(
                         QueryExecutionId=exec_id, MaxResults=1
                     )
-                    columns = [
-                        c["Name"]
-                        for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
-                    ]
-                    all_columns.append(columns)
+                    all_columns.append(get_query_result_columns(results))
                     break
                 if state in ("FAILED", "CANCELLED"):
-                    reason = resp["QueryExecution"]["Status"].get(
-                        "StateChangeReason", "Unknown error"
-                    )
+                    reason = get_query_failure_reason(resp)
                     return CheckResult.fail(
                         "athena_query", f"Query {i+1} failed: {reason}"
                     )
@@ -264,7 +265,7 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
     """Check that no existing graph uses this name."""
     try:
         resp = ClientFactory.default().neptune().list_graphs()
-        for g in resp.get("graphs", []):
+        for g in get_graph_names(resp):
             if g["name"] == graph_name:
                 return CheckResult.fail(
                     "graph_name_available",
@@ -283,8 +284,8 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
 def check_credentials() -> CheckResult:
     """Check that AWS credentials are valid."""
     try:
-        identity = ClientFactory.default().sts().get_caller_identity()
-        return CheckResult.ok("credentials", f"Resolved as {identity['Arn']}")
+        resp = ClientFactory.default().sts().get_caller_identity()
+        return CheckResult.ok("credentials", f"Resolved as {get_caller_arn(resp)}")
     except Exception as e:
         return CheckResult.fail("credentials", f"Cannot resolve credentials: {e}")
 

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -1,0 +1,295 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resource validation for nx-neptune migrations.
+
+Provides upfront checks for S3, Athena, and Neptune Analytics resources
+so configuration errors surface immediately — not minutes into a pipeline.
+"""
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from botocore.exceptions import ClientError
+
+from nx_neptune.clients.client_factory import ClientFactory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CheckResult:
+    check: str
+    passed: bool
+    message: str
+
+    def to_dict(self) -> dict:
+        return {"check": self.check, "passed": self.passed, "message": self.message}
+
+
+def _parse_bucket(s3_uri: str) -> str:
+    """Extract bucket name from s3://bucket/path/."""
+    return s3_uri.replace("s3://", "").split("/")[0]
+
+
+def _parse_prefix(s3_uri: str) -> str:
+    """Extract prefix from s3://bucket/prefix/."""
+    parts = s3_uri.replace("s3://", "").split("/", 1)
+    return parts[1] if len(parts) > 1 else ""
+
+
+# --- S3 checks ---
+
+
+def check_bucket_exists(s3_uri: str) -> CheckResult:
+    """Check that the S3 bucket exists and is accessible."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        ClientFactory.default().s3().head_bucket(Bucket=bucket)
+        return CheckResult("s3_bucket_exists", True, f"Bucket '{bucket}' exists")
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "404":
+            return CheckResult("s3_bucket_exists", False, f"Bucket '{bucket}' not found")
+        if code == "403":
+            return CheckResult("s3_bucket_exists", False, f"Access denied to bucket '{bucket}'")
+        return CheckResult("s3_bucket_exists", False, str(e))
+
+
+def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
+    """Check that the bucket is in the expected region."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
+        location = resp.get("LocationConstraint") or "us-east-1"
+        if location == expected_region:
+            return CheckResult("s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}")
+        return CheckResult(
+            "s3_bucket_region", False,
+            f"Bucket '{bucket}' is in {location}, expected {expected_region}",
+        )
+    except ClientError as e:
+        return CheckResult("s3_bucket_region", False, str(e))
+
+
+def check_bucket_encryption(s3_uri: str) -> CheckResult:
+    """Check that the bucket has KMS encryption configured."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().get_bucket_encryption(Bucket=bucket)
+        rules = resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", [])
+        for rule in rules:
+            sse = rule.get("ApplyServerSideEncryptionByDefault", {})
+            if sse.get("SSEAlgorithm") == "aws:kms":
+                key = sse.get("KMSMasterKeyID", "AWS managed key")
+                return CheckResult("s3_bucket_encryption", True, f"KMS encryption: {key}")
+        return CheckResult(
+            "s3_bucket_encryption", False,
+            f"Bucket '{bucket}' does not use KMS encryption",
+        )
+    except ClientError as e:
+        if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
+            return CheckResult(
+                "s3_bucket_encryption", False,
+                f"No encryption configured on bucket '{bucket}'",
+            )
+        return CheckResult("s3_bucket_encryption", False, str(e))
+
+
+def check_bucket_versioning(s3_uri: str) -> CheckResult:
+    """Check that the bucket has versioning enabled."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
+        status = resp.get("Status", "Disabled")
+        if status == "Enabled":
+            return CheckResult("s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'")
+        return CheckResult(
+            "s3_bucket_versioning", False,
+            f"Versioning not enabled on '{bucket}'",
+        )
+    except ClientError as e:
+        return CheckResult("s3_bucket_versioning", False, str(e))
+
+
+def check_path_empty(s3_uri: str) -> CheckResult:
+    """Check that the S3 path has no existing objects."""
+    bucket = _parse_bucket(s3_uri)
+    prefix = _parse_prefix(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        if resp.get("KeyCount", 0) == 0:
+            return CheckResult("s3_path_empty", True, f"Path '{s3_uri}' is empty")
+        return CheckResult(
+            "s3_path_empty", False,
+            f"Path '{s3_uri}' is not empty — leftover files may cause issues",
+        )
+    except ClientError as e:
+        return CheckResult("s3_path_empty", False, str(e))
+
+
+# --- Athena checks ---
+
+
+def check_athena_database(catalog: str, database: str) -> CheckResult:
+    """Check that the Athena database exists."""
+    try:
+        ClientFactory.default().athena().get_database(CatalogName=catalog, DatabaseName=database)
+        return CheckResult("athena_database", True, f"Database '{database}' found in catalog '{catalog}'")
+    except ClientError as e:
+        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+            return CheckResult("athena_database", False, f"Database '{database}' not found in catalog '{catalog}'")
+        return CheckResult("athena_database", False, str(e))
+
+
+def check_athena_table(catalog: str, database: str, table: str) -> CheckResult:
+    """Check that the Athena table exists and return its columns."""
+    try:
+        resp = ClientFactory.default().athena().get_table_metadata(
+            CatalogName=catalog, DatabaseName=database, TableName=table
+        )
+        columns = resp["TableMetadata"].get("Columns", [])
+        col_names = [c["Name"] for c in columns]
+        return CheckResult(
+            "athena_table", True,
+            f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
+        )
+    except ClientError as e:
+        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+            return CheckResult("athena_table", False, f"Table '{table}' not found in '{database}'")
+        return CheckResult("athena_table", False, str(e))
+
+
+def check_athena_query(
+    sql_query: str, catalog: str, database: str, output_location: str
+) -> CheckResult:
+    """Validate SQL query by running with LIMIT 0 and checking required columns."""
+    queries = [q.strip() for q in sql_query.split(";") if q.strip()]
+    all_columns: list[list[str]] = []
+
+    try:
+        athena = ClientFactory.default().athena()
+
+        for i, q in enumerate(queries):
+            stripped = re.sub(r'\s+LIMIT\s+\d+\s*$', '', q.rstrip(), flags=re.IGNORECASE)
+            wrapped = f"{stripped} LIMIT 0"
+
+            exec_id = athena.start_query_execution(
+                QueryString=wrapped,
+                QueryExecutionContext={"Catalog": catalog, "Database": database},
+                ResultConfiguration={"OutputLocation": output_location},
+            )["QueryExecutionId"]
+
+            while True:
+                resp = athena.get_query_execution(QueryExecutionId=exec_id)
+                state = resp["QueryExecution"]["Status"]["State"]
+                if state == "SUCCEEDED":
+                    results = athena.get_query_results(QueryExecutionId=exec_id, MaxResults=1)
+                    columns = [c["Name"] for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
+                    all_columns.append(columns)
+                    break
+                if state in ("FAILED", "CANCELLED"):
+                    reason = resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error")
+                    return CheckResult("athena_query", False, f"Query {i+1} failed: {reason}")
+                time.sleep(1)
+
+        for i, columns in enumerate(all_columns):
+            if "~id" not in columns:
+                return CheckResult(
+                    "athena_query", False,
+                    f"Query {i+1} missing required '~id' column. Got: {', '.join(columns)}",
+                )
+
+        combined = [c for cols in all_columns for c in cols]
+        return CheckResult("athena_query", True, f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}")
+    except ClientError as e:
+        return CheckResult("athena_query", False, str(e))
+
+
+# --- Neptune Analytics checks ---
+
+
+def check_graph_name_available(graph_name: str) -> CheckResult:
+    """Check that no existing graph uses this name prefix."""
+    try:
+        resp = ClientFactory.default().neptune().list_graphs()
+        for g in resp.get("graphs", []):
+            if g["name"].startswith(graph_name):
+                return CheckResult(
+                    "graph_name_available", False,
+                    f"Graph '{g['name']}' ({g['id']}) already exists with this prefix",
+                )
+        return CheckResult("graph_name_available", True, f"No existing graph named '{graph_name}'")
+    except ClientError as e:
+        return CheckResult("graph_name_available", False, str(e))
+
+
+# --- Credentials check ---
+
+
+def check_credentials() -> CheckResult:
+    """Check that AWS credentials are valid."""
+    try:
+        identity = ClientFactory.default().sts().get_caller_identity()
+        return CheckResult("credentials", True, f"Resolved as {identity['Arn']}")
+    except Exception as e:
+        return CheckResult("credentials", False, f"Cannot resolve credentials: {e}")
+
+
+# --- Orchestrator ---
+
+
+def validate_resources(
+    s3_staging_bucket: Optional[str] = None,
+    athena_output_bucket: Optional[str] = None,
+    athena_catalog: str = "AwsDataCatalog",
+    athena_database: Optional[str] = None,
+    athena_table: Optional[str] = None,
+    sql_query: Optional[str] = None,
+    graph_name: Optional[str] = None,
+    expected_region: Optional[str] = None,
+) -> list[dict]:
+    """Run all applicable validation checks and return results.
+
+    Only validates resources that are provided — no false errors for unused features.
+    """
+    results: list[CheckResult] = []
+
+    # Always check credentials first
+    cred_check = check_credentials()
+    results.append(cred_check)
+    if not cred_check.passed:
+        return [r.to_dict() for r in results]
+
+    # S3 staging bucket
+    if s3_staging_bucket:
+        results.append(check_bucket_exists(s3_staging_bucket))
+        if expected_region:
+            results.append(check_bucket_region(s3_staging_bucket, expected_region))
+        results.append(check_bucket_versioning(s3_staging_bucket))
+
+    # Athena output bucket
+    if athena_output_bucket:
+        results.append(check_bucket_exists(athena_output_bucket))
+        if expected_region:
+            results.append(check_bucket_region(athena_output_bucket, expected_region))
+        results.append(check_path_empty(athena_output_bucket))
+
+    # Athena database/table
+    if athena_database:
+        results.append(check_athena_database(athena_catalog, athena_database))
+        if athena_table:
+            results.append(check_athena_table(athena_catalog, athena_database, athena_table))
+
+    # Athena query validation
+    if sql_query and athena_database and s3_staging_bucket:
+        results.append(check_athena_query(sql_query, athena_catalog, athena_database, s3_staging_bucket))
+
+    # Graph name
+    if graph_name:
+        results.append(check_graph_name_available(graph_name))
+
+    return [r.to_dict() for r in results]

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -26,7 +26,10 @@ from nx_neptune.clients.response_utils import (
     get_query_result_columns,
     get_query_state,
     get_table_columns,
+    is_access_denied,
+    is_entity_not_found,
     is_kms_encrypted,
+    is_not_found,
     is_versioning_enabled,
 )
 
@@ -72,13 +75,10 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
         ClientFactory.default().s3().head_bucket(Bucket=bucket)
         return CheckResult.ok("s3_bucket_exists", f"Bucket '{bucket}' exists")
     except ClientError as e:
-        code = e.response["Error"]["Code"]
-        if code == "404":
+        if is_not_found(e):
             return CheckResult.fail("s3_bucket_exists", f"Bucket '{bucket}' not found")
-        if code == "403":
-            return CheckResult.fail(
-                "s3_bucket_exists", f"Access denied to bucket '{bucket}'"
-            )
+        if is_access_denied(e):
+            return CheckResult.fail("s3_bucket_exists", f"Access denied to bucket '{bucket}'")
         return CheckResult.fail("s3_bucket_exists", str(e))
 
 
@@ -171,7 +171,7 @@ def check_athena_database(
             "athena_database", f"Database '{database}' found in catalog '{catalog}'"
         )
     except ClientError as e:
-        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+        if is_entity_not_found(e):
             return CheckResult.fail(
                 "athena_database",
                 f"Database '{database}' not found in catalog '{catalog}'",
@@ -197,7 +197,7 @@ def check_athena_table(
             f"Table '{table}' found with {len(col_names)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
-        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+        if is_entity_not_found(e):
             return CheckResult.fail(
                 "athena_table", f"Table '{table}' not found in '{database}'"
             )

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -53,9 +53,13 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
     except ClientError as e:
         code = e.response["Error"]["Code"]
         if code == "404":
-            return CheckResult("s3_bucket_exists", False, f"Bucket '{bucket}' not found")
+            return CheckResult(
+                "s3_bucket_exists", False, f"Bucket '{bucket}' not found"
+            )
         if code == "403":
-            return CheckResult("s3_bucket_exists", False, f"Access denied to bucket '{bucket}'")
+            return CheckResult(
+                "s3_bucket_exists", False, f"Access denied to bucket '{bucket}'"
+            )
         return CheckResult("s3_bucket_exists", False, str(e))
 
 
@@ -64,11 +68,16 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
-        location = resp.get("LocationConstraint") or "us-east-1"
+        location = (
+            resp.get("LocationConstraint") or "us-east-1"
+        )  # S3 API returns None for us-east-1
         if location == expected_region:
-            return CheckResult("s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}")
+            return CheckResult(
+                "s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}"
+            )
         return CheckResult(
-            "s3_bucket_region", False,
+            "s3_bucket_region",
+            False,
             f"Bucket '{bucket}' is in {location}, expected {expected_region}",
         )
     except ClientError as e:
@@ -85,15 +94,19 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
             sse = rule.get("ApplyServerSideEncryptionByDefault", {})
             if sse.get("SSEAlgorithm") == "aws:kms":
                 key = sse.get("KMSMasterKeyID", "AWS managed key")
-                return CheckResult("s3_bucket_encryption", True, f"KMS encryption: {key}")
+                return CheckResult(
+                    "s3_bucket_encryption", True, f"KMS encryption: {key}"
+                )
         return CheckResult(
-            "s3_bucket_encryption", False,
+            "s3_bucket_encryption",
+            False,
             f"Bucket '{bucket}' does not use KMS encryption",
         )
     except ClientError as e:
         if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
             return CheckResult(
-                "s3_bucket_encryption", False,
+                "s3_bucket_encryption",
+                False,
                 f"No encryption configured on bucket '{bucket}'",
             )
         return CheckResult("s3_bucket_encryption", False, str(e))
@@ -106,9 +119,12 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
         status = resp.get("Status", "Disabled")
         if status == "Enabled":
-            return CheckResult("s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'")
+            return CheckResult(
+                "s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'"
+            )
         return CheckResult(
-            "s3_bucket_versioning", False,
+            "s3_bucket_versioning",
+            False,
             f"Versioning not enabled on '{bucket}'",
         )
     except ClientError as e:
@@ -120,11 +136,16 @@ def check_path_empty(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     prefix = _parse_prefix(s3_uri)
     try:
-        resp = ClientFactory.default().s3().list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        resp = (
+            ClientFactory.default()
+            .s3()
+            .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        )
         if resp.get("KeyCount", 0) == 0:
             return CheckResult("s3_path_empty", True, f"Path '{s3_uri}' is empty")
         return CheckResult(
-            "s3_path_empty", False,
+            "s3_path_empty",
+            False,
             f"Path '{s3_uri}' is not empty — leftover files may cause issues",
         )
     except ClientError as e:
@@ -134,37 +155,58 @@ def check_path_empty(s3_uri: str) -> CheckResult:
 # --- Athena checks ---
 
 
-def check_athena_database(catalog: str, database: str) -> CheckResult:
+def check_athena_database(
+    database: str, catalog: str = "AwsDataCatalog"
+) -> CheckResult:
     """Check that the Athena database exists."""
     try:
-        ClientFactory.default().athena().get_database(CatalogName=catalog, DatabaseName=database)
-        return CheckResult("athena_database", True, f"Database '{database}' found in catalog '{catalog}'")
+        ClientFactory.default().athena().get_database(
+            CatalogName=catalog, DatabaseName=database
+        )
+        return CheckResult(
+            "athena_database",
+            True,
+            f"Database '{database}' found in catalog '{catalog}'",
+        )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult("athena_database", False, f"Database '{database}' not found in catalog '{catalog}'")
+            return CheckResult(
+                "athena_database",
+                False,
+                f"Database '{database}' not found in catalog '{catalog}'",
+            )
         return CheckResult("athena_database", False, str(e))
 
 
-def check_athena_table(catalog: str, database: str, table: str) -> CheckResult:
+def check_athena_table(
+    database: str, table: str, catalog: str = "AwsDataCatalog"
+) -> CheckResult:
     """Check that the Athena table exists and return its columns."""
     try:
-        resp = ClientFactory.default().athena().get_table_metadata(
-            CatalogName=catalog, DatabaseName=database, TableName=table
+        resp = (
+            ClientFactory.default()
+            .athena()
+            .get_table_metadata(
+                CatalogName=catalog, DatabaseName=database, TableName=table
+            )
         )
         columns = resp["TableMetadata"].get("Columns", [])
         col_names = [c["Name"] for c in columns]
         return CheckResult(
-            "athena_table", True,
+            "athena_table",
+            True,
             f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult("athena_table", False, f"Table '{table}' not found in '{database}'")
+            return CheckResult(
+                "athena_table", False, f"Table '{table}' not found in '{database}'"
+            )
         return CheckResult("athena_table", False, str(e))
 
 
 def check_athena_query(
-    sql_query: str, catalog: str, database: str, output_location: str
+    sql_query: str, database: str, output_location: str, catalog: str = "AwsDataCatalog"
 ) -> CheckResult:
     """Validate SQL query by running with LIMIT 0 and checking required columns."""
     queries = [q.strip() for q in sql_query.split(";") if q.strip()]
@@ -174,7 +216,9 @@ def check_athena_query(
         athena = ClientFactory.default().athena()
 
         for i, q in enumerate(queries):
-            stripped = re.sub(r'\s+LIMIT\s+\d+\s*$', '', q.rstrip(), flags=re.IGNORECASE)
+            stripped = re.sub(
+                r"\s+LIMIT\s+\d+\s*$", "", q.rstrip(), flags=re.IGNORECASE
+            )
             wrapped = f"{stripped} LIMIT 0"
 
             exec_id = athena.start_query_execution(
@@ -187,24 +231,38 @@ def check_athena_query(
                 resp = athena.get_query_execution(QueryExecutionId=exec_id)
                 state = resp["QueryExecution"]["Status"]["State"]
                 if state == "SUCCEEDED":
-                    results = athena.get_query_results(QueryExecutionId=exec_id, MaxResults=1)
-                    columns = [c["Name"] for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
+                    results = athena.get_query_results(
+                        QueryExecutionId=exec_id, MaxResults=1
+                    )
+                    columns = [
+                        c["Name"]
+                        for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
+                    ]
                     all_columns.append(columns)
                     break
                 if state in ("FAILED", "CANCELLED"):
-                    reason = resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error")
-                    return CheckResult("athena_query", False, f"Query {i+1} failed: {reason}")
+                    reason = resp["QueryExecution"]["Status"].get(
+                        "StateChangeReason", "Unknown error"
+                    )
+                    return CheckResult(
+                        "athena_query", False, f"Query {i+1} failed: {reason}"
+                    )
                 time.sleep(1)
 
         for i, columns in enumerate(all_columns):
             if "~id" not in columns:
                 return CheckResult(
-                    "athena_query", False,
+                    "athena_query",
+                    False,
                     f"Query {i+1} missing required '~id' column. Got: {', '.join(columns)}",
                 )
 
         combined = [c for cols in all_columns for c in cols]
-        return CheckResult("athena_query", True, f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}")
+        return CheckResult(
+            "athena_query",
+            True,
+            f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}",
+        )
     except ClientError as e:
         return CheckResult("athena_query", False, str(e))
 
@@ -213,16 +271,19 @@ def check_athena_query(
 
 
 def check_graph_name_available(graph_name: str) -> CheckResult:
-    """Check that no existing graph uses this name prefix."""
+    """Check that no existing graph uses this name."""
     try:
         resp = ClientFactory.default().neptune().list_graphs()
         for g in resp.get("graphs", []):
-            if g["name"].startswith(graph_name):
+            if g["name"] == graph_name:
                 return CheckResult(
-                    "graph_name_available", False,
-                    f"Graph '{g['name']}' ({g['id']}) already exists with this prefix",
+                    "graph_name_available",
+                    False,
+                    f"Graph '{g['name']}' ({g['id']}) already exists",
                 )
-        return CheckResult("graph_name_available", True, f"No existing graph named '{graph_name}'")
+        return CheckResult(
+            "graph_name_available", True, f"No existing graph named '{graph_name}'"
+        )
     except ClientError as e:
         return CheckResult("graph_name_available", False, str(e))
 
@@ -280,13 +341,19 @@ def validate_resources(
 
     # Athena database/table
     if athena_database:
-        results.append(check_athena_database(athena_catalog, athena_database))
+        results.append(check_athena_database(athena_database, athena_catalog))
         if athena_table:
-            results.append(check_athena_table(athena_catalog, athena_database, athena_table))
+            results.append(
+                check_athena_table(athena_database, athena_table, athena_catalog)
+            )
 
     # Athena query validation
     if sql_query and athena_database and s3_staging_bucket:
-        results.append(check_athena_query(sql_query, athena_catalog, athena_database, s3_staging_bucket))
+        results.append(
+            check_athena_query(
+                sql_query, athena_database, s3_staging_bucket, athena_catalog
+            )
+        )
 
     # Graph name
     if graph_name:

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -17,7 +17,6 @@ from botocore.exceptions import ClientError
 
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune.clients.response_utils import (
-    get_bucket_region,
     get_caller_arn,
     get_graph_names,
     get_kms_key_id,
@@ -39,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class CheckResult:
-    check: str
+    check_name: str
     passed: bool
     message: str
 
@@ -52,7 +51,11 @@ class CheckResult:
         return cls(check, False, msg)
 
     def to_dict(self) -> dict:
-        return {"check": self.check, "passed": self.passed, "message": self.message}
+        return {
+            "check": self.check_name,
+            "passed": self.passed,
+            "message": self.message,
+        }
 
 
 def _parse_bucket(s3_uri: str) -> str:
@@ -89,8 +92,8 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     """Check that the bucket is in the expected region."""
     bucket = _parse_bucket(s3_uri)
     try:
-        resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
-        location = get_bucket_region(resp)
+        resp = ClientFactory.default().s3().head_bucket(Bucket=bucket)
+        location = resp["BucketRegion"]
         if location == expected_region:
             return CheckResult.ok(
                 "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -93,17 +93,18 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().head_bucket(Bucket=bucket)
-        location = resp["BucketRegion"]
-        if location == expected_region:
-            return CheckResult.ok(
-                "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"
-            )
-        return CheckResult.fail(
-            "s3_bucket_region",
-            f"Bucket '{bucket}' is in {location}, expected {expected_region}",
-        )
     except ClientError as e:
         return CheckResult.fail("s3_bucket_region", str(e))
+
+    location = resp["BucketRegion"]
+    if location == expected_region:
+        return CheckResult.ok(
+            "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"
+        )
+    return CheckResult.fail(
+        "s3_bucket_region",
+        f"Bucket '{bucket}' is in {location}, expected {expected_region}",
+    )
 
 
 def check_bucket_encryption(s3_uri: str) -> CheckResult:
@@ -111,13 +112,6 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_encryption(Bucket=bucket)
-        if is_kms_encrypted(resp):
-            return CheckResult.ok(
-                "s3_bucket_encryption", f"KMS encryption: {get_kms_key_id(resp)}"
-            )
-        return CheckResult.fail(
-            "s3_bucket_encryption", f"Bucket '{bucket}' does not use KMS encryption"
-        )
     except ClientError as e:
         if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
             return CheckResult.fail(
@@ -125,21 +119,30 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
             )
         return CheckResult.fail("s3_bucket_encryption", str(e))
 
+    if is_kms_encrypted(resp):
+        return CheckResult.ok(
+            "s3_bucket_encryption", f"KMS encryption: {get_kms_key_id(resp)}"
+        )
+    return CheckResult.fail(
+        "s3_bucket_encryption", f"Bucket '{bucket}' does not use KMS encryption"
+    )
+
 
 def check_bucket_versioning(s3_uri: str) -> CheckResult:
     """Check that the bucket has versioning enabled."""
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
-        if is_versioning_enabled(resp):
-            return CheckResult.ok(
-                "s3_bucket_versioning", f"Versioning enabled on '{bucket}'"
-            )
-        return CheckResult.fail(
-            "s3_bucket_versioning", f"Versioning not enabled on '{bucket}'"
-        )
     except ClientError as e:
         return CheckResult.fail("s3_bucket_versioning", str(e))
+
+    if is_versioning_enabled(resp):
+        return CheckResult.ok(
+            "s3_bucket_versioning", f"Versioning enabled on '{bucket}'"
+        )
+    return CheckResult.fail(
+        "s3_bucket_versioning", f"Versioning not enabled on '{bucket}'"
+    )
 
 
 def check_path_empty(s3_uri: str) -> CheckResult:
@@ -152,14 +155,15 @@ def check_path_empty(s3_uri: str) -> CheckResult:
             .s3()
             .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         )
-        if get_object_count(resp) == 0:
-            return CheckResult.ok("s3_path_empty", f"Path '{s3_uri}' is empty")
-        return CheckResult.fail(
-            "s3_path_empty",
-            f"Path '{s3_uri}' is not empty — leftover files may cause issues",
-        )
     except ClientError as e:
         return CheckResult.fail("s3_path_empty", str(e))
+
+    if get_object_count(resp) == 0:
+        return CheckResult.ok("s3_path_empty", f"Path '{s3_uri}' is empty")
+    return CheckResult.fail(
+        "s3_path_empty",
+        f"Path '{s3_uri}' is not empty — leftover files may cause issues",
+    )
 
 
 # --- Athena checks ---
@@ -197,17 +201,18 @@ def check_athena_table(
                 CatalogName=catalog, DatabaseName=database, TableName=table
             )
         )
-        col_names = get_table_columns(resp)
-        return CheckResult.ok(
-            "athena_table",
-            f"Table '{table}' found with {len(col_names)} columns: {', '.join(col_names)}",
-        )
     except ClientError as e:
         if is_entity_not_found(e):
             return CheckResult.fail(
                 "athena_table", f"Table '{table}' not found in '{database}'"
             )
         return CheckResult.fail("athena_table", str(e))
+
+    col_names = get_table_columns(resp)
+    return CheckResult.ok(
+        "athena_table",
+        f"Table '{table}' found with {len(col_names)} columns: {', '.join(col_names)}",
+    )
 
 
 def check_athena_query(

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -26,6 +26,14 @@ class CheckResult:
     passed: bool
     message: str
 
+    @classmethod
+    def ok(cls, check: str, msg: str) -> "CheckResult":
+        return cls(check, True, msg)
+
+    @classmethod
+    def fail(cls, check: str, msg: str) -> "CheckResult":
+        return cls(check, False, msg)
+
     def to_dict(self) -> dict:
         return {"check": self.check, "passed": self.passed, "message": self.message}
 
@@ -49,18 +57,16 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         ClientFactory.default().s3().head_bucket(Bucket=bucket)
-        return CheckResult("s3_bucket_exists", True, f"Bucket '{bucket}' exists")
+        return CheckResult.ok("s3_bucket_exists", f"Bucket '{bucket}' exists")
     except ClientError as e:
         code = e.response["Error"]["Code"]
         if code == "404":
-            return CheckResult(
-                "s3_bucket_exists", False, f"Bucket '{bucket}' not found"
-            )
+            return CheckResult.fail("s3_bucket_exists", f"Bucket '{bucket}' not found")
         if code == "403":
-            return CheckResult(
-                "s3_bucket_exists", False, f"Access denied to bucket '{bucket}'"
+            return CheckResult.fail(
+                "s3_bucket_exists", f"Access denied to bucket '{bucket}'"
             )
-        return CheckResult("s3_bucket_exists", False, str(e))
+        return CheckResult.fail("s3_bucket_exists", str(e))
 
 
 def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
@@ -72,16 +78,15 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
             resp.get("LocationConstraint") or "us-east-1"
         )  # S3 API returns None for us-east-1
         if location == expected_region:
-            return CheckResult(
-                "s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}"
+            return CheckResult.ok(
+                "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"
             )
-        return CheckResult(
+        return CheckResult.fail(
             "s3_bucket_region",
-            False,
             f"Bucket '{bucket}' is in {location}, expected {expected_region}",
         )
     except ClientError as e:
-        return CheckResult("s3_bucket_region", False, str(e))
+        return CheckResult.fail("s3_bucket_region", str(e))
 
 
 def check_bucket_encryption(s3_uri: str) -> CheckResult:
@@ -94,22 +99,16 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
             sse = rule.get("ApplyServerSideEncryptionByDefault", {})
             if sse.get("SSEAlgorithm") == "aws:kms":
                 key = sse.get("KMSMasterKeyID", "AWS managed key")
-                return CheckResult(
-                    "s3_bucket_encryption", True, f"KMS encryption: {key}"
-                )
-        return CheckResult(
-            "s3_bucket_encryption",
-            False,
-            f"Bucket '{bucket}' does not use KMS encryption",
+                return CheckResult.ok("s3_bucket_encryption", f"KMS encryption: {key}")
+        return CheckResult.fail(
+            "s3_bucket_encryption", f"Bucket '{bucket}' does not use KMS encryption"
         )
     except ClientError as e:
         if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
-            return CheckResult(
-                "s3_bucket_encryption",
-                False,
-                f"No encryption configured on bucket '{bucket}'",
+            return CheckResult.fail(
+                "s3_bucket_encryption", f"No encryption configured on bucket '{bucket}'"
             )
-        return CheckResult("s3_bucket_encryption", False, str(e))
+        return CheckResult.fail("s3_bucket_encryption", str(e))
 
 
 def check_bucket_versioning(s3_uri: str) -> CheckResult:
@@ -119,16 +118,14 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
         status = resp.get("Status", "Disabled")
         if status == "Enabled":
-            return CheckResult(
-                "s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'"
+            return CheckResult.ok(
+                "s3_bucket_versioning", f"Versioning enabled on '{bucket}'"
             )
-        return CheckResult(
-            "s3_bucket_versioning",
-            False,
-            f"Versioning not enabled on '{bucket}'",
+        return CheckResult.fail(
+            "s3_bucket_versioning", f"Versioning not enabled on '{bucket}'"
         )
     except ClientError as e:
-        return CheckResult("s3_bucket_versioning", False, str(e))
+        return CheckResult.fail("s3_bucket_versioning", str(e))
 
 
 def check_path_empty(s3_uri: str) -> CheckResult:
@@ -142,14 +139,13 @@ def check_path_empty(s3_uri: str) -> CheckResult:
             .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         )
         if resp.get("KeyCount", 0) == 0:
-            return CheckResult("s3_path_empty", True, f"Path '{s3_uri}' is empty")
-        return CheckResult(
+            return CheckResult.ok("s3_path_empty", f"Path '{s3_uri}' is empty")
+        return CheckResult.fail(
             "s3_path_empty",
-            False,
             f"Path '{s3_uri}' is not empty — leftover files may cause issues",
         )
     except ClientError as e:
-        return CheckResult("s3_path_empty", False, str(e))
+        return CheckResult.fail("s3_path_empty", str(e))
 
 
 # --- Athena checks ---
@@ -163,19 +159,16 @@ def check_athena_database(
         ClientFactory.default().athena().get_database(
             CatalogName=catalog, DatabaseName=database
         )
-        return CheckResult(
-            "athena_database",
-            True,
-            f"Database '{database}' found in catalog '{catalog}'",
+        return CheckResult.ok(
+            "athena_database", f"Database '{database}' found in catalog '{catalog}'"
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult(
+            return CheckResult.fail(
                 "athena_database",
-                False,
                 f"Database '{database}' not found in catalog '{catalog}'",
             )
-        return CheckResult("athena_database", False, str(e))
+        return CheckResult.fail("athena_database", str(e))
 
 
 def check_athena_table(
@@ -192,17 +185,16 @@ def check_athena_table(
         )
         columns = resp["TableMetadata"].get("Columns", [])
         col_names = [c["Name"] for c in columns]
-        return CheckResult(
+        return CheckResult.ok(
             "athena_table",
-            True,
             f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult(
-                "athena_table", False, f"Table '{table}' not found in '{database}'"
+            return CheckResult.fail(
+                "athena_table", f"Table '{table}' not found in '{database}'"
             )
-        return CheckResult("athena_table", False, str(e))
+        return CheckResult.fail("athena_table", str(e))
 
 
 def check_athena_query(
@@ -244,27 +236,25 @@ def check_athena_query(
                     reason = resp["QueryExecution"]["Status"].get(
                         "StateChangeReason", "Unknown error"
                     )
-                    return CheckResult(
-                        "athena_query", False, f"Query {i+1} failed: {reason}"
+                    return CheckResult.fail(
+                        "athena_query", f"Query {i+1} failed: {reason}"
                     )
                 time.sleep(1)
 
         for i, columns in enumerate(all_columns):
             if "~id" not in columns:
-                return CheckResult(
+                return CheckResult.fail(
                     "athena_query",
-                    False,
                     f"Query {i+1} missing required '~id' column. Got: {', '.join(columns)}",
                 )
 
         combined = [c for cols in all_columns for c in cols]
-        return CheckResult(
+        return CheckResult.ok(
             "athena_query",
-            True,
             f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}",
         )
     except ClientError as e:
-        return CheckResult("athena_query", False, str(e))
+        return CheckResult.fail("athena_query", str(e))
 
 
 # --- Neptune Analytics checks ---
@@ -276,16 +266,15 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
         resp = ClientFactory.default().neptune().list_graphs()
         for g in resp.get("graphs", []):
             if g["name"] == graph_name:
-                return CheckResult(
+                return CheckResult.fail(
                     "graph_name_available",
-                    False,
                     f"Graph '{g['name']}' ({g['id']}) already exists",
                 )
-        return CheckResult(
-            "graph_name_available", True, f"No existing graph named '{graph_name}'"
+        return CheckResult.ok(
+            "graph_name_available", f"No existing graph named '{graph_name}'"
         )
     except ClientError as e:
-        return CheckResult("graph_name_available", False, str(e))
+        return CheckResult.fail("graph_name_available", str(e))
 
 
 # --- Credentials check ---
@@ -295,9 +284,9 @@ def check_credentials() -> CheckResult:
     """Check that AWS credentials are valid."""
     try:
         identity = ClientFactory.default().sts().get_caller_identity()
-        return CheckResult("credentials", True, f"Resolved as {identity['Arn']}")
+        return CheckResult.ok("credentials", f"Resolved as {identity['Arn']}")
     except Exception as e:
-        return CheckResult("credentials", False, f"Cannot resolve credentials: {e}")
+        return CheckResult.fail("credentials", f"Cannot resolve credentials: {e}")
 
 
 # --- Orchestrator ---

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -81,10 +81,14 @@ class TestCheckBucketEncryption:
     def test_kms_encrypted(self, mock_factory):
         mock_factory.s3.return_value.get_bucket_encryption.return_value = {
             "ServerSideEncryptionConfiguration": {
-                "Rules": [{"ApplyServerSideEncryptionByDefault": {
-                    "SSEAlgorithm": "aws:kms",
-                    "KMSMasterKeyID": "arn:aws:kms:us-west-2:123:key/abc",
-                }}]
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                            "KMSMasterKeyID": "arn:aws:kms:us-west-2:123:key/abc",
+                        }
+                    }
+                ]
             }
         }
         result = check_bucket_encryption("s3://my-bucket/")
@@ -94,7 +98,9 @@ class TestCheckBucketEncryption:
     def test_no_kms(self, mock_factory):
         mock_factory.s3.return_value.get_bucket_encryption.return_value = {
             "ServerSideEncryptionConfiguration": {
-                "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+                "Rules": [
+                    {"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
+                ]
             }
         }
         result = check_bucket_encryption("s3://my-bucket/")
@@ -103,7 +109,9 @@ class TestCheckBucketEncryption:
 
 class TestCheckBucketVersioning:
     def test_versioning_enabled(self, mock_factory):
-        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {
+            "Status": "Enabled"
+        }
         result = check_bucket_versioning("s3://my-bucket/")
         assert result.passed is True
 
@@ -128,7 +136,7 @@ class TestCheckPathEmpty:
 class TestCheckAthenaDatabase:
     def test_database_exists(self, mock_factory):
         mock_factory.athena.return_value.get_database.return_value = {}
-        result = check_athena_database("AwsDataCatalog", "mydb")
+        result = check_athena_database("mydb")
         assert result.passed is True
 
     def test_database_not_found(self, mock_factory):
@@ -136,7 +144,7 @@ class TestCheckAthenaDatabase:
             {"Error": {"Code": "EntityNotFoundException", "Message": "not found"}},
             "GetDatabase",
         )
-        result = check_athena_database("AwsDataCatalog", "missing")
+        result = check_athena_database("missing")
         assert result.passed is False
 
 
@@ -145,7 +153,7 @@ class TestCheckAthenaTable:
         mock_factory.athena.return_value.get_table_metadata.return_value = {
             "TableMetadata": {"Columns": [{"Name": "~id"}, {"Name": "name"}]}
         }
-        result = check_athena_table("AwsDataCatalog", "mydb", "mytable")
+        result = check_athena_table("mydb", "mytable")
         assert result.passed is True
         assert "2 columns" in result.message
 
@@ -158,7 +166,7 @@ class TestCheckGraphNameAvailable:
 
     def test_name_taken(self, mock_factory):
         mock_factory.neptune.return_value.list_graphs.return_value = {
-            "graphs": [{"name": "my-graph-123", "id": "g-abc"}]
+            "graphs": [{"name": "my-graph", "id": "g-abc"}]
         }
         result = check_graph_name_available("my-graph")
         assert result.passed is False
@@ -174,22 +182,30 @@ class TestCheckCredentials:
         assert result.passed is True
 
     def test_invalid_credentials(self, mock_factory):
-        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("expired")
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception(
+            "expired"
+        )
         result = check_credentials()
         assert result.passed is False
 
 
 class TestValidateResources:
     def test_credentials_fail_short_circuits(self, mock_factory):
-        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("no creds")
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception(
+            "no creds"
+        )
         results = validate_resources(s3_staging_bucket="s3://bucket/")
         assert len(results) == 1
         assert results[0]["passed"] is False
 
     def test_s3_checks_run(self, mock_factory):
-        mock_factory.sts.return_value.get_caller_identity.return_value = {"Arn": "arn:aws:iam::123:user/dev"}
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
         mock_factory.s3.return_value.head_bucket.return_value = {}
-        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {
+            "Status": "Enabled"
+        }
         results = validate_resources(s3_staging_bucket="s3://bucket/")
         checks = [r["check"] for r in results]
         assert "credentials" in checks

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -55,23 +55,23 @@ class TestCheckBucketExists:
 
 class TestCheckBucketRegion:
     def test_correct_region(self, mock_factory):
-        mock_factory.s3.return_value.get_bucket_location.return_value = {
-            "LocationConstraint": "us-west-2"
+        mock_factory.s3.return_value.head_bucket.return_value = {
+            "BucketRegion": "us-west-2"
         }
         result = check_bucket_region("s3://my-bucket/", "us-west-2")
         assert result.passed is True
 
     def test_wrong_region(self, mock_factory):
-        mock_factory.s3.return_value.get_bucket_location.return_value = {
-            "LocationConstraint": "eu-west-1"
+        mock_factory.s3.return_value.head_bucket.return_value = {
+            "BucketRegion": "eu-west-1"
         }
         result = check_bucket_region("s3://my-bucket/", "us-west-2")
         assert result.passed is False
         assert "eu-west-1" in result.message
 
-    def test_us_east_1_null(self, mock_factory):
-        mock_factory.s3.return_value.get_bucket_location.return_value = {
-            "LocationConstraint": None
+    def test_us_east_1(self, mock_factory):
+        mock_factory.s3.return_value.head_bucket.return_value = {
+            "BucketRegion": "us-east-1"
         }
         result = check_bucket_region("s3://my-bucket/", "us-east-1")
         assert result.passed is True
@@ -238,9 +238,8 @@ class TestValidateResources:
         mock_factory.sts.return_value.get_caller_identity.return_value = {
             "Arn": "arn:aws:iam::123:user/dev"
         }
-        mock_factory.s3.return_value.head_bucket.return_value = {}
-        mock_factory.s3.return_value.get_bucket_location.return_value = {
-            "LocationConstraint": "us-west-2"
+        mock_factory.s3.return_value.head_bucket.return_value = {
+            "BucketRegion": "us-west-2"
         }
         mock_factory.s3.return_value.get_bucket_versioning.return_value = {
             "Status": "Enabled"

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -1,0 +1,197 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from nx_neptune.validators import (
+    CheckResult,
+    check_athena_database,
+    check_athena_table,
+    check_bucket_encryption,
+    check_bucket_exists,
+    check_bucket_region,
+    check_bucket_versioning,
+    check_credentials,
+    check_graph_name_available,
+    check_path_empty,
+    validate_resources,
+)
+
+
+@pytest.fixture
+def mock_factory():
+    with patch("nx_neptune.validators.ClientFactory") as mock_cls:
+        factory = MagicMock()
+        mock_cls.default.return_value = factory
+        yield factory
+
+
+class TestCheckBucketExists:
+    def test_bucket_exists(self, mock_factory):
+        mock_factory.s3.return_value.head_bucket.return_value = {}
+        result = check_bucket_exists("s3://my-bucket/path/")
+        assert result.passed is True
+        assert "my-bucket" in result.message
+
+    def test_bucket_not_found(self, mock_factory):
+        mock_factory.s3.return_value.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadBucket"
+        )
+        result = check_bucket_exists("s3://missing-bucket/")
+        assert result.passed is False
+        assert "not found" in result.message
+
+    def test_bucket_access_denied(self, mock_factory):
+        mock_factory.s3.return_value.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "403"}}, "HeadBucket"
+        )
+        result = check_bucket_exists("s3://private-bucket/")
+        assert result.passed is False
+        assert "Access denied" in result.message
+
+
+class TestCheckBucketRegion:
+    def test_correct_region(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": "us-west-2"
+        }
+        result = check_bucket_region("s3://my-bucket/", "us-west-2")
+        assert result.passed is True
+
+    def test_wrong_region(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": "eu-west-1"
+        }
+        result = check_bucket_region("s3://my-bucket/", "us-west-2")
+        assert result.passed is False
+        assert "eu-west-1" in result.message
+
+    def test_us_east_1_null(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": None
+        }
+        result = check_bucket_region("s3://my-bucket/", "us-east-1")
+        assert result.passed is True
+
+
+class TestCheckBucketEncryption:
+    def test_kms_encrypted(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.return_value = {
+            "ServerSideEncryptionConfiguration": {
+                "Rules": [{"ApplyServerSideEncryptionByDefault": {
+                    "SSEAlgorithm": "aws:kms",
+                    "KMSMasterKeyID": "arn:aws:kms:us-west-2:123:key/abc",
+                }}]
+            }
+        }
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is True
+        assert "KMS" in result.message
+
+    def test_no_kms(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.return_value = {
+            "ServerSideEncryptionConfiguration": {
+                "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+            }
+        }
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is False
+
+
+class TestCheckBucketVersioning:
+    def test_versioning_enabled(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        result = check_bucket_versioning("s3://my-bucket/")
+        assert result.passed is True
+
+    def test_versioning_disabled(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {}
+        result = check_bucket_versioning("s3://my-bucket/")
+        assert result.passed is False
+
+
+class TestCheckPathEmpty:
+    def test_path_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 0}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is True
+
+    def test_path_not_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 1}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is False
+
+
+class TestCheckAthenaDatabase:
+    def test_database_exists(self, mock_factory):
+        mock_factory.athena.return_value.get_database.return_value = {}
+        result = check_athena_database("AwsDataCatalog", "mydb")
+        assert result.passed is True
+
+    def test_database_not_found(self, mock_factory):
+        mock_factory.athena.return_value.get_database.side_effect = ClientError(
+            {"Error": {"Code": "EntityNotFoundException", "Message": "not found"}},
+            "GetDatabase",
+        )
+        result = check_athena_database("AwsDataCatalog", "missing")
+        assert result.passed is False
+
+
+class TestCheckAthenaTable:
+    def test_table_exists(self, mock_factory):
+        mock_factory.athena.return_value.get_table_metadata.return_value = {
+            "TableMetadata": {"Columns": [{"Name": "~id"}, {"Name": "name"}]}
+        }
+        result = check_athena_table("AwsDataCatalog", "mydb", "mytable")
+        assert result.passed is True
+        assert "2 columns" in result.message
+
+
+class TestCheckGraphNameAvailable:
+    def test_name_available(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {"graphs": []}
+        result = check_graph_name_available("my-graph")
+        assert result.passed is True
+
+    def test_name_taken(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {
+            "graphs": [{"name": "my-graph-123", "id": "g-abc"}]
+        }
+        result = check_graph_name_available("my-graph")
+        assert result.passed is False
+        assert "already exists" in result.message
+
+
+class TestCheckCredentials:
+    def test_valid_credentials(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        result = check_credentials()
+        assert result.passed is True
+
+    def test_invalid_credentials(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("expired")
+        result = check_credentials()
+        assert result.passed is False
+
+
+class TestValidateResources:
+    def test_credentials_fail_short_circuits(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("no creds")
+        results = validate_resources(s3_staging_bucket="s3://bucket/")
+        assert len(results) == 1
+        assert results[0]["passed"] is False
+
+    def test_s3_checks_run(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {"Arn": "arn:aws:iam::123:user/dev"}
+        mock_factory.s3.return_value.head_bucket.return_value = {}
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        results = validate_resources(s3_staging_bucket="s3://bucket/")
+        checks = [r["check"] for r in results]
+        assert "credentials" in checks
+        assert "s3_bucket_exists" in checks
+        assert "s3_bucket_versioning" in checks

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -211,3 +211,177 @@ class TestValidateResources:
         assert "credentials" in checks
         assert "s3_bucket_exists" in checks
         assert "s3_bucket_versioning" in checks
+
+    def test_athena_checks_run(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        mock_factory.athena.return_value.get_database.return_value = {}
+        mock_factory.athena.return_value.get_table_metadata.return_value = {
+            "TableMetadata": {"Columns": [{"Name": "~id"}]}
+        }
+        results = validate_resources(athena_database="mydb", athena_table="mytable")
+        checks = [r["check"] for r in results]
+        assert "athena_database" in checks
+        assert "athena_table" in checks
+
+    def test_graph_name_check_runs(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        mock_factory.neptune.return_value.list_graphs.return_value = {"graphs": []}
+        results = validate_resources(graph_name="my-graph")
+        checks = [r["check"] for r in results]
+        assert "graph_name_available" in checks
+
+    def test_region_check_runs(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        mock_factory.s3.return_value.head_bucket.return_value = {}
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": "us-west-2"
+        }
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {
+            "Status": "Enabled"
+        }
+        results = validate_resources(
+            s3_staging_bucket="s3://bucket/", expected_region="us-west-2"
+        )
+        checks = [r["check"] for r in results]
+        assert "s3_bucket_region" in checks
+
+
+class TestCheckBucketEncryptionErrors:
+    def test_no_encryption_configured(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ServerSideEncryptionConfigurationNotFoundError",
+                    "Message": "",
+                }
+            },
+            "GetBucketEncryption",
+        )
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is False
+        assert "No encryption configured" in result.message
+
+    def test_unexpected_error(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "Internal"}}, "GetBucketEncryption"
+        )
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is False
+
+
+class TestCheckPathEmpty:
+    def test_path_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 0}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is True
+
+    def test_path_not_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 1}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is False
+
+    def test_error(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchBucket", "Message": ""}}, "ListObjectsV2"
+        )
+        result = check_path_empty("s3://missing/path/")
+        assert result.passed is False
+
+
+class TestCheckAthenaTableErrors:
+    def test_table_not_found(self, mock_factory):
+        mock_factory.athena.return_value.get_table_metadata.side_effect = ClientError(
+            {"Error": {"Code": "EntityNotFoundException", "Message": "not found"}},
+            "GetTableMetadata",
+        )
+        from nx_neptune.validators import check_athena_table
+
+        result = check_athena_table("mydb", "missing")
+        assert result.passed is False
+        assert "not found" in result.message
+
+
+class TestCheckAthenaQuery:
+    @patch("nx_neptune.validators.wait_until_all_complete")
+    def test_query_succeeds(self, mock_wait, mock_factory):
+        athena = mock_factory.athena.return_value
+        athena.start_query_execution.return_value = {"QueryExecutionId": "qid-1"}
+        mock_wait.return_value = None
+        athena.get_query_execution.return_value = {
+            "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
+        }
+        athena.get_query_results.return_value = {
+            "ResultSet": {
+                "ResultSetMetadata": {"ColumnInfo": [{"Name": "~id"}, {"Name": "name"}]}
+            }
+        }
+        from nx_neptune.validators import check_athena_query
+
+        result = check_athena_query("SELECT * FROM t", "mydb", "s3://output/")
+        assert result.passed is True
+        assert "1 query" in result.message
+
+    @patch("nx_neptune.validators.wait_until_all_complete")
+    def test_query_fails(self, mock_wait, mock_factory):
+        athena = mock_factory.athena.return_value
+        athena.start_query_execution.return_value = {"QueryExecutionId": "qid-1"}
+        mock_wait.return_value = None
+        athena.get_query_execution.return_value = {
+            "QueryExecution": {
+                "Status": {"State": "FAILED", "StateChangeReason": "Syntax error"}
+            }
+        }
+        from nx_neptune.validators import check_athena_query
+
+        result = check_athena_query("SELECT bad", "mydb", "s3://output/")
+        assert result.passed is False
+        assert "Syntax error" in result.message
+
+    @patch("nx_neptune.validators.wait_until_all_complete")
+    def test_query_missing_id_column(self, mock_wait, mock_factory):
+        athena = mock_factory.athena.return_value
+        athena.start_query_execution.return_value = {"QueryExecutionId": "qid-1"}
+        mock_wait.return_value = None
+        athena.get_query_execution.return_value = {
+            "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
+        }
+        athena.get_query_results.return_value = {
+            "ResultSet": {
+                "ResultSetMetadata": {
+                    "ColumnInfo": [{"Name": "name"}, {"Name": "value"}]
+                }
+            }
+        }
+        from nx_neptune.validators import check_athena_query
+
+        result = check_athena_query("SELECT * FROM t", "mydb", "s3://output/")
+        assert result.passed is False
+        assert "~id" in result.message
+
+
+class TestCheckGraphNameAvailable:
+    def test_name_available(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {"graphs": []}
+        result = check_graph_name_available("my-graph")
+        assert result.passed is True
+
+    def test_name_taken(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {
+            "graphs": [{"name": "my-graph", "id": "g-abc"}]
+        }
+        result = check_graph_name_available("my-graph")
+        assert result.passed is False
+        assert "already exists" in result.message
+
+    def test_error(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "err"}}, "ListGraphs"
+        )
+        result = check_graph_name_available("my-graph")
+        assert result.passed is False


### PR DESCRIPTION
### Summary

Adds upfront resource validation so configuration errors surface immediately — not minutes into a pipeline. Introduces `response_utils.py` as the shared translation layer between raw boto3 responses and typed Python values.


### Architectural context

This PR establishes a layered separation of concerns for the project. `response_utils.py` sits at the infrastructure layer — it owns all boto3 response parsing so that higher-level modules never dig into nested dicts or match error strings directly. `validators.py` sits at the operations layer — it makes API calls, then delegates interpretation to `response_utils` to get definitive answers.

This pattern is designed to scale: as we add more checks or refactor `instance_management`, the same response interpreters and error classifiers are reusable without duplication. New contributors can add a validation check by composing existing building blocks (factory for clients, response_utils for interpretation, CheckResult for output) without understanding boto3 response structures.

### New files

| File | Purpose |
|------|---------|
| `nx_neptune/clients/response_utils.py` | Pure functions: dict in → typed answer out. Response interpreters + error classifiers. |
| `nx_neptune/validators.py` | Resource validation checks using `ClientFactory.default()` and `response_utils` |
| `tests/clients/test_validators.py` | 32 tests, 92% coverage |

### Public API

```python
# Individual checks — return CheckResult
check_bucket_exists("s3://my-bucket/")
check_bucket_region("s3://my-bucket/", "us-west-2")
check_bucket_encryption("s3://my-bucket/")
check_bucket_versioning("s3://my-bucket/")
check_path_empty("s3://my-bucket/output/")
check_athena_database("mydb")
check_athena_table("mydb", "mytable")
check_athena_query("SELECT ...", "mydb", "s3://output/")
check_graph_name_available("my-graph")
check_credentials()

# Orchestrator — returns list[dict]
validate_resources(s3_staging_bucket="s3://...", graph_name="my-graph")
```

### Design

- `response_utils` — stateless module-level functions, no classes. Reusable by `instance_management` and `session_manager` (backlog).
- `CheckResult.ok()` / `.fail()` — concise constructors for pass/fail results
- Error classifiers: `is_not_found`, `is_access_denied`, `is_entity_not_found` — reusable across any check
- Athena query validation uses `wait_until_all_complete` from `task_future` via `asyncio.run()` — no duplicated polling
- All clients from `ClientFactory.default()` — shared cache, single region

### Testing

- 32 validator tests, 92% coverage
- 380 total tests pass, mypy clean