### PR TITLE
Feat: ClientFactory adoption - pt2

### DIFF
--- a/nx_neptune/clients/client_factory.py
+++ b/nx_neptune/clients/client_factory.py
@@ -34,8 +34,8 @@ class ClientFactory:
     Ensures consistent configuration (user agent, timeouts, region) across
     all AWS service clients used by the library.
 
-    Use ``ClientFactory.default()`` for a shared singleton, or create an
-    instance for custom configuration.
+    When called with no arguments, returns a shared singleton instance.
+    When called with custom configuration, creates a new instance.
 
     Args:
         region: AWS region name. If None, uses boto3 default.
@@ -45,21 +45,29 @@ class ClientFactory:
 
     _default: Optional["ClientFactory"] = None
 
-    @classmethod
-    def default(cls) -> "ClientFactory":
-        """Return the shared default factory (lazy-initialized)."""
-        if cls._default is None:
-            cls._default = cls()
-        return cls._default
+    def __new__(
+        cls,
+        region: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+    ):
+        if region is None and timeout_seconds is None:
+            if cls._default is None:
+                cls._default = super().__new__(cls)
+                cls._default._initialized = False
+            return cls._default
+        return super().__new__(cls)
 
     def __init__(
         self,
         region: Optional[str] = None,
         timeout_seconds: Optional[int] = None,
     ):
+        if getattr(self, "_initialized", False):
+            return
         self._region = region
         self._timeout_seconds = timeout_seconds
         self._clients: dict[str, BaseClient] = {}
+        self._initialized = True
 
     def _base_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}

--- a/nx_neptune/clients/client_factory.py
+++ b/nx_neptune/clients/client_factory.py
@@ -53,7 +53,6 @@ class ClientFactory:
         if region is None and timeout_seconds is None:
             if cls._default is None:
                 cls._default = super().__new__(cls)
-                cls._default._initialized = False
             return cls._default
         return super().__new__(cls)
 
@@ -62,12 +61,11 @@ class ClientFactory:
         region: Optional[str] = None,
         timeout_seconds: Optional[int] = None,
     ):
-        if getattr(self, "_initialized", False):
+        if hasattr(self, "_clients"):
             return
         self._region = region
         self._timeout_seconds = timeout_seconds
         self._clients: dict[str, BaseClient] = {}
-        self._initialized = True
 
     def _base_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}

--- a/nx_neptune/clients/client_factory.py
+++ b/nx_neptune/clients/client_factory.py
@@ -34,7 +34,7 @@ class ClientFactory:
     Ensures consistent configuration (user agent, timeouts, region) across
     all AWS service clients used by the library.
 
-    When called with no arguments, returns a shared singleton instance.
+    When called with no arguments, returns the shared singleton default instance.
     When called with custom configuration, creates a new instance.
 
     Args:

--- a/nx_neptune/clients/iam_client.py
+++ b/nx_neptune/clients/iam_client.py
@@ -200,7 +200,7 @@ class IamClientWrapper:
             ValueError: If versioning is not enabled or status cannot be determined
         """
         if s3_client is None:
-            s3_client = ClientFactory.default().s3()
+            s3_client = ClientFactory().s3()
         bucket_name, _ = split_s3_arn_to_bucket_and_path(bucket_arn)
         try:
             response = s3_client.get_bucket_versioning(Bucket=bucket_name)

--- a/nx_neptune/clients/iam_client.py
+++ b/nx_neptune/clients/iam_client.py
@@ -13,7 +13,6 @@
 import logging
 from typing import Optional, Union
 
-import boto3
 import jmespath
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
@@ -21,6 +20,7 @@ from botocore.utils import ArnParser
 
 __all__ = ["IamClientWrapper", "split_s3_arn_to_bucket_and_path"]
 
+from .client_factory import ClientFactory
 from .neptune_constants import SERVICE_NA
 
 
@@ -200,7 +200,7 @@ class IamClientWrapper:
             ValueError: If versioning is not enabled or status cannot be determined
         """
         if s3_client is None:
-            s3_client = boto3.client("s3")
+            s3_client = ClientFactory.default().s3()
         bucket_name, _ = split_s3_arn_to_bucket_and_path(bucket_arn)
         try:
             response = s3_client.get_bucket_versioning(Bucket=bucket_name)

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -60,7 +60,7 @@ class NeptuneAnalyticsClient:
         elif timeout_seconds:
             self.client = ClientFactory(timeout_seconds=timeout_seconds).neptune()
         else:
-            self.client = ClientFactory.default().neptune()
+            self.client = ClientFactory().neptune()
         self.logger = logger or logging.getLogger(__name__)
         self.name = name or ""
         self.status = status or ""

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -20,6 +20,7 @@ from botocore.config import Config
 
 from .client_factory import ClientFactory
 from .neptune_constants import APP_ID_NX, SERVICE_NA
+from .client_factory import ClientFactory
 
 
 class NeptuneAnalyticsClient:

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -57,10 +57,8 @@ class NeptuneAnalyticsClient:
         self.graph_id = graph_id
         if client:
             self.client = client
-        elif timeout_seconds:
-            self.client = ClientFactory(timeout_seconds=timeout_seconds).neptune()
         else:
-            self.client = ClientFactory().neptune()
+            self.client = ClientFactory(timeout_seconds=timeout_seconds).neptune()
         self.logger = logger or logging.getLogger(__name__)
         self.name = name or ""
         self.status = status or ""

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -20,7 +20,6 @@ from botocore.config import Config
 
 from .client_factory import ClientFactory
 from .neptune_constants import APP_ID_NX, SERVICE_NA
-from .client_factory import ClientFactory
 
 
 class NeptuneAnalyticsClient:

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -58,8 +58,10 @@ class NeptuneAnalyticsClient:
         self.graph_id = graph_id
         if client:
             self.client = client
-        else:
+        elif timeout_seconds:
             self.client = ClientFactory(timeout_seconds=timeout_seconds).neptune()
+        else:
+            self.client = ClientFactory.default().neptune()
         self.logger = logger or logging.getLogger(__name__)
         self.name = name or ""
         self.status = status or ""

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -96,7 +96,7 @@ async def create_na_instance(
         Exception: If the Neptune Analytics instance creation fails
     """
     _create_iam_wrapper(sts_client, iam_client).has_create_na_permissions()
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
 
     response = _create_na_instance_task(na_client, config, graph_name_prefix)
     prospective_graph_id = _get_graph_id(response)
@@ -165,7 +165,7 @@ async def create_na_instance_with_s3_import(
 
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
 
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
     # Retrieve key_arn for the bucket and permission check if present
     key_arn = _get_bucket_encryption_key_arn(s3_arn)
     # Permission checks
@@ -239,7 +239,7 @@ async def create_na_instance_from_snapshot(
         ValueError: If the role lacks required permissions
     """
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
 
     # Permissions check
     iam_client_wrapper.has_create_na_from_snapshot_permissions()
@@ -294,7 +294,7 @@ async def delete_graph_snapshot(
         ValueError: If the role lacks required permissions
     """
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
 
     # Permissions check
     iam_client_wrapper.has_delete_snapshot_permissions()
@@ -346,7 +346,7 @@ async def start_na_instance(
         ValueError: If the role lacks required permissions or if graph is not in STOPPED state
     """
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
     iam_client_wrapper.has_start_na_permissions()
 
     if status_exception := _graph_status_check(na_client, graph_id, "STOPPED"):
@@ -393,7 +393,7 @@ async def stop_na_instance(
         ValueError: If the role lacks required permissions or if graph is not in AVAILABLE state
     """
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
     iam_client_wrapper.has_stop_na_permissions()
 
     if status_exception := _graph_status_check(na_client, graph_id, "AVAILABLE"):
@@ -443,7 +443,7 @@ async def delete_na_instance(
     # Permission check
     _create_iam_wrapper(sts_client, iam_client).has_delete_na_permissions()
 
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
 
     response = _delete_na_instance_task(na_client, graph_id)
     status_code = _get_status_code(response)
@@ -491,7 +491,7 @@ async def create_graph_snapshot(
     """
     # Permission check
     _create_iam_wrapper(sts_client, iam_client).has_create_na_snapshot_permissions()
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
 
     kwargs: dict[str, Any] = {
         "graphIdentifier": graph_id,
@@ -645,7 +645,7 @@ async def reset_graph(
         Exception: If an invalid status code is returned
     """
     if na_client is None:
-        na_client = ClientFactory.default().neptune()
+        na_client = ClientFactory().neptune()
 
     logger.info(
         f"Perform reset_graph action on graph: [{graph_id}] with skip_snapshot: [{skip_snapshot}]"
@@ -692,7 +692,7 @@ async def update_na_instance_size(
         Exception: If the resize operation fails
         ValueError: If the role lacks required permissions
     """
-    na_client = na_client or ClientFactory.default().neptune()
+    na_client = na_client or ClientFactory().neptune()
 
     # Permission check
     _create_iam_wrapper(sts_client, iam_client).has_update_na_permissions()
@@ -976,7 +976,7 @@ def _get_bucket_encryption_key_arn(s3_arn):
     """
     try:
         # Create an S3 client
-        s3_client = ClientFactory.default().s3()
+        s3_client = ClientFactory().s3()
 
         # Get the bucket encryption configuration
         bucket_name = _clean_s3_path(s3_arn)
@@ -1101,7 +1101,7 @@ async def export_athena_table_to_s3(
         list: List of successfully processed query execute ids.
     """
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    athena_client = athena_client or ClientFactory.default().athena()
+    athena_client = athena_client or ClientFactory().athena()
 
     # Get KMS key if bucket is encrypted
     key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1121,7 +1121,7 @@ async def export_athena_table_to_s3(
         query_execution_ids.append(query_execution_id)
 
     # Wait on all query execution IDs
-    s3_client = s3_client or ClientFactory.default().s3()
+    s3_client = s3_client or ClientFactory().s3()
     bucket_name, bucket_prefix = split_s3_arn_to_bucket_and_path(s3_bucket)
 
     await wait_until_all_complete(
@@ -1188,7 +1188,7 @@ async def create_csv_table_from_s3(
     """
     # Permission checks
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    athena_client = athena_client or ClientFactory.default().athena()
+    athena_client = athena_client or ClientFactory().athena()
 
     # Get KMS keys if buckets are encrypted
     s3_key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1199,7 +1199,7 @@ async def create_csv_table_from_s3(
     iam_client_wrapper.has_athena_permissions(s3_output_bucket, output_key_arn)
 
     # Wait on all query execution IDs
-    s3_client = s3_client or ClientFactory.default().s3()
+    s3_client = s3_client or ClientFactory().s3()
     bucket_name, bucket_prefix = split_s3_arn_to_bucket_and_path(s3_bucket)
 
     logger.debug(f"Inspecting files from {s3_bucket}")
@@ -1373,7 +1373,7 @@ async def create_iceberg_table_from_table(
     """
     # Permission checks
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    athena_client = athena_client or ClientFactory.default().athena()
+    athena_client = athena_client or ClientFactory().athena()
 
     # Get KMS key if output bucket is encrypted
     output_key_arn = _get_bucket_encryption_key_arn(s3_output_bucket)
@@ -1453,7 +1453,7 @@ async def create_table_schema_from_s3(
     """
     # Permission checks
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    athena_client = athena_client or ClientFactory.default().athena()
+    athena_client = athena_client or ClientFactory().athena()
 
     # Get KMS key if bucket is encrypted
     key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1512,7 +1512,7 @@ async def drop_athena_table(
     """
     # Permission checks
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
-    athena_client = athena_client or ClientFactory.default().athena()
+    athena_client = athena_client or ClientFactory().athena()
 
     # Get KMS key if bucket is encrypted
     key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1622,7 +1622,7 @@ def empty_s3_bucket(
 
     # Create S3 client if not provided
     if s3_client is None:
-        s3_client = ClientFactory.default().s3()
+        s3_client = ClientFactory().s3()
 
     iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
 
@@ -1671,7 +1671,7 @@ def empty_s3_bucket(
 
 
 def validate_permissions():
-    factory = ClientFactory.default()
+    factory = ClientFactory()
     user_arn = factory.sts().get_caller_identity()["Arn"]
     iam_client_wrapper = IamClientWrapper(role_arn=user_arn, client=factory.iam())
 
@@ -1848,7 +1848,7 @@ def _create_iam_wrapper(
     Returns:
         IamClientWrapper: Wrapper with the caller's role ARN
     """
-    factory = ClientFactory.default()
+    factory = ClientFactory()
     if sts_client is None:
         sts_client = factory.sts()
     user_arn = sts_client.get_caller_identity()["Arn"]
@@ -1892,7 +1892,7 @@ def execute_athena_query(
         Exception: If the query execution fails or times out
     """
     if client is None:
-        client = ClientFactory.default().athena()
+        client = ClientFactory().athena()
     execution_id = _execute_athena_query(
         client, sql_statement, output_location, sql_parameters, catalog, database
     )
@@ -1925,7 +1925,7 @@ def get_athena_query_results(
         are not needed.
     """
     if client is None:
-        client = ClientFactory.default().athena()
+        client = ClientFactory().athena()
 
     rows = []
     try:

--- a/nx_neptune/na_graph.py
+++ b/nx_neptune/na_graph.py
@@ -14,7 +14,6 @@ import logging
 from asyncio import Task
 from typing import Any, List, Optional
 
-import boto3
 import networkx
 from botocore.config import Config
 from networkx import DiGraph, Graph
@@ -102,7 +101,9 @@ class NeptuneGraph:
             config.graph_id,
             logger=logger,
         )
-        iam_client = IamClientWrapper(s3_iam_role, boto3.client(SERVICE_IAM), logger)
+        iam_client = IamClientWrapper(
+            s3_iam_role, ClientFactory.default().iam(), logger
+        )
         return cls(
             graph=graph,
             logger=logger,

--- a/nx_neptune/na_graph.py
+++ b/nx_neptune/na_graph.py
@@ -95,15 +95,13 @@ class NeptuneGraph:
             logger = logging.getLogger(__name__)
         s3_iam_role = config.s3_iam_role
         if s3_iam_role is None:
-            s3_iam_role = ClientFactory.default().sts().get_caller_identity()["Arn"]
+            s3_iam_role = ClientFactory().sts().get_caller_identity()["Arn"]
 
         na_client = NeptuneAnalyticsClient(
             config.graph_id,
             logger=logger,
         )
-        iam_client = IamClientWrapper(
-            s3_iam_role, ClientFactory.default().iam(), logger
-        )
+        iam_client = IamClientWrapper(s3_iam_role, ClientFactory().iam(), logger)
         return cls(
             graph=graph,
             logger=logger,

--- a/nx_neptune/na_graph.py
+++ b/nx_neptune/na_graph.py
@@ -26,9 +26,7 @@ from .clients import (
     PARAM_TRAVERSAL_DIRECTION_BOTH,
     PARAM_TRAVERSAL_DIRECTION_INBOUND,
     PARAM_TRAVERSAL_DIRECTION_OUTBOUND,
-    SERVICE_IAM,
-    SERVICE_NA,
-    SERVICE_STS,
+    ClientFactory,
     Edge,
     IamClientWrapper,
     NeptuneAnalyticsClient,
@@ -98,7 +96,7 @@ class NeptuneGraph:
             logger = logging.getLogger(__name__)
         s3_iam_role = config.s3_iam_role
         if s3_iam_role is None:
-            s3_iam_role = boto3.client(SERVICE_STS).get_caller_identity()["Arn"]
+            s3_iam_role = ClientFactory.default().sts().get_caller_identity()["Arn"]
 
         na_client = NeptuneAnalyticsClient(
             config.graph_id,

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -46,7 +46,7 @@ class SessionManager:
         """
         self.session_name = session_name
         self.cleanup_task = cleanup_task or CleanupTask.NONE
-        self._clients = ClientFactory.default()
+        self._clients = ClientFactory()
         self._neptune_client = self._clients.neptune()
         self._sts_client = self._clients.sts()
         self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -47,7 +47,7 @@ class SessionManager:
         """
         self.session_name = session_name
         self.cleanup_task = cleanup_task or CleanupTask.NONE
-        self._clients = clients or ClientFactory()
+        self._clients = clients or ClientFactory.default()
         self._neptune_client = self._clients.neptune()
         self._sts_client = self._clients.sts()
         self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -34,7 +34,7 @@ class CleanupTask(Enum):
 class SessionManager:
     """Manages Neptune Analytics sessions and graph operations."""
 
-    def __init__(self, session_name=None, cleanup_task=None):
+    def __init__(self, session_name=None, cleanup_task=None, clients=None):
         """Initialize a SessionManager instance.
 
         Args:
@@ -43,10 +43,11 @@ class SessionManager:
               When set to DESTROY, will destroy all instances in the session on exit.
               When set to RESET, will reset all instances in the session on exit.
               When set to STOP, will stop all instances in the session on exit.
+            clients (ClientFactory, optional): Factory for creating boto3 clients. If None, a default is created.
         """
         self.session_name = session_name
         self.cleanup_task = cleanup_task or CleanupTask.NONE
-        self._clients = ClientFactory.default()
+        self._clients = clients or ClientFactory()
         self._neptune_client = self._clients.neptune()
         self._sts_client = self._clients.sts()
         self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -34,7 +34,7 @@ class CleanupTask(Enum):
 class SessionManager:
     """Manages Neptune Analytics sessions and graph operations."""
 
-    def __init__(self, session_name=None, cleanup_task=None, clients=None):
+    def __init__(self, session_name=None, cleanup_task=None):
         """Initialize a SessionManager instance.
 
         Args:
@@ -43,11 +43,10 @@ class SessionManager:
               When set to DESTROY, will destroy all instances in the session on exit.
               When set to RESET, will reset all instances in the session on exit.
               When set to STOP, will stop all instances in the session on exit.
-            clients (ClientFactory, optional): Factory for creating boto3 clients. If None, a default is created.
         """
         self.session_name = session_name
         self.cleanup_task = cleanup_task or CleanupTask.NONE
-        self._clients = clients or ClientFactory.default()
+        self._clients = ClientFactory.default()
         self._neptune_client = self._clients.neptune()
         self._sts_client = self._clients.sts()
         self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -76,7 +76,7 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
     """Check that the S3 bucket exists and is accessible."""
     bucket = _parse_bucket(s3_uri)
     try:
-        ClientFactory.default().s3().head_bucket(Bucket=bucket)
+        ClientFactory().s3().head_bucket(Bucket=bucket)
         return CheckResult.ok("s3_bucket_exists", f"Bucket '{bucket}' exists")
     except ClientError as e:
         if is_not_found(e):
@@ -92,7 +92,7 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     """Check that the bucket is in the expected region."""
     bucket = _parse_bucket(s3_uri)
     try:
-        resp = ClientFactory.default().s3().head_bucket(Bucket=bucket)
+        resp = ClientFactory().s3().head_bucket(Bucket=bucket)
     except ClientError as e:
         return CheckResult.fail("s3_bucket_region", str(e))
 
@@ -111,7 +111,7 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
     """Check that the bucket has KMS encryption configured."""
     bucket = _parse_bucket(s3_uri)
     try:
-        resp = ClientFactory.default().s3().get_bucket_encryption(Bucket=bucket)
+        resp = ClientFactory().s3().get_bucket_encryption(Bucket=bucket)
     except ClientError as e:
         if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
             return CheckResult.fail(
@@ -132,7 +132,7 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
     """Check that the bucket has versioning enabled."""
     bucket = _parse_bucket(s3_uri)
     try:
-        resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
+        resp = ClientFactory().s3().get_bucket_versioning(Bucket=bucket)
     except ClientError as e:
         return CheckResult.fail("s3_bucket_versioning", str(e))
 
@@ -151,7 +151,7 @@ def check_path_empty(s3_uri: str) -> CheckResult:
     prefix = _parse_prefix(s3_uri)
     try:
         resp = (
-            ClientFactory.default()
+            ClientFactory()
             .s3()
             .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         )
@@ -174,7 +174,7 @@ def check_athena_database(
 ) -> CheckResult:
     """Check that the Athena database exists."""
     try:
-        ClientFactory.default().athena().get_database(
+        ClientFactory().athena().get_database(
             CatalogName=catalog, DatabaseName=database
         )
         return CheckResult.ok(
@@ -195,7 +195,7 @@ def check_athena_table(
     """Check that the Athena table exists and return its columns."""
     try:
         resp = (
-            ClientFactory.default()
+            ClientFactory()
             .athena()
             .get_table_metadata(
                 CatalogName=catalog, DatabaseName=database, TableName=table
@@ -223,7 +223,7 @@ def check_athena_query(
     all_columns: list[list[str]] = []
 
     try:
-        athena = ClientFactory.default().athena()
+        athena = ClientFactory().athena()
 
         for i, q in enumerate(queries):
             stripped = re.sub(
@@ -274,7 +274,7 @@ def check_athena_query(
 def check_graph_name_available(graph_name: str) -> CheckResult:
     """Check that no existing graph uses this name."""
     try:
-        resp = ClientFactory.default().neptune().list_graphs()
+        resp = ClientFactory().neptune().list_graphs()
         for g in get_graph_names(resp):
             if g["name"] == graph_name:
                 return CheckResult.fail(
@@ -294,7 +294,7 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
 def check_credentials() -> CheckResult:
     """Check that AWS credentials are valid."""
     try:
-        resp = ClientFactory.default().sts().get_caller_identity()
+        resp = ClientFactory().sts().get_caller_identity()
         return CheckResult.ok("credentials", f"Resolved as {get_caller_arn(resp)}")
     except Exception as e:
         return CheckResult.fail("credentials", f"Cannot resolve credentials: {e}")

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -397,7 +397,7 @@ def test_get_bucket_encryption_key_arn(
     """Test the _get_bucket_encryption_key_arn function with various scenarios."""
     # Mock the S3 client
     mock_s3_client = MagicMock()
-    mock_factory_cls.default.return_value.s3.return_value = mock_s3_client
+    mock_factory_cls.return_value.s3.return_value = mock_s3_client
 
     # Configure the mock response
     mock_s3_client.get_bucket_encryption.return_value = mock_response
@@ -409,7 +409,7 @@ def test_get_bucket_encryption_key_arn(
     assert result == expected_result
 
     # Verify the S3 client was called correctly
-    mock_factory_cls.default.return_value.s3.assert_called_once()
+    mock_factory_cls.return_value.s3.assert_called_once()
     mock_s3_client.get_bucket_encryption.assert_called_once_with(
         Bucket="my-test-bucket"
     )
@@ -420,7 +420,7 @@ def test_get_bucket_encryption_key_arn_with_exception(mock_factory_cls):
     """Test handling of exceptions when retrieving bucket encryption."""
     # Mock the S3 client to raise an exception
     mock_s3_client = MagicMock()
-    mock_factory_cls.default.return_value.s3.return_value = mock_s3_client
+    mock_factory_cls.return_value.s3.return_value = mock_s3_client
     mock_s3_client.get_bucket_encryption.side_effect = Exception(
         "Bucket encryption not configured"
     )
@@ -432,7 +432,7 @@ def test_get_bucket_encryption_key_arn_with_exception(mock_factory_cls):
     assert result is None
 
     # Verify the S3 client was called correctly
-    mock_factory_cls.default.return_value.s3.assert_called_once()
+    mock_factory_cls.return_value.s3.assert_called_once()
     mock_s3_client.get_bucket_encryption.assert_called_once_with(
         Bucket="my-test-bucket"
     )
@@ -1679,7 +1679,7 @@ def test_get_athena_query_results_empty(mock_boto3_client):
 def test_get_athena_query_results_creates_default_client(mock_factory_cls):
     """Test that a default Athena client is created when none is provided."""
     mock_athena_client = MagicMock()
-    mock_factory_cls.default.return_value.athena.return_value = mock_athena_client
+    mock_factory_cls.return_value.athena.return_value = mock_athena_client
     mock_athena_client.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
     }
@@ -1689,4 +1689,4 @@ def test_get_athena_query_results_creates_default_client(mock_factory_cls):
 
     get_athena_query_results("test-query-id")
 
-    mock_factory_cls.default.return_value.athena.assert_called_once()
+    mock_factory_cls.return_value.athena.assert_called_once()

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -25,7 +25,7 @@ from nx_neptune.validators import (
 def mock_factory():
     with patch("nx_neptune.validators.ClientFactory") as mock_cls:
         factory = MagicMock()
-        mock_cls.default.return_value = factory
+        mock_cls.return_value = factory
         yield factory
 
 


### PR DESCRIPTION
### Summary

Completes the `ClientFactory` adoption across all core modules. Every AWS client in the main code path now goes through `ClientFactory.default()`, ensuring consistent region, session, and caching behavior.

### Changes

| File | What changed |
|------|-------------|
| `nx_neptune/clients/na_client.py` | Uses `ClientFactory.default().neptune()` when no custom timeout; only creates a separate factory for custom `timeout_seconds` |
| `nx_neptune/clients/iam_client.py` | Replaced `boto3.client("s3")` fallback with `ClientFactory.default().s3()`, removed `boto3` import |
| `nx_neptune/na_graph.py` | Replaced `boto3.client(SERVICE_STS)` and `boto3.client(SERVICE_IAM)` with `ClientFactory.default()`, removed `boto3` import and unused `SERVICE_*` constants |

### Why

Before this change, `na_client`, `iam_client`, and `na_graph` created their own boto3 clients independently. This meant:
- No shared caching — duplicate clients for the same service
- No region guarantee — each client could resolve to a different default region
- Inconsistent testing — had to mock boto3 in multiple places

Now there's one door in for AWS access. Mock `ClientFactory.default()` once and the entire library uses it.

### Not in scope

`utils/utils.py` still has 3 direct `boto3.client()` calls for experimental services (`bedrock-runtime`, `s3vectors`) not yet in `ClientFactory`. These are utility functions, not core path.

### Testing

- 348 tests pass, mypy clean