### PR TITLE
Misc: New make target `lock-and-tes` and py deps bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ lock-check:       ## Verify lock files are in sync with pyproject.toml (used by 
 	$(ENV_PREFIX)pip-compile pyproject.toml -o requirements.txt --strip-extras
 	$(ENV_PREFIX)pip-compile pyproject.toml --extra test --extra developer -o requirements-dev.txt --strip-extras
 
+.PHONY: lock-and-test
+lock-and-test:    ## Regenerate lock files, install deps, and run tests.
+	$(MAKE) lock
+	$(ENV_PREFIX)pip install -r requirements-dev.txt
+	$(MAKE) test
+
 
 .PHONY: dist
 dist: ## install the distribution

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --extra=developer --extra=test --output-file=requirements-dev.txt --strip-extras pyproject.toml
 #
-ast-serialize==0.3.0
+ast-serialize==0.5.0
     # via mypy
-black==26.3.1
+black==26.5.1
     # via nx-neptune (pyproject.toml)
-boto3==1.43.6
+boto3==1.43.11
     # via nx-neptune (pyproject.toml)
-botocore==1.43.6
+botocore==1.43.11
     # via
     #   boto3
     #   s3transfer
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   opensearch-py
     #   requests
@@ -22,7 +22,7 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.7
     # via requests
-click==8.3.3
+click==8.4.0
     # via black
 coverage==7.14.0
     # via pytest-cov
@@ -46,7 +46,7 @@ grpcio==1.80.0
     # via opensearch-protobufs
 identify==2.6.19
     # via pre-commit
-idna==3.14
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
@@ -70,7 +70,7 @@ networkx==3.6.1
     # via nx-neptune (pyproject.toml)
 nodeenv==1.10.0
     # via pre-commit
-numpy==2.4.4
+numpy==2.4.6
     # via
     #   nx-neptune (pyproject.toml)
     #   pandas
@@ -83,7 +83,7 @@ packaging==26.2
     # via
     #   black
     #   pytest
-pandas==3.0.2
+pandas==3.0.3
     # via nx-neptune (pyproject.toml)
 pathspec==1.1.1
     # via
@@ -104,7 +104,7 @@ pre-commit==4.5.1
     # via nx-neptune (pyproject.toml)
 prettytable==3.17.0
     # via pip-licenses
-protobuf==7.34.1
+protobuf==7.35.0
     # via opensearch-protobufs
 pycodestyle==2.14.0
     # via flake8
@@ -129,7 +129,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   opensearch-py
     #   pandas
-python-discovery==1.3.0
+python-discovery==1.3.1
     # via virtualenv
 python-dotenv==1.2.2
     # via dotenv
@@ -137,7 +137,7 @@ pytokens==0.4.1
     # via black
 pyyaml==6.0.3
     # via pre-commit
-requests==2.33.1
+requests==2.34.2
     # via opensearch-py
 s3transfer==0.17.0
     # via boto3
@@ -145,7 +145,7 @@ scipy==1.17.1
     # via nx-neptune (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-sqlglot==30.7.0
+sqlglot==30.8.0
     # via nx-neptune (pyproject.toml)
 typing-extensions==4.15.0
     # via
@@ -157,7 +157,7 @@ urllib3==2.7.0
     #   botocore
     #   opensearch-py
     #   requests
-virtualenv==21.3.1
+virtualenv==21.3.3
     # via pre-commit
 wcwidth==0.7.0
     # via prettytable

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras pyproject.toml
 #
-boto3==1.43.6
+boto3==1.43.11
     # via nx-neptune (pyproject.toml)
-botocore==1.43.6
+botocore==1.43.11
     # via
     #   boto3
     #   s3transfer
@@ -24,7 +24,7 @@ s3transfer==0.17.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-sqlglot==30.7.0
+sqlglot==30.8.0
     # via nx-neptune (pyproject.toml)
 urllib3==2.7.0
     # via botocore


### PR DESCRIPTION
### Summary :memo:
Introduced a new `make` target to streamline the testing of Python deps bump. 

Related: 
https://github.com/awslabs/nx-neptune/pull/236
https://github.com/awslabs/nx-neptune/pull/234
https://github.com/awslabs/nx-neptune/pull/232
https://github.com/awslabs/nx-neptune/pull/231
https://github.com/awslabs/nx-neptune/pull/226


### Test plan:



### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
