### PR TITLE
Misc: `response_utils.py` adoption - pt2

### DIFF
--- a/nx_neptune/clients/__init__.py
+++ b/nx_neptune/clients/__init__.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 # clients
+from .client_factory import ClientFactory
 from .iam_client import IamClient
 from .na_client import NeptuneAnalyticsClient
 from .na_models import Edge, Node

--- a/nx_neptune/clients/client_factory.py
+++ b/nx_neptune/clients/client_factory.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from typing import Any, Optional
+
+import boto3
+from botocore.client import BaseClient
+from botocore.config import Config
+
+from .neptune_constants import (
+    APP_ID_NX,
+    SERVICE_ATHENA,
+    SERVICE_IAM,
+    SERVICE_NA,
+    SERVICE_S3,
+    SERVICE_STS,
+)
+
+__all__ = ["ClientFactory"]
+
+
+class ClientFactory:
+    """Centralized factory for creating and caching boto3 clients.
+
+    Ensures consistent configuration (user agent, timeouts, region) across
+    all AWS service clients used by the library.
+
+    Args:
+        region: AWS region name. If None, uses boto3 default.
+        timeout_seconds: Read timeout for long-running operations (e.g., queries).
+            Applied to the Neptune Analytics client.
+    """
+
+    def __init__(
+        self,
+        region: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+    ):
+        self._region = region
+        self._timeout_seconds = timeout_seconds
+        self._clients: dict[str, BaseClient] = {}
+
+    def _base_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        if self._region:
+            kwargs["region_name"] = self._region
+        return kwargs
+
+    def _na_config(self) -> Config:
+        config_kwargs: dict[str, Any] = {"user_agent_appid": APP_ID_NX}
+        if self._timeout_seconds:
+            config_kwargs["read_timeout"] = self._timeout_seconds
+        return Config(**config_kwargs)
+
+    def neptune(self) -> BaseClient:
+        """Get or create the Neptune Analytics client."""
+        if SERVICE_NA not in self._clients:
+            self._clients[SERVICE_NA] = boto3.client(
+                service_name=SERVICE_NA, config=self._na_config(), **self._base_kwargs()
+            )
+        return self._clients[SERVICE_NA]
+
+    def s3(self) -> BaseClient:
+        """Get or create the S3 client."""
+        if SERVICE_S3 not in self._clients:
+            self._clients[SERVICE_S3] = boto3.client(
+                service_name=SERVICE_S3, **self._base_kwargs()
+            )
+        return self._clients[SERVICE_S3]
+
+    def athena(self) -> BaseClient:
+        """Get or create the Athena client."""
+        if SERVICE_ATHENA not in self._clients:
+            self._clients[SERVICE_ATHENA] = boto3.client(
+                service_name=SERVICE_ATHENA, **self._base_kwargs()
+            )
+        return self._clients[SERVICE_ATHENA]
+
+    def sts(self) -> BaseClient:
+        """Get or create the STS client."""
+        if SERVICE_STS not in self._clients:
+            self._clients[SERVICE_STS] = boto3.client(
+                service_name=SERVICE_STS, **self._base_kwargs()
+            )
+        return self._clients[SERVICE_STS]
+
+    def iam(self) -> BaseClient:
+        """Get or create the IAM client."""
+        if SERVICE_IAM not in self._clients:
+            self._clients[SERVICE_IAM] = boto3.client(
+                service_name=SERVICE_IAM, **self._base_kwargs()
+            )
+        return self._clients[SERVICE_IAM]

--- a/nx_neptune/clients/client_factory.py
+++ b/nx_neptune/clients/client_factory.py
@@ -34,11 +34,23 @@ class ClientFactory:
     Ensures consistent configuration (user agent, timeouts, region) across
     all AWS service clients used by the library.
 
+    Use ``ClientFactory.default()`` for a shared singleton, or create an
+    instance for custom configuration.
+
     Args:
         region: AWS region name. If None, uses boto3 default.
         timeout_seconds: Read timeout for long-running operations (e.g., queries).
             Applied to the Neptune Analytics client.
     """
+
+    _default: Optional["ClientFactory"] = None
+
+    @classmethod
+    def default(cls) -> "ClientFactory":
+        """Return the shared default factory (lazy-initialized)."""
+        if cls._default is None:
+            cls._default = cls()
+        return cls._default
 
     def __init__(
         self,

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -19,6 +19,7 @@ from botocore.client import BaseClient
 from botocore.config import Config
 
 from .neptune_constants import APP_ID_NX, SERVICE_NA
+from .client_factory import ClientFactory
 
 
 class NeptuneAnalyticsClient:
@@ -57,8 +58,6 @@ class NeptuneAnalyticsClient:
         if client:
             self.client = client
         else:
-            from .client_factory import ClientFactory
-
             self.client = ClientFactory(timeout_seconds=timeout_seconds).neptune()
         self.logger = logger or logging.getLogger(__name__)
         self.name = name or ""

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -18,8 +18,8 @@ import boto3
 from botocore.client import BaseClient
 from botocore.config import Config
 
-from .neptune_constants import APP_ID_NX, SERVICE_NA
 from .client_factory import ClientFactory
+from .neptune_constants import APP_ID_NX, SERVICE_NA
 
 
 class NeptuneAnalyticsClient:

--- a/nx_neptune/clients/na_client.py
+++ b/nx_neptune/clients/na_client.py
@@ -57,12 +57,9 @@ class NeptuneAnalyticsClient:
         if client:
             self.client = client
         else:
-            config_kwargs: dict[str, Any] = {"user_agent_appid": APP_ID_NX}
-            if timeout_seconds:
-                config_kwargs["read_timeout"] = timeout_seconds
-            self.client = boto3.client(
-                service_name=SERVICE_NA, config=Config(**config_kwargs)
-            )
+            from .client_factory import ClientFactory
+
+            self.client = ClientFactory(timeout_seconds=timeout_seconds).neptune()
         self.logger = logger or logging.getLogger(__name__)
         self.name = name or ""
         self.status = status or ""

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 from botocore.exceptions import ClientError
 
-
 # --- Error classifiers ---
 
 
@@ -34,6 +33,7 @@ def is_entity_not_found(e: ClientError) -> bool:
     """Is this an Athena entity-not-found error?"""
     msg = str(e)
     return "EntityNotFoundException" in msg or "MetadataException" in msg
+
 
 # --- S3 ---
 

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Response interpreters for boto3 API responses.
+
+Pure functions that translate raw boto3 response dicts into typed answers.
+No API calls — just dict parsing with purpose.
+"""
+
+from typing import Optional
+
+# --- S3 ---
+
+
+def get_bucket_region(resp: dict) -> str:
+    """Get bucket region from get_bucket_location response."""
+    # S3 API returns None for us-east-1
+    return resp.get("LocationConstraint") or "us-east-1"
+
+
+def is_kms_encrypted(resp: dict) -> bool:
+    """Check if get_bucket_encryption response uses KMS."""
+    for rule in resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", []):
+        sse = rule.get("ApplyServerSideEncryptionByDefault", {})
+        if sse.get("SSEAlgorithm") == "aws:kms":
+            return True
+    return False
+
+
+def get_kms_key_id(resp: dict) -> Optional[str]:
+    """Extract KMS key ID from get_bucket_encryption response."""
+    for rule in resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", []):
+        sse = rule.get("ApplyServerSideEncryptionByDefault", {})
+        if sse.get("SSEAlgorithm") == "aws:kms":
+            return sse.get("KMSMasterKeyID")
+    return None
+
+
+def is_versioning_enabled(resp: dict) -> bool:
+    """Check if get_bucket_versioning response shows enabled."""
+    return resp.get("Status") == "Enabled"
+
+
+def get_object_count(resp: dict) -> int:
+    """Get object count from list_objects_v2 response."""
+    return resp.get("KeyCount", 0)
+
+
+# --- Athena ---
+
+
+def get_table_columns(resp: dict) -> list[str]:
+    """Extract column names from get_table_metadata response."""
+    return [c["Name"] for c in resp.get("TableMetadata", {}).get("Columns", [])]
+
+
+def get_query_state(resp: dict) -> str:
+    """Get execution state from get_query_execution response."""
+    return resp["QueryExecution"]["Status"]["State"]
+
+
+def get_query_failure_reason(resp: dict) -> str:
+    """Get failure reason from get_query_execution response."""
+    return resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error")
+
+
+def get_query_result_columns(resp: dict) -> list[str]:
+    """Extract column names from get_query_results response."""
+    return [c["Name"] for c in resp["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
+
+
+# --- Neptune ---
+
+
+def get_graph_names(resp: dict) -> list[dict]:
+    """Get graph name/id pairs from list_graphs response."""
+    return [{"name": g["name"], "id": g["id"]} for g in resp.get("graphs", [])]
+
+
+# --- STS ---
+
+
+def get_caller_arn(resp: dict) -> str:
+    """Get caller ARN from get_caller_identity response."""
+    return resp["Arn"]

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -9,6 +9,32 @@ No API calls — just dict parsing with purpose.
 
 from typing import Optional
 
+from botocore.exceptions import ClientError
+
+
+# --- Error classifiers ---
+
+
+def get_error_code(e: ClientError) -> str:
+    """Get HTTP error code from a ClientError."""
+    return e.response["Error"]["Code"]
+
+
+def is_not_found(e: ClientError) -> bool:
+    """Is this a 404 / not-found error?"""
+    return get_error_code(e) == "404"
+
+
+def is_access_denied(e: ClientError) -> bool:
+    """Is this a 403 / access-denied error?"""
+    return get_error_code(e) == "403"
+
+
+def is_entity_not_found(e: ClientError) -> bool:
+    """Is this an Athena entity-not-found error?"""
+    msg = str(e)
+    return "EntityNotFoundException" in msg or "MetadataException" in msg
+
 # --- S3 ---
 
 

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -5,6 +5,13 @@
 
 Pure functions that translate raw boto3 response dicts into typed answers.
 No API calls — just dict parsing with purpose.
+
+Naming convention: {product}_{verb}_{noun}
+  - s3_*      — S3 responses
+  - athena_*  — Athena responses
+  - nx_*      — Neptune Analytics responses
+  - sts_*     — STS responses
+  - boto_*    — Generic boto3 responses / error classifiers
 """
 
 from typing import Optional
@@ -14,17 +21,17 @@ from botocore.exceptions import ClientError
 # --- Error classifiers ---
 
 
-def is_not_found(e: ClientError) -> bool:
+def boto_is_not_found(e: ClientError) -> bool:
     """Is this a 404 / not-found error?"""
     return e.response["Error"]["Code"] == "404"
 
 
-def is_access_denied(e: ClientError) -> bool:
+def boto_is_access_denied(e: ClientError) -> bool:
     """Is this a 403 / access-denied error?"""
     return e.response["Error"]["Code"] == "403"
 
 
-def is_entity_not_found(e: ClientError) -> bool:
+def athena_is_entity_not_found(e: ClientError) -> bool:
     """Is this an Athena entity-not-found error?"""
     msg = str(e)
     return "EntityNotFoundException" in msg or "MetadataException" in msg
@@ -33,13 +40,13 @@ def is_entity_not_found(e: ClientError) -> bool:
 # --- S3 ---
 
 
-def get_bucket_region(resp: dict) -> str:
+def s3_get_bucket_region(resp: dict) -> str:
     """Get bucket region from get_bucket_location response."""
     # S3 API returns None for us-east-1
     return resp.get("LocationConstraint") or "us-east-1"
 
 
-def is_kms_encrypted(resp: dict) -> bool:
+def s3_is_kms_encrypted(resp: dict) -> bool:
     """Check if get_bucket_encryption response uses KMS."""
     for rule in resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", []):
         sse = rule.get("ApplyServerSideEncryptionByDefault", {})
@@ -48,7 +55,7 @@ def is_kms_encrypted(resp: dict) -> bool:
     return False
 
 
-def get_kms_key_id(resp: dict) -> Optional[str]:
+def s3_get_kms_key_id(resp: dict) -> Optional[str]:
     """Extract KMS key ID from get_bucket_encryption response."""
     for rule in resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", []):
         sse = rule.get("ApplyServerSideEncryptionByDefault", {})
@@ -57,35 +64,45 @@ def get_kms_key_id(resp: dict) -> Optional[str]:
     return None
 
 
-def is_versioning_enabled(resp: dict) -> bool:
+def s3_is_versioning_enabled(resp: dict) -> bool:
     """Check if get_bucket_versioning response shows enabled."""
     return resp.get("Status") == "Enabled"
 
 
-def get_object_count(resp: dict) -> int:
+def s3_get_object_count(resp: dict) -> int:
     """Get object count from list_objects_v2 response."""
     return resp.get("KeyCount", 0)
+
+
+def s3_get_contents(resp: dict) -> list[dict]:
+    """Get Contents list from list_objects_v2 response."""
+    return resp.get("Contents", [])
 
 
 # --- Athena ---
 
 
-def get_table_columns(resp: dict) -> list[str]:
+def athena_get_table_columns(resp: dict) -> list[str]:
     """Extract column names from get_table_metadata response."""
     return [c["Name"] for c in resp.get("TableMetadata", {}).get("Columns", [])]
 
 
-def get_query_state(resp: dict) -> str:
+def athena_get_query_state(resp: dict) -> str:
     """Get execution state from get_query_execution response."""
     return resp["QueryExecution"]["Status"]["State"]
 
 
-def get_query_failure_reason(resp: dict) -> str:
+def athena_get_query_execution_id(resp: dict) -> str:
+    """Get QueryExecutionId from start_query_execution response."""
+    return resp["QueryExecutionId"]
+
+
+def athena_get_query_failure_reason(resp: dict) -> str:
     """Get failure reason from get_query_execution response."""
     return resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error")
 
 
-def get_query_result_columns(resp: dict) -> list[str]:
+def athena_get_query_result_columns(resp: dict) -> list[str]:
     """Extract column names from get_query_results response."""
     return [c["Name"] for c in resp["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
 
@@ -93,14 +110,37 @@ def get_query_result_columns(resp: dict) -> list[str]:
 # --- Neptune ---
 
 
-def get_graph_names(resp: dict) -> list[dict]:
+def na_get_graph_names(resp: dict) -> list[dict]:
     """Get graph name/id pairs from list_graphs response."""
     return [{"name": g["name"], "id": g["id"]} for g in resp.get("graphs", [])]
+
+
+def na_get_graph_id(resp: dict) -> str:
+    """Get graph ID from create/get graph response."""
+    return resp.get("graphId") or resp.get("id")  # type: ignore[return-value]
+
+
+def na_get_task_id(resp: dict) -> str:
+    """Get task ID from import/export task response."""
+    return resp.get("taskId")  # type: ignore[return-value]
+
+
+def na_get_snapshot_id(resp: dict) -> str:
+    """Get snapshot ID from create_graph_snapshot response."""
+    return resp["id"]
+
+
+# --- Common ---
+
+
+def boto_get_status_code(resp: dict) -> Optional[int]:
+    """Get HTTP status code from any boto3 response."""
+    return (resp.get("ResponseMetadata") or {}).get("HTTPStatusCode")
 
 
 # --- STS ---
 
 
-def get_caller_arn(resp: dict) -> str:
+def sts_get_caller_arn(resp: dict) -> str:
     """Get caller ARN from get_caller_identity response."""
     return resp["Arn"]

--- a/nx_neptune/clients/response_utils.py
+++ b/nx_neptune/clients/response_utils.py
@@ -14,19 +14,14 @@ from botocore.exceptions import ClientError
 # --- Error classifiers ---
 
 
-def get_error_code(e: ClientError) -> str:
-    """Get HTTP error code from a ClientError."""
-    return e.response["Error"]["Code"]
-
-
 def is_not_found(e: ClientError) -> bool:
     """Is this a 404 / not-found error?"""
-    return get_error_code(e) == "404"
+    return e.response["Error"]["Code"] == "404"
 
 
 def is_access_denied(e: ClientError) -> bool:
     """Is this a 403 / access-denied error?"""
-    return get_error_code(e) == "403"
+    return e.response["Error"]["Code"] == "403"
 
 
 def is_entity_not_found(e: ClientError) -> bool:

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -24,10 +24,9 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from sqlglot import exp, parse_one
 
-from .clients import SERVICE_IAM, SERVICE_NA, SERVICE_STS, IamClient
+from .clients import IamClient
 from .clients.client_factory import ClientFactory
 from .clients.iam_client import split_s3_arn_to_bucket_and_path
-from .clients.neptune_constants import APP_ID_NX, SERVICE_ATHENA, SERVICE_S3
 from .na_graph import NeptuneGraph
 
 __all__ = [
@@ -650,7 +649,7 @@ async def reset_graph(
         Exception: If an invalid status code is returned
     """
     if na_client is None:
-        na_client = ClientFactory().neptune()
+        na_client = ClientFactory.default().neptune()
 
     logger.info(
         f"Perform reset_graph action on graph: [{graph_id}] with skip_snapshot: [{skip_snapshot}]"
@@ -981,7 +980,7 @@ def _get_bucket_encryption_key_arn(s3_arn):
     """
     try:
         # Create an S3 client
-        s3_client = ClientFactory().s3()
+        s3_client = ClientFactory.default().s3()
 
         # Get the bucket encryption configuration
         bucket_name = _clean_s3_path(s3_arn)
@@ -1127,7 +1126,7 @@ async def export_athena_table_to_s3(
         query_execution_ids.append(query_execution_id)
 
     # Wait on all query execution IDs
-    s3_client = s3_client or ClientFactory().s3()
+    s3_client = s3_client or ClientFactory.default().s3()
     bucket_name, bucket_prefix = split_s3_arn_to_bucket_and_path(s3_bucket)
 
     await wait_until_all_complete(
@@ -1206,7 +1205,7 @@ async def create_csv_table_from_s3(
     iam_client_wrapper.has_athena_permissions(s3_output_bucket, output_key_arn)
 
     # Wait on all query execution IDs
-    s3_client = s3_client or ClientFactory().s3()
+    s3_client = s3_client or ClientFactory.default().s3()
     bucket_name, bucket_prefix = split_s3_arn_to_bucket_and_path(s3_bucket)
 
     logger.debug(f"Inspecting files from {s3_bucket}")
@@ -1632,7 +1631,7 @@ def empty_s3_bucket(
 
     # Create S3 client if not provided
     if s3_client is None:
-        s3_client = ClientFactory().s3()
+        s3_client = ClientFactory.default().s3()
 
     # Create IamClient using _get_or_create_clients
     iam_client_wrapper, _, _ = _get_or_create_clients(sts_client, iam_client, None)
@@ -1682,7 +1681,7 @@ def empty_s3_bucket(
 
 
 def validate_permissions():
-    factory = ClientFactory()
+    factory = ClientFactory.default()
     user_arn = factory.sts().get_caller_identity()["Arn"]
     iam_client = IamClient(role_arn=user_arn, client=factory.iam())
 
@@ -1865,7 +1864,7 @@ def _get_or_create_clients(
     Returns:
         Tuple[IamClient, BaseClient, BaseClient]: Tuple containing (iam_client, na_client, athena_client)
     """
-    factory = clients or ClientFactory()
+    factory = clients or ClientFactory.default()
 
     if sts_client is None:
         sts_client = factory.sts()
@@ -1922,7 +1921,7 @@ def execute_athena_query(
         Exception: If the query execution fails or times out
     """
     if client is None:
-        client = ClientFactory().athena()
+        client = ClientFactory.default().athena()
     execution_id = _execute_athena_query(
         client, sql_statement, output_location, sql_parameters, catalog, database
     )
@@ -1955,7 +1954,7 @@ def get_athena_query_results(
         are not needed.
     """
     if client is None:
-        client = ClientFactory().athena()
+        client = ClientFactory.default().athena()
 
     rows = []
     try:

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -27,6 +27,16 @@ from sqlglot import exp, parse_one
 from .clients import IamClient
 from .clients.client_factory import ClientFactory
 from .clients.iam_client import split_s3_arn_to_bucket_and_path
+from .clients.response_utils import (
+    athena_get_query_execution_id,
+    athena_get_query_state,
+    boto_get_status_code,
+    na_get_graph_id,
+    na_get_snapshot_id,
+    na_get_task_id,
+    s3_get_contents,
+    sts_get_caller_arn,
+)
 from .na_graph import NeptuneGraph
 
 __all__ = [
@@ -100,8 +110,8 @@ async def create_na_instance(
     iam_client.has_create_na_permissions()
 
     response = _create_na_instance_task(na_client, config, graph_name_prefix)
-    prospective_graph_id = _get_graph_id(response)
-    status_code = _get_status_code(response)
+    prospective_graph_id = na_get_graph_id(response)
+    status_code = boto_get_status_code(response)
 
     if status_code == 201:
         await _get_status_check_future(
@@ -178,10 +188,10 @@ async def create_na_instance_with_s3_import(
         graph_name, s3_arn, iam_client_wrapper.role_arn, config
     )
     response = na_client.create_graph_using_import_task(**kwargs)
-    graph_id = response.get("graphId")
-    task_id = response.get("taskId")
+    graph_id = na_get_graph_id(response)
+    task_id = na_get_task_id(response)
 
-    if _get_status_code(response) == 201:
+    if boto_get_status_code(response) == 201:
         # Import task status check
         await _get_status_check_future(
             na_client, TaskType.IMPORT, task_id, polling_interval, max_attempts
@@ -248,9 +258,9 @@ async def create_na_instance_from_snapshot(
     response = _create_na_instance_from_snapshot_task(
         na_client, snapshot_id, config, graph_name_prefix
     )
-    prospective_graph_id = _get_graph_id(response)
+    prospective_graph_id = na_get_graph_id(response)
 
-    if _get_status_code(response) == 201:
+    if boto_get_status_code(response) == 201:
         await _get_status_check_future(
             na_client,
             TaskType.CREATE,
@@ -301,7 +311,7 @@ async def delete_graph_snapshot(
     iam_client_wrapper.has_delete_snapshot_permissions()
     response = na_client.delete_graph_snapshot(snapshotIdentifier=snapshot_id)
 
-    status_code = _get_status_code(response)
+    status_code = boto_get_status_code(response)
     if status_code == 200:
         await _get_status_check_future(
             na_client,
@@ -354,7 +364,7 @@ async def start_na_instance(
         await status_exception  # This will raise the exception
 
     response = na_client.start_graph(graphIdentifier=graph_id)
-    status_code = _get_status_code(response)
+    status_code = boto_get_status_code(response)
     if status_code == 200:
         fut = TaskFuture(graph_id, TaskType.START, polling_interval, max_attempts)
         await fut.wait_until_complete(na_client)
@@ -401,7 +411,7 @@ async def stop_na_instance(
         await status_exception  # This will raise the exception
 
     response = na_client.stop_graph(graphIdentifier=graph_id)
-    status_code = _get_status_code(response)
+    status_code = boto_get_status_code(response)
     if status_code == 200:
         fut = TaskFuture(graph_id, TaskType.STOP, polling_interval, max_attempts)
         await fut.wait_until_complete(na_client)
@@ -449,7 +459,7 @@ async def delete_na_instance(
     iam_client.has_delete_na_permissions()
 
     response = _delete_na_instance_task(na_client, graph_id)
-    status_code = _get_status_code(response)
+    status_code = boto_get_status_code(response)
     if status_code == 200:
         fut = TaskFuture(graph_id, TaskType.DELETE, polling_interval, max_attempts)
         await fut.wait_until_complete(na_client)
@@ -505,8 +515,8 @@ async def create_graph_snapshot(
         kwargs["tags"] = tag
 
     response = na_client.create_graph_snapshot(**kwargs)
-    snapshot_id = response["id"]
-    status_code = _get_status_code(response)
+    snapshot_id = na_get_snapshot_id(response)
+    status_code = boto_get_status_code(response)
     if status_code == 201:
         await _get_status_check_future(
             na_client,
@@ -655,7 +665,7 @@ async def reset_graph(
         f"Perform reset_graph action on graph: [{graph_id}] with skip_snapshot: [{skip_snapshot}]"
     )
     response = na_client.reset_graph(graphIdentifier=graph_id, skipSnapshot=skip_snapshot)  # type: ignore[attr-defined]
-    status_code = _get_status_code(response)
+    status_code = boto_get_status_code(response)
     if status_code == 200:
         fut = TaskFuture(graph_id, TaskType.RESET_GRAPH, polling_interval, max_attempts)
         await fut.wait_until_complete(na_client)
@@ -706,7 +716,7 @@ async def update_na_instance_size(
     response = na_client.update_graph(
         graphIdentifier=graph_id, provisionedMemory=prospect_size
     )
-    status_code = _get_status_code(response)
+    status_code = boto_get_status_code(response)
     if status_code == 200:
         fut = TaskFuture(graph_id, TaskType.UPDATE, polling_interval, max_attempts)
         await fut.wait_until_complete(na_client)
@@ -897,7 +907,7 @@ def _start_import_task(
             format=format_type,
             roleArn=role_arn,
         )
-        task_id = response.get("taskId")
+        task_id = na_get_task_id(response)
         return task_id
     except ClientError as e:
         raise e
@@ -962,7 +972,7 @@ def _start_export_task(
         response = client.start_export_task(  # type: ignore[attr-defined]
             **kwargs_export
         )
-        task_id = response.get("taskId")
+        task_id = na_get_task_id(response)
         return task_id
 
     except ClientError as e:
@@ -1027,32 +1037,6 @@ def _clean_s3_path(s3_path):
 
     # If there's no '/', return the bucket name
     return parts[0]
-
-
-def _get_status_code(response: dict):
-    """
-    Extract the HTTP status code from an AWS API response.
-
-    Args:
-        response (dict): The AWS API response dictionary
-
-    Returns:
-        int or None: The HTTP status code if available, None otherwise
-    """
-    return (response.get("ResponseMetadata") or {}).get("HTTPStatusCode")
-
-
-def _get_graph_id(response: dict):
-    """
-    Extract the graph ID from a Neptune Analytics API response.
-
-    Args:
-        response (dict): The Neptune Analytics API response dictionary
-
-    Returns:
-        str or None: The graph ID if available, None otherwise
-    """
-    return response.get("id")
 
 
 def _create_random_graph_name(graph_name_prefix: Optional[str] = None) -> str:
@@ -1210,7 +1194,7 @@ async def create_csv_table_from_s3(
     logger.debug(f"Inspecting files from {s3_bucket}")
 
     response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=bucket_prefix)
-    file_paths = response.get("Contents", [])
+    file_paths = s3_get_contents(response)
 
     logger.info(f"Moving 'Edge_*.csv' files to folder {s3_bucket}/Edge")
     edge_sql_statement = _build_sql_statement(
@@ -1590,8 +1574,8 @@ def _execute_athena_query(
 
     try:
         response = client.start_query_execution(**query_execution_params)
-        logger.info(f"Executing query: {response['QueryExecutionId']}")
-        query_execution_id = response["QueryExecutionId"]
+        logger.info(f"Executing query: {athena_get_query_execution_id(response)}")
+        query_execution_id = athena_get_query_execution_id(response)
     except ClientError as e:
         logger.error(f"Error creating table: {e}")
         raise
@@ -1677,7 +1661,7 @@ def empty_s3_bucket(
 
 def validate_permissions():
     factory = ClientFactory.default()
-    user_arn = factory.sts().get_caller_identity()["Arn"]
+    user_arn = sts_get_caller_arn(factory.sts().get_caller_identity())
     iam_client = IamClient(role_arn=user_arn, client=factory.iam())
 
     s3_import = os.getenv("NETWORKX_S3_IMPORT_BUCKET_PATH")
@@ -1856,7 +1840,7 @@ def _create_iam_wrapper(
     factory = ClientFactory.default()
     if sts_client is None:
         sts_client = factory.sts()
-    user_arn = sts_client.get_caller_identity()["Arn"]
+    user_arn = sts_get_caller_arn(sts_client.get_caller_identity())
     if iam_client is None:
         iam_client = factory.iam()
     return IamClient(role_arn=user_arn, client=iam_client)
@@ -1935,7 +1919,7 @@ def get_athena_query_results(
     rows = []
     try:
         status = client.get_query_execution(QueryExecutionId=query_execution_id)
-        state = status["QueryExecution"]["Status"]["State"]
+        state = athena_get_query_state(status)
         if state != "SUCCEEDED":
             raise RuntimeError(
                 f"Query {query_execution_id} is in state {state}, cannot fetch results"

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -95,7 +95,7 @@ async def create_na_instance(
     Raises:
         Exception: If the Neptune Analytics instance creation fails
     """
-    iam_client = _resolve_iam_client(sts_client, iam_client)
+    iam_client = _create_iam_wrapper(sts_client, iam_client)
     na_client = na_client or ClientFactory.default().neptune()
     iam_client.has_create_na_permissions()
 
@@ -164,7 +164,7 @@ async def create_na_instance_with_s3_import(
         ValueError: If the role lacks required permissions
     """
 
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
 
     na_client = na_client or ClientFactory.default().neptune()
     # Retrieve key_arn for the bucket and permission check if present
@@ -239,7 +239,7 @@ async def create_na_instance_from_snapshot(
         Exception: If the Neptune Analytics instance creation fails
         ValueError: If the role lacks required permissions
     """
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     na_client = na_client or ClientFactory.default().neptune()
 
     # Permissions check
@@ -294,7 +294,7 @@ async def delete_graph_snapshot(
         Exception: If the snapshot deletion fails
         ValueError: If the role lacks required permissions
     """
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     na_client = na_client or ClientFactory.default().neptune()
 
     # Permissions check
@@ -346,7 +346,7 @@ async def start_na_instance(
         Exception: If the start operation fails with an invalid status code
         ValueError: If the role lacks required permissions or if graph is not in STOPPED state
     """
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     na_client = na_client or ClientFactory.default().neptune()
     iam_client_wrapper.has_start_na_permissions()
 
@@ -393,7 +393,7 @@ async def stop_na_instance(
         Exception: If the stop operation fails with an invalid status code
         ValueError: If the role lacks required permissions or if graph is not in AVAILABLE state
     """
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     na_client = na_client or ClientFactory.default().neptune()
     iam_client_wrapper.has_stop_na_permissions()
 
@@ -442,7 +442,7 @@ async def delete_na_instance(
         ValueError: If the role lacks required permissions
     """
 
-    iam_client = _resolve_iam_client(sts_client, iam_client)
+    iam_client = _create_iam_wrapper(sts_client, iam_client)
 
     na_client = na_client or ClientFactory.default().neptune()
     # Permission check
@@ -493,7 +493,7 @@ async def create_graph_snapshot(
         ValueError: If the role lacks required permissions
     """
     # Permission check
-    iam_client = _resolve_iam_client(sts_client, iam_client)
+    iam_client = _create_iam_wrapper(sts_client, iam_client)
     na_client = na_client or ClientFactory.default().neptune()
     iam_client.has_create_na_snapshot_permissions()
 
@@ -696,7 +696,7 @@ async def update_na_instance_size(
         Exception: If the resize operation fails
         ValueError: If the role lacks required permissions
     """
-    iam_client = _resolve_iam_client(sts_client, iam_client)
+    iam_client = _create_iam_wrapper(sts_client, iam_client)
     na_client = na_client or ClientFactory.default().neptune()
 
     # Permission check
@@ -1105,7 +1105,7 @@ async def export_athena_table_to_s3(
     Returns:
         list: List of successfully processed query execute ids.
     """
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if bucket is encrypted
@@ -1192,7 +1192,7 @@ async def create_csv_table_from_s3(
         Exception: If any query fails
     """
     # Permission checks
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS keys if buckets are encrypted
@@ -1377,7 +1377,7 @@ async def create_iceberg_table_from_table(
         str: Returns the query_execution_id if successful
     """
     # Permission checks
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if output bucket is encrypted
@@ -1457,7 +1457,7 @@ async def create_table_schema_from_s3(
         str: Returns the query_execution_id if successful
     """
     # Permission checks
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if bucket is encrypted
@@ -1516,7 +1516,7 @@ async def drop_athena_table(
         str: Returns the query_execution_id if successful
     """
     # Permission checks
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
     athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if bucket is encrypted
@@ -1629,7 +1629,7 @@ def empty_s3_bucket(
     if s3_client is None:
         s3_client = ClientFactory.default().s3()
 
-    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    iam_client_wrapper = _create_iam_wrapper(sts_client, iam_client)
 
     # raises an error validation fails
     iam_client_wrapper.has_delete_s3_permissions(s3_arn)
@@ -1839,7 +1839,7 @@ def _get_status_check_future(
     return asyncio.wrap_future(fut)
 
 
-def _resolve_iam_client(
+def _create_iam_wrapper(
     sts_client: Optional[BaseClient] = None,
     iam_client: Optional[BaseClient] = None,
 ) -> IamClient:

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -95,7 +95,8 @@ async def create_na_instance(
     Raises:
         Exception: If the Neptune Analytics instance creation fails
     """
-    iam_client, na_client, _ = _get_or_create_clients(sts_client, iam_client, na_client)
+    iam_client = _resolve_iam_client(sts_client, iam_client)
+    na_client = na_client or ClientFactory.default().neptune()
     iam_client.has_create_na_permissions()
 
     response = _create_na_instance_task(na_client, config, graph_name_prefix)
@@ -163,9 +164,9 @@ async def create_na_instance_with_s3_import(
         ValueError: If the role lacks required permissions
     """
 
-    iam_client_wrapper, na_client, _ = _get_or_create_clients(
-        sts_client, iam_client, na_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+
+    na_client = na_client or ClientFactory.default().neptune()
     # Retrieve key_arn for the bucket and permission check if present
     key_arn = _get_bucket_encryption_key_arn(s3_arn)
     # Permission checks
@@ -238,9 +239,8 @@ async def create_na_instance_from_snapshot(
         Exception: If the Neptune Analytics instance creation fails
         ValueError: If the role lacks required permissions
     """
-    iam_client_wrapper, na_client, _ = _get_or_create_clients(
-        sts_client, iam_client, na_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    na_client = na_client or ClientFactory.default().neptune()
 
     # Permissions check
     iam_client_wrapper.has_create_na_from_snapshot_permissions()
@@ -294,9 +294,8 @@ async def delete_graph_snapshot(
         Exception: If the snapshot deletion fails
         ValueError: If the role lacks required permissions
     """
-    iam_client_wrapper, na_client, _ = _get_or_create_clients(
-        sts_client, iam_client, na_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    na_client = na_client or ClientFactory.default().neptune()
 
     # Permissions check
     iam_client_wrapper.has_delete_snapshot_permissions()
@@ -347,9 +346,8 @@ async def start_na_instance(
         Exception: If the start operation fails with an invalid status code
         ValueError: If the role lacks required permissions or if graph is not in STOPPED state
     """
-    iam_client_wrapper, na_client, _ = _get_or_create_clients(
-        sts_client, iam_client, na_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    na_client = na_client or ClientFactory.default().neptune()
     iam_client_wrapper.has_start_na_permissions()
 
     if status_exception := _graph_status_check(na_client, graph_id, "STOPPED"):
@@ -395,9 +393,8 @@ async def stop_na_instance(
         Exception: If the stop operation fails with an invalid status code
         ValueError: If the role lacks required permissions or if graph is not in AVAILABLE state
     """
-    iam_client_wrapper, na_client, _ = _get_or_create_clients(
-        sts_client, iam_client, na_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    na_client = na_client or ClientFactory.default().neptune()
     iam_client_wrapper.has_stop_na_permissions()
 
     if status_exception := _graph_status_check(na_client, graph_id, "AVAILABLE"):
@@ -445,7 +442,9 @@ async def delete_na_instance(
         ValueError: If the role lacks required permissions
     """
 
-    iam_client, na_client, _ = _get_or_create_clients(sts_client, iam_client, na_client)
+    iam_client = _resolve_iam_client(sts_client, iam_client)
+
+    na_client = na_client or ClientFactory.default().neptune()
     # Permission check
     iam_client.has_delete_na_permissions()
 
@@ -494,7 +493,8 @@ async def create_graph_snapshot(
         ValueError: If the role lacks required permissions
     """
     # Permission check
-    iam_client, na_client, _ = _get_or_create_clients(sts_client, iam_client, na_client)
+    iam_client = _resolve_iam_client(sts_client, iam_client)
+    na_client = na_client or ClientFactory.default().neptune()
     iam_client.has_create_na_snapshot_permissions()
 
     kwargs: dict[str, Any] = {
@@ -696,7 +696,8 @@ async def update_na_instance_size(
         Exception: If the resize operation fails
         ValueError: If the role lacks required permissions
     """
-    iam_client, na_client, _ = _get_or_create_clients(sts_client, iam_client, na_client)
+    iam_client = _resolve_iam_client(sts_client, iam_client)
+    na_client = na_client or ClientFactory.default().neptune()
 
     # Permission check
     iam_client.has_update_na_permissions()
@@ -1104,9 +1105,8 @@ async def export_athena_table_to_s3(
     Returns:
         list: List of successfully processed query execute ids.
     """
-    iam_client_wrapper, _, athena_client = _get_or_create_clients(
-        sts_client, iam_client, None, athena_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if bucket is encrypted
     key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1192,9 +1192,8 @@ async def create_csv_table_from_s3(
         Exception: If any query fails
     """
     # Permission checks
-    iam_client_wrapper, _, athena_client = _get_or_create_clients(
-        sts_client, iam_client, None, athena_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS keys if buckets are encrypted
     s3_key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1378,9 +1377,8 @@ async def create_iceberg_table_from_table(
         str: Returns the query_execution_id if successful
     """
     # Permission checks
-    iam_client_wrapper, _, athena_client = _get_or_create_clients(
-        sts_client, iam_client, None, athena_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if output bucket is encrypted
     output_key_arn = _get_bucket_encryption_key_arn(s3_output_bucket)
@@ -1459,9 +1457,8 @@ async def create_table_schema_from_s3(
         str: Returns the query_execution_id if successful
     """
     # Permission checks
-    iam_client_wrapper, _, athena_client = _get_or_create_clients(
-        sts_client, iam_client, None, athena_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if bucket is encrypted
     key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1519,9 +1516,8 @@ async def drop_athena_table(
         str: Returns the query_execution_id if successful
     """
     # Permission checks
-    iam_client_wrapper, _, athena_client = _get_or_create_clients(
-        sts_client, iam_client, None, athena_client
-    )
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
+    athena_client = athena_client or ClientFactory.default().athena()
 
     # Get KMS key if bucket is encrypted
     key_arn = _get_bucket_encryption_key_arn(s3_bucket)
@@ -1633,8 +1629,7 @@ def empty_s3_bucket(
     if s3_client is None:
         s3_client = ClientFactory.default().s3()
 
-    # Create IamClient using _get_or_create_clients
-    iam_client_wrapper, _, _ = _get_or_create_clients(sts_client, iam_client, None)
+    iam_client_wrapper = _resolve_iam_client(sts_client, iam_client)
 
     # raises an error validation fails
     iam_client_wrapper.has_delete_s3_permissions(s3_arn)
@@ -1844,46 +1839,27 @@ def _get_status_check_future(
     return asyncio.wrap_future(fut)
 
 
-def _get_or_create_clients(
+def _resolve_iam_client(
     sts_client: Optional[BaseClient] = None,
     iam_client: Optional[BaseClient] = None,
-    na_client: Optional[BaseClient] = None,
-    athena_client: Optional[BaseClient] = None,
-    clients: Optional[ClientFactory] = None,
-):
+) -> IamClient:
     """
-    Create or reuse provided AWS clients.
+    Resolve the caller identity and return an IamClient wrapper.
 
     Args:
         sts_client (Optional[BaseClient]): Optional STS boto3 client
         iam_client (Optional[BaseClient]): Optional IAM boto3 client
-        na_client (Optional[BaseClient]): Optional Neptune Analytics boto3 client
-        athena_client (Optional[BaseClient]): Optional Athena boto3 client
-        clients (Optional[ClientFactory]): Optional client factory for creating clients
 
     Returns:
-        Tuple[IamClient, BaseClient, BaseClient]: Tuple containing (iam_client, na_client, athena_client)
+        IamClient: Wrapper with the caller's role ARN
     """
-    factory = clients or ClientFactory.default()
-
+    factory = ClientFactory.default()
     if sts_client is None:
         sts_client = factory.sts()
     user_arn = sts_client.get_caller_identity()["Arn"]
-
-    # Create IamClient
     if iam_client is None:
         iam_client = factory.iam()
-    iam_client_wrapper = IamClient(role_arn=user_arn, client=iam_client)
-
-    # Create Neptune Analytics client if not provided
-    if na_client is None:
-        na_client = factory.neptune()
-
-    # Create Athena client if not provided
-    if athena_client is None:
-        athena_client = factory.athena()
-
-    return iam_client_wrapper, na_client, athena_client
+    return IamClient(role_arn=user_arn, client=iam_client)
 
 
 def execute_athena_query(

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -25,6 +25,7 @@ from botocore.exceptions import ClientError
 from sqlglot import exp, parse_one
 
 from .clients import SERVICE_IAM, SERVICE_NA, SERVICE_STS, IamClient
+from .clients.client_factory import ClientFactory
 from .clients.iam_client import split_s3_arn_to_bucket_and_path
 from .clients.neptune_constants import APP_ID_NX, SERVICE_ATHENA, SERVICE_S3
 from .na_graph import NeptuneGraph
@@ -649,9 +650,7 @@ async def reset_graph(
         Exception: If an invalid status code is returned
     """
     if na_client is None:
-        na_client = boto3.client(
-            service_name=SERVICE_NA, config=Config(user_agent_appid=APP_ID_NX)
-        )
+        na_client = ClientFactory().neptune()
 
     logger.info(
         f"Perform reset_graph action on graph: [{graph_id}] with skip_snapshot: [{skip_snapshot}]"
@@ -982,7 +981,7 @@ def _get_bucket_encryption_key_arn(s3_arn):
     """
     try:
         # Create an S3 client
-        s3_client = boto3.client(SERVICE_S3)
+        s3_client = ClientFactory().s3()
 
         # Get the bucket encryption configuration
         bucket_name = _clean_s3_path(s3_arn)
@@ -1128,7 +1127,7 @@ async def export_athena_table_to_s3(
         query_execution_ids.append(query_execution_id)
 
     # Wait on all query execution IDs
-    s3_client = s3_client or boto3.client(SERVICE_S3)
+    s3_client = s3_client or ClientFactory().s3()
     bucket_name, bucket_prefix = split_s3_arn_to_bucket_and_path(s3_bucket)
 
     await wait_until_all_complete(
@@ -1207,7 +1206,7 @@ async def create_csv_table_from_s3(
     iam_client_wrapper.has_athena_permissions(s3_output_bucket, output_key_arn)
 
     # Wait on all query execution IDs
-    s3_client = s3_client or boto3.client(SERVICE_S3)
+    s3_client = s3_client or ClientFactory().s3()
     bucket_name, bucket_prefix = split_s3_arn_to_bucket_and_path(s3_bucket)
 
     logger.debug(f"Inspecting files from {s3_bucket}")
@@ -1633,7 +1632,7 @@ def empty_s3_bucket(
 
     # Create S3 client if not provided
     if s3_client is None:
-        s3_client = boto3.client(SERVICE_S3)
+        s3_client = ClientFactory().s3()
 
     # Create IamClient using _get_or_create_clients
     iam_client_wrapper, _, _ = _get_or_create_clients(sts_client, iam_client, None)
@@ -1683,8 +1682,9 @@ def empty_s3_bucket(
 
 
 def validate_permissions():
-    user_arn = boto3.client(SERVICE_STS).get_caller_identity()["Arn"]
-    iam_client = IamClient(role_arn=user_arn, client=boto3.client(SERVICE_IAM))
+    factory = ClientFactory()
+    user_arn = factory.sts().get_caller_identity()["Arn"]
+    iam_client = IamClient(role_arn=user_arn, client=factory.iam())
 
     s3_import = os.getenv("NETWORKX_S3_IMPORT_BUCKET_PATH")
     s3_export = os.getenv("NETWORKX_S3_EXPORT_BUCKET_PATH")
@@ -1850,6 +1850,7 @@ def _get_or_create_clients(
     iam_client: Optional[BaseClient] = None,
     na_client: Optional[BaseClient] = None,
     athena_client: Optional[BaseClient] = None,
+    clients: Optional[ClientFactory] = None,
 ):
     """
     Create or reuse provided AWS clients.
@@ -1859,28 +1860,29 @@ def _get_or_create_clients(
         iam_client (Optional[BaseClient]): Optional IAM boto3 client
         na_client (Optional[BaseClient]): Optional Neptune Analytics boto3 client
         athena_client (Optional[BaseClient]): Optional Athena boto3 client
+        clients (Optional[ClientFactory]): Optional client factory for creating clients
 
     Returns:
         Tuple[IamClient, BaseClient, BaseClient]: Tuple containing (iam_client, na_client, athena_client)
     """
+    factory = clients or ClientFactory()
+
     if sts_client is None:
-        sts_client = boto3.client(SERVICE_STS)
+        sts_client = factory.sts()
     user_arn = sts_client.get_caller_identity()["Arn"]
 
     # Create IamClient
     if iam_client is None:
-        iam_client = boto3.client(SERVICE_IAM)
+        iam_client = factory.iam()
     iam_client_wrapper = IamClient(role_arn=user_arn, client=iam_client)
 
     # Create Neptune Analytics client if not provided
     if na_client is None:
-        na_client = boto3.client(
-            service_name=SERVICE_NA, config=Config(user_agent_appid=APP_ID_NX)
-        )
+        na_client = factory.neptune()
 
     # Create Athena client if not provided
     if athena_client is None:
-        athena_client = boto3.client(SERVICE_ATHENA)
+        athena_client = factory.athena()
 
     return iam_client_wrapper, na_client, athena_client
 
@@ -1920,7 +1922,7 @@ def execute_athena_query(
         Exception: If the query execution fails or times out
     """
     if client is None:
-        client = boto3.client("athena")
+        client = ClientFactory().athena()
     execution_id = _execute_athena_query(
         client, sql_statement, output_location, sql_parameters, catalog, database
     )
@@ -1953,7 +1955,7 @@ def get_athena_query_results(
         are not needed.
     """
     if client is None:
-        client = boto3.client("athena")
+        client = ClientFactory().athena()
 
     rows = []
     try:

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -13,14 +13,6 @@ from botocore.exceptions import ClientError
 from . import NeptuneGraph, instance_management
 from .clients import IamClient, NeptuneAnalyticsClient
 from .clients.client_factory import ClientFactory
-from .clients.neptune_constants import (
-    APP_ID_NX,
-    SERVICE_ATHENA,
-    SERVICE_IAM,
-    SERVICE_NA,
-    SERVICE_S3,
-    SERVICE_STS,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +47,7 @@ class SessionManager:
         """
         self.session_name = session_name
         self.cleanup_task = cleanup_task or CleanupTask.NONE
-        self._clients = clients or ClientFactory()
+        self._clients = clients or ClientFactory.default()
         self._neptune_client = self._clients.neptune()
         self._sts_client = self._clients.sts()
         self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -13,6 +13,7 @@ from botocore.exceptions import ClientError
 from . import NeptuneGraph, instance_management
 from .clients import IamClient, NeptuneAnalyticsClient
 from .clients.client_factory import ClientFactory
+from .clients.response_utils import sts_get_caller_arn
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class SessionManager:
         self._clients = ClientFactory.default()
         self._neptune_client = self._clients.neptune()
         self._sts_client = self._clients.sts()
-        self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]
+        self._s3_iam_role = sts_get_caller_arn(self._sts_client.get_caller_identity())
         self._iam_client = self._clients.iam()
         self._s3_client = self._clients.s3()
         self._athena_client = self._clients.athena()

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -34,7 +34,7 @@ class CleanupTask(Enum):
 class SessionManager:
     """Manages Neptune Analytics sessions and graph operations."""
 
-    def __init__(self, session_name=None, cleanup_task=None, clients=None):
+    def __init__(self, session_name=None, cleanup_task=None):
         """Initialize a SessionManager instance.
 
         Args:
@@ -43,11 +43,10 @@ class SessionManager:
               When set to DESTROY, will destroy all instances in the session on exit.
               When set to RESET, will reset all instances in the session on exit.
               When set to STOP, will stop all instances in the session on exit.
-            clients (ClientFactory, optional): Factory for creating boto3 clients. If None, a default is created.
         """
         self.session_name = session_name
         self.cleanup_task = cleanup_task or CleanupTask.NONE
-        self._clients = clients or ClientFactory.default()
+        self._clients = ClientFactory.default()
         self._neptune_client = self._clients.neptune()
         self._sts_client = self._clients.sts()
         self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]

--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 
 from . import NeptuneGraph, instance_management
 from .clients import IamClient, NeptuneAnalyticsClient
+from .clients.client_factory import ClientFactory
 from .clients.neptune_constants import (
     APP_ID_NX,
     SERVICE_ATHENA,
@@ -41,7 +42,7 @@ class CleanupTask(Enum):
 class SessionManager:
     """Manages Neptune Analytics sessions and graph operations."""
 
-    def __init__(self, session_name=None, cleanup_task=None):
+    def __init__(self, session_name=None, cleanup_task=None, clients=None):
         """Initialize a SessionManager instance.
 
         Args:
@@ -50,17 +51,17 @@ class SessionManager:
               When set to DESTROY, will destroy all instances in the session on exit.
               When set to RESET, will reset all instances in the session on exit.
               When set to STOP, will stop all instances in the session on exit.
+            clients (ClientFactory, optional): Factory for creating boto3 clients. If None, a default is created.
         """
         self.session_name = session_name
         self.cleanup_task = cleanup_task or CleanupTask.NONE
-        self._neptune_client = boto3.client(
-            service_name=SERVICE_NA, config=Config(user_agent_appid=APP_ID_NX)
-        )
-        self._sts_client = boto3.client(SERVICE_STS)
+        self._clients = clients or ClientFactory()
+        self._neptune_client = self._clients.neptune()
+        self._sts_client = self._clients.sts()
         self._s3_iam_role = self._sts_client.get_caller_identity()["Arn"]
-        self._iam_client = boto3.client(SERVICE_IAM)
-        self._s3_client = boto3.client(SERVICE_S3)
-        self._athena_client = boto3.client(SERVICE_ATHENA)
+        self._iam_client = self._clients.iam()
+        self._s3_client = self._clients.s3()
+        self._athena_client = self._clients.athena()
 
     @classmethod
     def session(cls, session_name=None, cleanup_task=None):

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -7,9 +7,9 @@ Provides upfront checks for S3, Athena, and Neptune Analytics resources
 so configuration errors surface immediately — not minutes into a pipeline.
 """
 
+import asyncio
 import logging
 import re
-import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -32,6 +32,7 @@ from nx_neptune.clients.response_utils import (
     is_not_found,
     is_versioning_enabled,
 )
+from nx_neptune.utils.task_future import TaskType, wait_until_all_complete
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,9 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
         if is_not_found(e):
             return CheckResult.fail("s3_bucket_exists", f"Bucket '{bucket}' not found")
         if is_access_denied(e):
-            return CheckResult.fail("s3_bucket_exists", f"Access denied to bucket '{bucket}'")
+            return CheckResult.fail(
+                "s3_bucket_exists", f"Access denied to bucket '{bucket}'"
+            )
         return CheckResult.fail("s3_bucket_exists", str(e))
 
 
@@ -226,21 +229,20 @@ def check_athena_query(
                 ResultConfiguration={"OutputLocation": output_location},
             )["QueryExecutionId"]
 
-            while True:
-                resp = athena.get_query_execution(QueryExecutionId=exec_id)
-                state = get_query_state(resp)
-                if state == "SUCCEEDED":
-                    results = athena.get_query_results(
-                        QueryExecutionId=exec_id, MaxResults=1
-                    )
-                    all_columns.append(get_query_result_columns(results))
-                    break
-                if state in ("FAILED", "CANCELLED"):
-                    reason = get_query_failure_reason(resp)
-                    return CheckResult.fail(
-                        "athena_query", f"Query {i+1} failed: {reason}"
-                    )
-                time.sleep(1)
+            asyncio.run(
+                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena)
+            )
+
+            resp = athena.get_query_execution(QueryExecutionId=exec_id)
+            state = get_query_state(resp)
+            if state != "SUCCEEDED":
+                return CheckResult.fail(
+                    "athena_query",
+                    f"Query {i+1} failed: {get_query_failure_reason(resp)}",
+                )
+
+            results = athena.get_query_results(QueryExecutionId=exec_id, MaxResults=1)
+            all_columns.append(get_query_result_columns(results))
 
         for i, columns in enumerate(all_columns):
             if "~id" not in columns:

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -16,6 +16,19 @@ from typing import Optional
 from botocore.exceptions import ClientError
 
 from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune.clients.response_utils import (
+    get_bucket_region,
+    get_caller_arn,
+    get_graph_names,
+    get_kms_key_id,
+    get_object_count,
+    get_query_failure_reason,
+    get_query_result_columns,
+    get_query_state,
+    get_table_columns,
+    is_kms_encrypted,
+    is_versioning_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +87,7 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
-        location = (
-            resp.get("LocationConstraint") or "us-east-1"
-        )  # S3 API returns None for us-east-1
+        location = get_bucket_region(resp)
         if location == expected_region:
             return CheckResult.ok(
                 "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"
@@ -94,12 +105,10 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_encryption(Bucket=bucket)
-        rules = resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", [])
-        for rule in rules:
-            sse = rule.get("ApplyServerSideEncryptionByDefault", {})
-            if sse.get("SSEAlgorithm") == "aws:kms":
-                key = sse.get("KMSMasterKeyID", "AWS managed key")
-                return CheckResult.ok("s3_bucket_encryption", f"KMS encryption: {key}")
+        if is_kms_encrypted(resp):
+            return CheckResult.ok(
+                "s3_bucket_encryption", f"KMS encryption: {get_kms_key_id(resp)}"
+            )
         return CheckResult.fail(
             "s3_bucket_encryption", f"Bucket '{bucket}' does not use KMS encryption"
         )
@@ -116,8 +125,7 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
-        status = resp.get("Status", "Disabled")
-        if status == "Enabled":
+        if is_versioning_enabled(resp):
             return CheckResult.ok(
                 "s3_bucket_versioning", f"Versioning enabled on '{bucket}'"
             )
@@ -138,7 +146,7 @@ def check_path_empty(s3_uri: str) -> CheckResult:
             .s3()
             .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         )
-        if resp.get("KeyCount", 0) == 0:
+        if get_object_count(resp) == 0:
             return CheckResult.ok("s3_path_empty", f"Path '{s3_uri}' is empty")
         return CheckResult.fail(
             "s3_path_empty",
@@ -183,11 +191,10 @@ def check_athena_table(
                 CatalogName=catalog, DatabaseName=database, TableName=table
             )
         )
-        columns = resp["TableMetadata"].get("Columns", [])
-        col_names = [c["Name"] for c in columns]
+        col_names = get_table_columns(resp)
         return CheckResult.ok(
             "athena_table",
-            f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
+            f"Table '{table}' found with {len(col_names)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
@@ -221,21 +228,15 @@ def check_athena_query(
 
             while True:
                 resp = athena.get_query_execution(QueryExecutionId=exec_id)
-                state = resp["QueryExecution"]["Status"]["State"]
+                state = get_query_state(resp)
                 if state == "SUCCEEDED":
                     results = athena.get_query_results(
                         QueryExecutionId=exec_id, MaxResults=1
                     )
-                    columns = [
-                        c["Name"]
-                        for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
-                    ]
-                    all_columns.append(columns)
+                    all_columns.append(get_query_result_columns(results))
                     break
                 if state in ("FAILED", "CANCELLED"):
-                    reason = resp["QueryExecution"]["Status"].get(
-                        "StateChangeReason", "Unknown error"
-                    )
+                    reason = get_query_failure_reason(resp)
                     return CheckResult.fail(
                         "athena_query", f"Query {i+1} failed: {reason}"
                     )
@@ -264,7 +265,7 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
     """Check that no existing graph uses this name."""
     try:
         resp = ClientFactory.default().neptune().list_graphs()
-        for g in resp.get("graphs", []):
+        for g in get_graph_names(resp):
             if g["name"] == graph_name:
                 return CheckResult.fail(
                     "graph_name_available",
@@ -283,8 +284,8 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
 def check_credentials() -> CheckResult:
     """Check that AWS credentials are valid."""
     try:
-        identity = ClientFactory.default().sts().get_caller_identity()
-        return CheckResult.ok("credentials", f"Resolved as {identity['Arn']}")
+        resp = ClientFactory.default().sts().get_caller_identity()
+        return CheckResult.ok("credentials", f"Resolved as {get_caller_arn(resp)}")
     except Exception as e:
         return CheckResult.fail("credentials", f"Cannot resolve credentials: {e}")
 

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -17,20 +17,20 @@ from botocore.exceptions import ClientError
 
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune.clients.response_utils import (
-    get_bucket_region,
-    get_caller_arn,
-    get_graph_names,
-    get_kms_key_id,
-    get_object_count,
-    get_query_failure_reason,
-    get_query_result_columns,
-    get_query_state,
-    get_table_columns,
-    is_access_denied,
-    is_entity_not_found,
-    is_kms_encrypted,
-    is_not_found,
-    is_versioning_enabled,
+    athena_get_query_failure_reason,
+    athena_get_query_result_columns,
+    athena_get_query_state,
+    athena_get_table_columns,
+    athena_is_entity_not_found,
+    boto_is_access_denied,
+    boto_is_not_found,
+    na_get_graph_names,
+    s3_get_bucket_region,
+    s3_get_kms_key_id,
+    s3_get_object_count,
+    s3_is_kms_encrypted,
+    s3_is_versioning_enabled,
+    sts_get_caller_arn,
 )
 from nx_neptune.utils.task_future import TaskType, wait_until_all_complete
 
@@ -76,9 +76,9 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
         ClientFactory.default().s3().head_bucket(Bucket=bucket)
         return CheckResult.ok("s3_bucket_exists", f"Bucket '{bucket}' exists")
     except ClientError as e:
-        if is_not_found(e):
+        if boto_is_not_found(e):
             return CheckResult.fail("s3_bucket_exists", f"Bucket '{bucket}' not found")
-        if is_access_denied(e):
+        if boto_is_access_denied(e):
             return CheckResult.fail(
                 "s3_bucket_exists", f"Access denied to bucket '{bucket}'"
             )
@@ -90,7 +90,7 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
-        location = get_bucket_region(resp)
+        location = s3_get_bucket_region(resp)
         if location == expected_region:
             return CheckResult.ok(
                 "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"
@@ -108,9 +108,9 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_encryption(Bucket=bucket)
-        if is_kms_encrypted(resp):
+        if s3_is_kms_encrypted(resp):
             return CheckResult.ok(
-                "s3_bucket_encryption", f"KMS encryption: {get_kms_key_id(resp)}"
+                "s3_bucket_encryption", f"KMS encryption: {s3_get_kms_key_id(resp)}"
             )
         return CheckResult.fail(
             "s3_bucket_encryption", f"Bucket '{bucket}' does not use KMS encryption"
@@ -128,7 +128,7 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
-        if is_versioning_enabled(resp):
+        if s3_is_versioning_enabled(resp):
             return CheckResult.ok(
                 "s3_bucket_versioning", f"Versioning enabled on '{bucket}'"
             )
@@ -149,7 +149,7 @@ def check_path_empty(s3_uri: str) -> CheckResult:
             .s3()
             .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         )
-        if get_object_count(resp) == 0:
+        if s3_get_object_count(resp) == 0:
             return CheckResult.ok("s3_path_empty", f"Path '{s3_uri}' is empty")
         return CheckResult.fail(
             "s3_path_empty",
@@ -174,7 +174,7 @@ def check_athena_database(
             "athena_database", f"Database '{database}' found in catalog '{catalog}'"
         )
     except ClientError as e:
-        if is_entity_not_found(e):
+        if athena_is_entity_not_found(e):
             return CheckResult.fail(
                 "athena_database",
                 f"Database '{database}' not found in catalog '{catalog}'",
@@ -194,13 +194,13 @@ def check_athena_table(
                 CatalogName=catalog, DatabaseName=database, TableName=table
             )
         )
-        col_names = get_table_columns(resp)
+        col_names = athena_get_table_columns(resp)
         return CheckResult.ok(
             "athena_table",
             f"Table '{table}' found with {len(col_names)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
-        if is_entity_not_found(e):
+        if athena_is_entity_not_found(e):
             return CheckResult.fail(
                 "athena_table", f"Table '{table}' not found in '{database}'"
             )
@@ -234,15 +234,15 @@ def check_athena_query(
             )
 
             resp = athena.get_query_execution(QueryExecutionId=exec_id)
-            state = get_query_state(resp)
+            state = athena_get_query_state(resp)
             if state != "SUCCEEDED":
                 return CheckResult.fail(
                     "athena_query",
-                    f"Query {i+1} failed: {get_query_failure_reason(resp)}",
+                    f"Query {i+1} failed: {athena_get_query_failure_reason(resp)}",
                 )
 
             results = athena.get_query_results(QueryExecutionId=exec_id, MaxResults=1)
-            all_columns.append(get_query_result_columns(results))
+            all_columns.append(athena_get_query_result_columns(results))
 
         for i, columns in enumerate(all_columns):
             if "~id" not in columns:
@@ -267,7 +267,7 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
     """Check that no existing graph uses this name."""
     try:
         resp = ClientFactory.default().neptune().list_graphs()
-        for g in get_graph_names(resp):
+        for g in na_get_graph_names(resp):
             if g["name"] == graph_name:
                 return CheckResult.fail(
                     "graph_name_available",
@@ -287,7 +287,7 @@ def check_credentials() -> CheckResult:
     """Check that AWS credentials are valid."""
     try:
         resp = ClientFactory.default().sts().get_caller_identity()
-        return CheckResult.ok("credentials", f"Resolved as {get_caller_arn(resp)}")
+        return CheckResult.ok("credentials", f"Resolved as {sts_get_caller_arn(resp)}")
     except Exception as e:
         return CheckResult.fail("credentials", f"Cannot resolve credentials: {e}")
 

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -1,0 +1,295 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resource validation for nx-neptune migrations.
+
+Provides upfront checks for S3, Athena, and Neptune Analytics resources
+so configuration errors surface immediately — not minutes into a pipeline.
+"""
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from botocore.exceptions import ClientError
+
+from nx_neptune.clients.client_factory import ClientFactory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CheckResult:
+    check: str
+    passed: bool
+    message: str
+
+    def to_dict(self) -> dict:
+        return {"check": self.check, "passed": self.passed, "message": self.message}
+
+
+def _parse_bucket(s3_uri: str) -> str:
+    """Extract bucket name from s3://bucket/path/."""
+    return s3_uri.replace("s3://", "").split("/")[0]
+
+
+def _parse_prefix(s3_uri: str) -> str:
+    """Extract prefix from s3://bucket/prefix/."""
+    parts = s3_uri.replace("s3://", "").split("/", 1)
+    return parts[1] if len(parts) > 1 else ""
+
+
+# --- S3 checks ---
+
+
+def check_bucket_exists(s3_uri: str) -> CheckResult:
+    """Check that the S3 bucket exists and is accessible."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        ClientFactory.default().s3().head_bucket(Bucket=bucket)
+        return CheckResult("s3_bucket_exists", True, f"Bucket '{bucket}' exists")
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "404":
+            return CheckResult("s3_bucket_exists", False, f"Bucket '{bucket}' not found")
+        if code == "403":
+            return CheckResult("s3_bucket_exists", False, f"Access denied to bucket '{bucket}'")
+        return CheckResult("s3_bucket_exists", False, str(e))
+
+
+def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
+    """Check that the bucket is in the expected region."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
+        location = resp.get("LocationConstraint") or "us-east-1"
+        if location == expected_region:
+            return CheckResult("s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}")
+        return CheckResult(
+            "s3_bucket_region", False,
+            f"Bucket '{bucket}' is in {location}, expected {expected_region}",
+        )
+    except ClientError as e:
+        return CheckResult("s3_bucket_region", False, str(e))
+
+
+def check_bucket_encryption(s3_uri: str) -> CheckResult:
+    """Check that the bucket has KMS encryption configured."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().get_bucket_encryption(Bucket=bucket)
+        rules = resp.get("ServerSideEncryptionConfiguration", {}).get("Rules", [])
+        for rule in rules:
+            sse = rule.get("ApplyServerSideEncryptionByDefault", {})
+            if sse.get("SSEAlgorithm") == "aws:kms":
+                key = sse.get("KMSMasterKeyID", "AWS managed key")
+                return CheckResult("s3_bucket_encryption", True, f"KMS encryption: {key}")
+        return CheckResult(
+            "s3_bucket_encryption", False,
+            f"Bucket '{bucket}' does not use KMS encryption",
+        )
+    except ClientError as e:
+        if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
+            return CheckResult(
+                "s3_bucket_encryption", False,
+                f"No encryption configured on bucket '{bucket}'",
+            )
+        return CheckResult("s3_bucket_encryption", False, str(e))
+
+
+def check_bucket_versioning(s3_uri: str) -> CheckResult:
+    """Check that the bucket has versioning enabled."""
+    bucket = _parse_bucket(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
+        status = resp.get("Status", "Disabled")
+        if status == "Enabled":
+            return CheckResult("s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'")
+        return CheckResult(
+            "s3_bucket_versioning", False,
+            f"Versioning not enabled on '{bucket}'",
+        )
+    except ClientError as e:
+        return CheckResult("s3_bucket_versioning", False, str(e))
+
+
+def check_path_empty(s3_uri: str) -> CheckResult:
+    """Check that the S3 path has no existing objects."""
+    bucket = _parse_bucket(s3_uri)
+    prefix = _parse_prefix(s3_uri)
+    try:
+        resp = ClientFactory.default().s3().list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        if resp.get("KeyCount", 0) == 0:
+            return CheckResult("s3_path_empty", True, f"Path '{s3_uri}' is empty")
+        return CheckResult(
+            "s3_path_empty", False,
+            f"Path '{s3_uri}' is not empty — leftover files may cause issues",
+        )
+    except ClientError as e:
+        return CheckResult("s3_path_empty", False, str(e))
+
+
+# --- Athena checks ---
+
+
+def check_athena_database(catalog: str, database: str) -> CheckResult:
+    """Check that the Athena database exists."""
+    try:
+        ClientFactory.default().athena().get_database(CatalogName=catalog, DatabaseName=database)
+        return CheckResult("athena_database", True, f"Database '{database}' found in catalog '{catalog}'")
+    except ClientError as e:
+        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+            return CheckResult("athena_database", False, f"Database '{database}' not found in catalog '{catalog}'")
+        return CheckResult("athena_database", False, str(e))
+
+
+def check_athena_table(catalog: str, database: str, table: str) -> CheckResult:
+    """Check that the Athena table exists and return its columns."""
+    try:
+        resp = ClientFactory.default().athena().get_table_metadata(
+            CatalogName=catalog, DatabaseName=database, TableName=table
+        )
+        columns = resp["TableMetadata"].get("Columns", [])
+        col_names = [c["Name"] for c in columns]
+        return CheckResult(
+            "athena_table", True,
+            f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
+        )
+    except ClientError as e:
+        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+            return CheckResult("athena_table", False, f"Table '{table}' not found in '{database}'")
+        return CheckResult("athena_table", False, str(e))
+
+
+def check_athena_query(
+    sql_query: str, catalog: str, database: str, output_location: str
+) -> CheckResult:
+    """Validate SQL query by running with LIMIT 0 and checking required columns."""
+    queries = [q.strip() for q in sql_query.split(";") if q.strip()]
+    all_columns: list[list[str]] = []
+
+    try:
+        athena = ClientFactory.default().athena()
+
+        for i, q in enumerate(queries):
+            stripped = re.sub(r'\s+LIMIT\s+\d+\s*$', '', q.rstrip(), flags=re.IGNORECASE)
+            wrapped = f"{stripped} LIMIT 0"
+
+            exec_id = athena.start_query_execution(
+                QueryString=wrapped,
+                QueryExecutionContext={"Catalog": catalog, "Database": database},
+                ResultConfiguration={"OutputLocation": output_location},
+            )["QueryExecutionId"]
+
+            while True:
+                resp = athena.get_query_execution(QueryExecutionId=exec_id)
+                state = resp["QueryExecution"]["Status"]["State"]
+                if state == "SUCCEEDED":
+                    results = athena.get_query_results(QueryExecutionId=exec_id, MaxResults=1)
+                    columns = [c["Name"] for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
+                    all_columns.append(columns)
+                    break
+                if state in ("FAILED", "CANCELLED"):
+                    reason = resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error")
+                    return CheckResult("athena_query", False, f"Query {i+1} failed: {reason}")
+                time.sleep(1)
+
+        for i, columns in enumerate(all_columns):
+            if "~id" not in columns:
+                return CheckResult(
+                    "athena_query", False,
+                    f"Query {i+1} missing required '~id' column. Got: {', '.join(columns)}",
+                )
+
+        combined = [c for cols in all_columns for c in cols]
+        return CheckResult("athena_query", True, f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}")
+    except ClientError as e:
+        return CheckResult("athena_query", False, str(e))
+
+
+# --- Neptune Analytics checks ---
+
+
+def check_graph_name_available(graph_name: str) -> CheckResult:
+    """Check that no existing graph uses this name prefix."""
+    try:
+        resp = ClientFactory.default().neptune().list_graphs()
+        for g in resp.get("graphs", []):
+            if g["name"].startswith(graph_name):
+                return CheckResult(
+                    "graph_name_available", False,
+                    f"Graph '{g['name']}' ({g['id']}) already exists with this prefix",
+                )
+        return CheckResult("graph_name_available", True, f"No existing graph named '{graph_name}'")
+    except ClientError as e:
+        return CheckResult("graph_name_available", False, str(e))
+
+
+# --- Credentials check ---
+
+
+def check_credentials() -> CheckResult:
+    """Check that AWS credentials are valid."""
+    try:
+        identity = ClientFactory.default().sts().get_caller_identity()
+        return CheckResult("credentials", True, f"Resolved as {identity['Arn']}")
+    except Exception as e:
+        return CheckResult("credentials", False, f"Cannot resolve credentials: {e}")
+
+
+# --- Orchestrator ---
+
+
+def validate_resources(
+    s3_staging_bucket: Optional[str] = None,
+    athena_output_bucket: Optional[str] = None,
+    athena_catalog: str = "AwsDataCatalog",
+    athena_database: Optional[str] = None,
+    athena_table: Optional[str] = None,
+    sql_query: Optional[str] = None,
+    graph_name: Optional[str] = None,
+    expected_region: Optional[str] = None,
+) -> list[dict]:
+    """Run all applicable validation checks and return results.
+
+    Only validates resources that are provided — no false errors for unused features.
+    """
+    results: list[CheckResult] = []
+
+    # Always check credentials first
+    cred_check = check_credentials()
+    results.append(cred_check)
+    if not cred_check.passed:
+        return [r.to_dict() for r in results]
+
+    # S3 staging bucket
+    if s3_staging_bucket:
+        results.append(check_bucket_exists(s3_staging_bucket))
+        if expected_region:
+            results.append(check_bucket_region(s3_staging_bucket, expected_region))
+        results.append(check_bucket_versioning(s3_staging_bucket))
+
+    # Athena output bucket
+    if athena_output_bucket:
+        results.append(check_bucket_exists(athena_output_bucket))
+        if expected_region:
+            results.append(check_bucket_region(athena_output_bucket, expected_region))
+        results.append(check_path_empty(athena_output_bucket))
+
+    # Athena database/table
+    if athena_database:
+        results.append(check_athena_database(athena_catalog, athena_database))
+        if athena_table:
+            results.append(check_athena_table(athena_catalog, athena_database, athena_table))
+
+    # Athena query validation
+    if sql_query and athena_database and s3_staging_bucket:
+        results.append(check_athena_query(sql_query, athena_catalog, athena_database, s3_staging_bucket))
+
+    # Graph name
+    if graph_name:
+        results.append(check_graph_name_available(graph_name))
+
+    return [r.to_dict() for r in results]

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -26,7 +26,10 @@ from nx_neptune.clients.response_utils import (
     get_query_result_columns,
     get_query_state,
     get_table_columns,
+    is_access_denied,
+    is_entity_not_found,
     is_kms_encrypted,
+    is_not_found,
     is_versioning_enabled,
 )
 
@@ -72,13 +75,10 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
         ClientFactory.default().s3().head_bucket(Bucket=bucket)
         return CheckResult.ok("s3_bucket_exists", f"Bucket '{bucket}' exists")
     except ClientError as e:
-        code = e.response["Error"]["Code"]
-        if code == "404":
+        if is_not_found(e):
             return CheckResult.fail("s3_bucket_exists", f"Bucket '{bucket}' not found")
-        if code == "403":
-            return CheckResult.fail(
-                "s3_bucket_exists", f"Access denied to bucket '{bucket}'"
-            )
+        if is_access_denied(e):
+            return CheckResult.fail("s3_bucket_exists", f"Access denied to bucket '{bucket}'")
         return CheckResult.fail("s3_bucket_exists", str(e))
 
 
@@ -171,7 +171,7 @@ def check_athena_database(
             "athena_database", f"Database '{database}' found in catalog '{catalog}'"
         )
     except ClientError as e:
-        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+        if is_entity_not_found(e):
             return CheckResult.fail(
                 "athena_database",
                 f"Database '{database}' not found in catalog '{catalog}'",
@@ -197,7 +197,7 @@ def check_athena_table(
             f"Table '{table}' found with {len(col_names)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
-        if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
+        if is_entity_not_found(e):
             return CheckResult.fail(
                 "athena_table", f"Table '{table}' not found in '{database}'"
             )

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -53,9 +53,13 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
     except ClientError as e:
         code = e.response["Error"]["Code"]
         if code == "404":
-            return CheckResult("s3_bucket_exists", False, f"Bucket '{bucket}' not found")
+            return CheckResult(
+                "s3_bucket_exists", False, f"Bucket '{bucket}' not found"
+            )
         if code == "403":
-            return CheckResult("s3_bucket_exists", False, f"Access denied to bucket '{bucket}'")
+            return CheckResult(
+                "s3_bucket_exists", False, f"Access denied to bucket '{bucket}'"
+            )
         return CheckResult("s3_bucket_exists", False, str(e))
 
 
@@ -64,11 +68,16 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         resp = ClientFactory.default().s3().get_bucket_location(Bucket=bucket)
-        location = resp.get("LocationConstraint") or "us-east-1"
+        location = (
+            resp.get("LocationConstraint") or "us-east-1"
+        )  # S3 API returns None for us-east-1
         if location == expected_region:
-            return CheckResult("s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}")
+            return CheckResult(
+                "s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}"
+            )
         return CheckResult(
-            "s3_bucket_region", False,
+            "s3_bucket_region",
+            False,
             f"Bucket '{bucket}' is in {location}, expected {expected_region}",
         )
     except ClientError as e:
@@ -85,15 +94,19 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
             sse = rule.get("ApplyServerSideEncryptionByDefault", {})
             if sse.get("SSEAlgorithm") == "aws:kms":
                 key = sse.get("KMSMasterKeyID", "AWS managed key")
-                return CheckResult("s3_bucket_encryption", True, f"KMS encryption: {key}")
+                return CheckResult(
+                    "s3_bucket_encryption", True, f"KMS encryption: {key}"
+                )
         return CheckResult(
-            "s3_bucket_encryption", False,
+            "s3_bucket_encryption",
+            False,
             f"Bucket '{bucket}' does not use KMS encryption",
         )
     except ClientError as e:
         if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
             return CheckResult(
-                "s3_bucket_encryption", False,
+                "s3_bucket_encryption",
+                False,
                 f"No encryption configured on bucket '{bucket}'",
             )
         return CheckResult("s3_bucket_encryption", False, str(e))
@@ -106,9 +119,12 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
         status = resp.get("Status", "Disabled")
         if status == "Enabled":
-            return CheckResult("s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'")
+            return CheckResult(
+                "s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'"
+            )
         return CheckResult(
-            "s3_bucket_versioning", False,
+            "s3_bucket_versioning",
+            False,
             f"Versioning not enabled on '{bucket}'",
         )
     except ClientError as e:
@@ -120,11 +136,16 @@ def check_path_empty(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     prefix = _parse_prefix(s3_uri)
     try:
-        resp = ClientFactory.default().s3().list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        resp = (
+            ClientFactory.default()
+            .s3()
+            .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        )
         if resp.get("KeyCount", 0) == 0:
             return CheckResult("s3_path_empty", True, f"Path '{s3_uri}' is empty")
         return CheckResult(
-            "s3_path_empty", False,
+            "s3_path_empty",
+            False,
             f"Path '{s3_uri}' is not empty — leftover files may cause issues",
         )
     except ClientError as e:
@@ -134,37 +155,58 @@ def check_path_empty(s3_uri: str) -> CheckResult:
 # --- Athena checks ---
 
 
-def check_athena_database(catalog: str, database: str) -> CheckResult:
+def check_athena_database(
+    database: str, catalog: str = "AwsDataCatalog"
+) -> CheckResult:
     """Check that the Athena database exists."""
     try:
-        ClientFactory.default().athena().get_database(CatalogName=catalog, DatabaseName=database)
-        return CheckResult("athena_database", True, f"Database '{database}' found in catalog '{catalog}'")
+        ClientFactory.default().athena().get_database(
+            CatalogName=catalog, DatabaseName=database
+        )
+        return CheckResult(
+            "athena_database",
+            True,
+            f"Database '{database}' found in catalog '{catalog}'",
+        )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult("athena_database", False, f"Database '{database}' not found in catalog '{catalog}'")
+            return CheckResult(
+                "athena_database",
+                False,
+                f"Database '{database}' not found in catalog '{catalog}'",
+            )
         return CheckResult("athena_database", False, str(e))
 
 
-def check_athena_table(catalog: str, database: str, table: str) -> CheckResult:
+def check_athena_table(
+    database: str, table: str, catalog: str = "AwsDataCatalog"
+) -> CheckResult:
     """Check that the Athena table exists and return its columns."""
     try:
-        resp = ClientFactory.default().athena().get_table_metadata(
-            CatalogName=catalog, DatabaseName=database, TableName=table
+        resp = (
+            ClientFactory.default()
+            .athena()
+            .get_table_metadata(
+                CatalogName=catalog, DatabaseName=database, TableName=table
+            )
         )
         columns = resp["TableMetadata"].get("Columns", [])
         col_names = [c["Name"] for c in columns]
         return CheckResult(
-            "athena_table", True,
+            "athena_table",
+            True,
             f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult("athena_table", False, f"Table '{table}' not found in '{database}'")
+            return CheckResult(
+                "athena_table", False, f"Table '{table}' not found in '{database}'"
+            )
         return CheckResult("athena_table", False, str(e))
 
 
 def check_athena_query(
-    sql_query: str, catalog: str, database: str, output_location: str
+    sql_query: str, database: str, output_location: str, catalog: str = "AwsDataCatalog"
 ) -> CheckResult:
     """Validate SQL query by running with LIMIT 0 and checking required columns."""
     queries = [q.strip() for q in sql_query.split(";") if q.strip()]
@@ -174,7 +216,9 @@ def check_athena_query(
         athena = ClientFactory.default().athena()
 
         for i, q in enumerate(queries):
-            stripped = re.sub(r'\s+LIMIT\s+\d+\s*$', '', q.rstrip(), flags=re.IGNORECASE)
+            stripped = re.sub(
+                r"\s+LIMIT\s+\d+\s*$", "", q.rstrip(), flags=re.IGNORECASE
+            )
             wrapped = f"{stripped} LIMIT 0"
 
             exec_id = athena.start_query_execution(
@@ -187,24 +231,38 @@ def check_athena_query(
                 resp = athena.get_query_execution(QueryExecutionId=exec_id)
                 state = resp["QueryExecution"]["Status"]["State"]
                 if state == "SUCCEEDED":
-                    results = athena.get_query_results(QueryExecutionId=exec_id, MaxResults=1)
-                    columns = [c["Name"] for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
+                    results = athena.get_query_results(
+                        QueryExecutionId=exec_id, MaxResults=1
+                    )
+                    columns = [
+                        c["Name"]
+                        for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
+                    ]
                     all_columns.append(columns)
                     break
                 if state in ("FAILED", "CANCELLED"):
-                    reason = resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error")
-                    return CheckResult("athena_query", False, f"Query {i+1} failed: {reason}")
+                    reason = resp["QueryExecution"]["Status"].get(
+                        "StateChangeReason", "Unknown error"
+                    )
+                    return CheckResult(
+                        "athena_query", False, f"Query {i+1} failed: {reason}"
+                    )
                 time.sleep(1)
 
         for i, columns in enumerate(all_columns):
             if "~id" not in columns:
                 return CheckResult(
-                    "athena_query", False,
+                    "athena_query",
+                    False,
                     f"Query {i+1} missing required '~id' column. Got: {', '.join(columns)}",
                 )
 
         combined = [c for cols in all_columns for c in cols]
-        return CheckResult("athena_query", True, f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}")
+        return CheckResult(
+            "athena_query",
+            True,
+            f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}",
+        )
     except ClientError as e:
         return CheckResult("athena_query", False, str(e))
 
@@ -213,16 +271,19 @@ def check_athena_query(
 
 
 def check_graph_name_available(graph_name: str) -> CheckResult:
-    """Check that no existing graph uses this name prefix."""
+    """Check that no existing graph uses this name."""
     try:
         resp = ClientFactory.default().neptune().list_graphs()
         for g in resp.get("graphs", []):
-            if g["name"].startswith(graph_name):
+            if g["name"] == graph_name:
                 return CheckResult(
-                    "graph_name_available", False,
-                    f"Graph '{g['name']}' ({g['id']}) already exists with this prefix",
+                    "graph_name_available",
+                    False,
+                    f"Graph '{g['name']}' ({g['id']}) already exists",
                 )
-        return CheckResult("graph_name_available", True, f"No existing graph named '{graph_name}'")
+        return CheckResult(
+            "graph_name_available", True, f"No existing graph named '{graph_name}'"
+        )
     except ClientError as e:
         return CheckResult("graph_name_available", False, str(e))
 
@@ -280,13 +341,19 @@ def validate_resources(
 
     # Athena database/table
     if athena_database:
-        results.append(check_athena_database(athena_catalog, athena_database))
+        results.append(check_athena_database(athena_database, athena_catalog))
         if athena_table:
-            results.append(check_athena_table(athena_catalog, athena_database, athena_table))
+            results.append(
+                check_athena_table(athena_database, athena_table, athena_catalog)
+            )
 
     # Athena query validation
     if sql_query and athena_database and s3_staging_bucket:
-        results.append(check_athena_query(sql_query, athena_catalog, athena_database, s3_staging_bucket))
+        results.append(
+            check_athena_query(
+                sql_query, athena_database, s3_staging_bucket, athena_catalog
+            )
+        )
 
     # Graph name
     if graph_name:

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -26,6 +26,14 @@ class CheckResult:
     passed: bool
     message: str
 
+    @classmethod
+    def ok(cls, check: str, msg: str) -> "CheckResult":
+        return cls(check, True, msg)
+
+    @classmethod
+    def fail(cls, check: str, msg: str) -> "CheckResult":
+        return cls(check, False, msg)
+
     def to_dict(self) -> dict:
         return {"check": self.check, "passed": self.passed, "message": self.message}
 
@@ -49,18 +57,16 @@ def check_bucket_exists(s3_uri: str) -> CheckResult:
     bucket = _parse_bucket(s3_uri)
     try:
         ClientFactory.default().s3().head_bucket(Bucket=bucket)
-        return CheckResult("s3_bucket_exists", True, f"Bucket '{bucket}' exists")
+        return CheckResult.ok("s3_bucket_exists", f"Bucket '{bucket}' exists")
     except ClientError as e:
         code = e.response["Error"]["Code"]
         if code == "404":
-            return CheckResult(
-                "s3_bucket_exists", False, f"Bucket '{bucket}' not found"
-            )
+            return CheckResult.fail("s3_bucket_exists", f"Bucket '{bucket}' not found")
         if code == "403":
-            return CheckResult(
-                "s3_bucket_exists", False, f"Access denied to bucket '{bucket}'"
+            return CheckResult.fail(
+                "s3_bucket_exists", f"Access denied to bucket '{bucket}'"
             )
-        return CheckResult("s3_bucket_exists", False, str(e))
+        return CheckResult.fail("s3_bucket_exists", str(e))
 
 
 def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
@@ -72,16 +78,15 @@ def check_bucket_region(s3_uri: str, expected_region: str) -> CheckResult:
             resp.get("LocationConstraint") or "us-east-1"
         )  # S3 API returns None for us-east-1
         if location == expected_region:
-            return CheckResult(
-                "s3_bucket_region", True, f"Bucket '{bucket}' is in {expected_region}"
+            return CheckResult.ok(
+                "s3_bucket_region", f"Bucket '{bucket}' is in {expected_region}"
             )
-        return CheckResult(
+        return CheckResult.fail(
             "s3_bucket_region",
-            False,
             f"Bucket '{bucket}' is in {location}, expected {expected_region}",
         )
     except ClientError as e:
-        return CheckResult("s3_bucket_region", False, str(e))
+        return CheckResult.fail("s3_bucket_region", str(e))
 
 
 def check_bucket_encryption(s3_uri: str) -> CheckResult:
@@ -94,22 +99,16 @@ def check_bucket_encryption(s3_uri: str) -> CheckResult:
             sse = rule.get("ApplyServerSideEncryptionByDefault", {})
             if sse.get("SSEAlgorithm") == "aws:kms":
                 key = sse.get("KMSMasterKeyID", "AWS managed key")
-                return CheckResult(
-                    "s3_bucket_encryption", True, f"KMS encryption: {key}"
-                )
-        return CheckResult(
-            "s3_bucket_encryption",
-            False,
-            f"Bucket '{bucket}' does not use KMS encryption",
+                return CheckResult.ok("s3_bucket_encryption", f"KMS encryption: {key}")
+        return CheckResult.fail(
+            "s3_bucket_encryption", f"Bucket '{bucket}' does not use KMS encryption"
         )
     except ClientError as e:
         if "ServerSideEncryptionConfigurationNotFoundError" in str(e):
-            return CheckResult(
-                "s3_bucket_encryption",
-                False,
-                f"No encryption configured on bucket '{bucket}'",
+            return CheckResult.fail(
+                "s3_bucket_encryption", f"No encryption configured on bucket '{bucket}'"
             )
-        return CheckResult("s3_bucket_encryption", False, str(e))
+        return CheckResult.fail("s3_bucket_encryption", str(e))
 
 
 def check_bucket_versioning(s3_uri: str) -> CheckResult:
@@ -119,16 +118,14 @@ def check_bucket_versioning(s3_uri: str) -> CheckResult:
         resp = ClientFactory.default().s3().get_bucket_versioning(Bucket=bucket)
         status = resp.get("Status", "Disabled")
         if status == "Enabled":
-            return CheckResult(
-                "s3_bucket_versioning", True, f"Versioning enabled on '{bucket}'"
+            return CheckResult.ok(
+                "s3_bucket_versioning", f"Versioning enabled on '{bucket}'"
             )
-        return CheckResult(
-            "s3_bucket_versioning",
-            False,
-            f"Versioning not enabled on '{bucket}'",
+        return CheckResult.fail(
+            "s3_bucket_versioning", f"Versioning not enabled on '{bucket}'"
         )
     except ClientError as e:
-        return CheckResult("s3_bucket_versioning", False, str(e))
+        return CheckResult.fail("s3_bucket_versioning", str(e))
 
 
 def check_path_empty(s3_uri: str) -> CheckResult:
@@ -142,14 +139,13 @@ def check_path_empty(s3_uri: str) -> CheckResult:
             .list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         )
         if resp.get("KeyCount", 0) == 0:
-            return CheckResult("s3_path_empty", True, f"Path '{s3_uri}' is empty")
-        return CheckResult(
+            return CheckResult.ok("s3_path_empty", f"Path '{s3_uri}' is empty")
+        return CheckResult.fail(
             "s3_path_empty",
-            False,
             f"Path '{s3_uri}' is not empty — leftover files may cause issues",
         )
     except ClientError as e:
-        return CheckResult("s3_path_empty", False, str(e))
+        return CheckResult.fail("s3_path_empty", str(e))
 
 
 # --- Athena checks ---
@@ -163,19 +159,16 @@ def check_athena_database(
         ClientFactory.default().athena().get_database(
             CatalogName=catalog, DatabaseName=database
         )
-        return CheckResult(
-            "athena_database",
-            True,
-            f"Database '{database}' found in catalog '{catalog}'",
+        return CheckResult.ok(
+            "athena_database", f"Database '{database}' found in catalog '{catalog}'"
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult(
+            return CheckResult.fail(
                 "athena_database",
-                False,
                 f"Database '{database}' not found in catalog '{catalog}'",
             )
-        return CheckResult("athena_database", False, str(e))
+        return CheckResult.fail("athena_database", str(e))
 
 
 def check_athena_table(
@@ -192,17 +185,16 @@ def check_athena_table(
         )
         columns = resp["TableMetadata"].get("Columns", [])
         col_names = [c["Name"] for c in columns]
-        return CheckResult(
+        return CheckResult.ok(
             "athena_table",
-            True,
             f"Table '{table}' found with {len(columns)} columns: {', '.join(col_names)}",
         )
     except ClientError as e:
         if "EntityNotFoundException" in str(e) or "MetadataException" in str(e):
-            return CheckResult(
-                "athena_table", False, f"Table '{table}' not found in '{database}'"
+            return CheckResult.fail(
+                "athena_table", f"Table '{table}' not found in '{database}'"
             )
-        return CheckResult("athena_table", False, str(e))
+        return CheckResult.fail("athena_table", str(e))
 
 
 def check_athena_query(
@@ -244,27 +236,25 @@ def check_athena_query(
                     reason = resp["QueryExecution"]["Status"].get(
                         "StateChangeReason", "Unknown error"
                     )
-                    return CheckResult(
-                        "athena_query", False, f"Query {i+1} failed: {reason}"
+                    return CheckResult.fail(
+                        "athena_query", f"Query {i+1} failed: {reason}"
                     )
                 time.sleep(1)
 
         for i, columns in enumerate(all_columns):
             if "~id" not in columns:
-                return CheckResult(
+                return CheckResult.fail(
                     "athena_query",
-                    False,
                     f"Query {i+1} missing required '~id' column. Got: {', '.join(columns)}",
                 )
 
         combined = [c for cols in all_columns for c in cols]
-        return CheckResult(
+        return CheckResult.ok(
             "athena_query",
-            True,
             f"{len(queries)} query(ies) valid. Columns: {', '.join(set(combined))}",
         )
     except ClientError as e:
-        return CheckResult("athena_query", False, str(e))
+        return CheckResult.fail("athena_query", str(e))
 
 
 # --- Neptune Analytics checks ---
@@ -276,16 +266,15 @@ def check_graph_name_available(graph_name: str) -> CheckResult:
         resp = ClientFactory.default().neptune().list_graphs()
         for g in resp.get("graphs", []):
             if g["name"] == graph_name:
-                return CheckResult(
+                return CheckResult.fail(
                     "graph_name_available",
-                    False,
                     f"Graph '{g['name']}' ({g['id']}) already exists",
                 )
-        return CheckResult(
-            "graph_name_available", True, f"No existing graph named '{graph_name}'"
+        return CheckResult.ok(
+            "graph_name_available", f"No existing graph named '{graph_name}'"
         )
     except ClientError as e:
-        return CheckResult("graph_name_available", False, str(e))
+        return CheckResult.fail("graph_name_available", str(e))
 
 
 # --- Credentials check ---
@@ -295,9 +284,9 @@ def check_credentials() -> CheckResult:
     """Check that AWS credentials are valid."""
     try:
         identity = ClientFactory.default().sts().get_caller_identity()
-        return CheckResult("credentials", True, f"Resolved as {identity['Arn']}")
+        return CheckResult.ok("credentials", f"Resolved as {identity['Arn']}")
     except Exception as e:
-        return CheckResult("credentials", False, f"Cannot resolve credentials: {e}")
+        return CheckResult.fail("credentials", f"Cannot resolve credentials: {e}")
 
 
 # --- Orchestrator ---

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -1202,11 +1202,11 @@ async def test_create_na_instance_from_snapshot_success(mock_boto3_client, mock_
 
 @pytest.mark.asyncio
 @patch("nx_neptune.instance_management._get_status_check_future")
-@patch("nx_neptune.instance_management._get_or_create_clients")
+@patch("nx_neptune.instance_management._resolve_iam_client")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
 async def test_create_na_instance_with_s3_import_success(
     mock_get_bucket_encryption_key_arn,
-    mock_get_or_create_clients,
+    mock_resolve_iam,
     mock_get_status_check_future,
 ):
     """Test successful creation of NA instance with S3 import."""
@@ -1216,7 +1216,7 @@ async def test_create_na_instance_with_s3_import_success(
     mock_iam_client = MagicMock()
     mock_iam_client.role_arn = "arn:aws:iam::123456789012:role/test-role"
 
-    mock_get_or_create_clients.return_value = (mock_iam_client, mock_na_client, None)
+    mock_resolve_iam.return_value = mock_iam_client
     mock_get_bucket_encryption_key_arn.return_value = None
 
     # Create an async function that returns None
@@ -1233,7 +1233,8 @@ async def test_create_na_instance_with_s3_import_success(
     }
 
     graph_id, task_id = await create_na_instance_with_s3_import(
-        "s3://test-bucket/test-data/"
+        "s3://test-bucket/test-data/",
+        na_client=mock_na_client,
     )
     assert graph_id == "test-graph-id"
     assert task_id == "test-task-id"
@@ -1282,11 +1283,11 @@ def test_get_create_instance_with_import_config_custom():
 @pytest.mark.asyncio
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._get_or_create_clients")
+@patch("nx_neptune.instance_management._resolve_iam_client")
 @patch("boto3.client")
 async def test_export_athena_table_to_s3_success(
     mock_boto3_client,
-    mock_get_or_create_clients,
+    mock_resolve_iam,
     mock_get_bucket_encryption,
     mock_execute_athena_query,
 ):
@@ -1306,11 +1307,7 @@ async def test_export_athena_table_to_s3_success(
         return MagicMock()
 
     mock_boto3_client.side_effect = client_factory
-    mock_get_or_create_clients.return_value = (
-        mock_iam_client,
-        None,
-        mock_athena_client,
-    )
+    mock_resolve_iam.return_value = mock_iam_client
     mock_get_bucket_encryption.return_value = None
     mock_execute_athena_query.side_effect = ["query-exec-id-1", "query-exec-id-2"]
 
@@ -1357,8 +1354,8 @@ async def test_update_instance_size_success(mock_boto3_client, mock_get_future):
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._get_or_create_clients")
-def test_empty_s3_bucket_folder_success(mock_get_or_create_clients, mock_boto3_client):
+@patch("nx_neptune.instance_management._resolve_iam_client")
+def test_empty_s3_bucket_folder_success(mock_resolve_iam, mock_boto3_client):
     """Test empty_s3_bucket with folder path (ends with /)."""
     # Setup mocks
     mock_s3_client = MagicMock()
@@ -1366,7 +1363,7 @@ def test_empty_s3_bucket_folder_success(mock_get_or_create_clients, mock_boto3_c
     mock_iam_client.has_delete_s3_permissions.return_value = True
 
     mock_boto3_client.return_value = mock_s3_client
-    mock_get_or_create_clients.return_value = (mock_iam_client, None, None)
+    mock_resolve_iam.return_value = mock_iam_client
 
     # Mock paginator for folder deletion
     mock_paginator = MagicMock()
@@ -1388,9 +1385,9 @@ def test_empty_s3_bucket_folder_success(mock_get_or_create_clients, mock_boto3_c
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._get_or_create_clients")
+@patch("nx_neptune.instance_management._resolve_iam_client")
 def test_empty_s3_bucket_specific_key_success(
-    mock_get_or_create_clients, mock_boto3_client
+    mock_resolve_iam, mock_boto3_client
 ):
     """Test empty_s3_bucket with specific key path."""
     # Setup mocks
@@ -1399,7 +1396,7 @@ def test_empty_s3_bucket_specific_key_success(
     mock_iam_client.has_delete_s3_permissions.return_value = True
 
     mock_boto3_client.return_value = mock_s3_client
-    mock_get_or_create_clients.return_value = (mock_iam_client, None, None)
+    mock_resolve_iam.return_value = mock_iam_client
 
     mock_s3_client.delete_objects.return_value = {"Deleted": []}
 
@@ -1423,9 +1420,9 @@ def test_empty_s3_bucket_invalid_arn(mock_boto3_client):
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._get_or_create_clients")
+@patch("nx_neptune.instance_management._resolve_iam_client")
 def test_empty_s3_bucket_permission_error(
-    mock_get_or_create_clients, mock_boto3_client
+    mock_resolve_iam, mock_boto3_client
 ):
     """Test empty_s3_bucket with permission error."""
     # Setup mocks
@@ -1433,7 +1430,7 @@ def test_empty_s3_bucket_permission_error(
     mock_s3_client = MagicMock()
 
     mock_boto3_client.return_value = mock_s3_client
-    mock_get_or_create_clients.return_value = (mock_iam_client, None, None)
+    mock_resolve_iam.return_value = mock_iam_client
     mock_iam_client.has_delete_s3_permissions.side_effect = Exception(
         "Permission denied"
     )
@@ -1444,15 +1441,15 @@ def test_empty_s3_bucket_permission_error(
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._get_or_create_clients")
-def test_empty_s3_bucket_client_error(mock_get_or_create_clients, mock_boto3_client):
+@patch("nx_neptune.instance_management._resolve_iam_client")
+def test_empty_s3_bucket_client_error(mock_resolve_iam, mock_boto3_client):
     """Test empty_s3_bucket with S3 client error."""
     # Setup mocks
     mock_s3_client = MagicMock()
     mock_iam_client = MagicMock()
 
     mock_boto3_client.return_value = mock_s3_client
-    mock_get_or_create_clients.return_value = (mock_iam_client, None, None)
+    mock_resolve_iam.return_value = mock_iam_client
     mock_iam_client.has_delete_s3_permissions.return_value = True
 
     # Mock S3 client error
@@ -1470,11 +1467,11 @@ def test_empty_s3_bucket_client_error(mock_get_or_create_clients, mock_boto3_cli
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._get_or_create_clients")
+@patch("nx_neptune.instance_management._resolve_iam_client")
 @patch("nx_neptune.instance_management.TaskFuture")
 async def test_drop_athena_table_success(
     mock_task_future,
-    mock_get_or_create_clients,
+    mock_resolve_iam,
     mock_get_bucket_encryption,
     mock_execute_athena_query,
     mock_boto3_client,
@@ -1487,11 +1484,7 @@ async def test_drop_athena_table_success(
 
     mock_iam_client = MagicMock()
     mock_iam_client.has_athena_permissions.return_value = True
-    mock_get_or_create_clients.return_value = (
-        mock_iam_client,
-        None,
-        mock_athena_client,
-    )
+    mock_resolve_iam.return_value = mock_iam_client
     mock_get_bucket_encryption.return_value = None
 
     mock_future = AsyncMock()
@@ -1519,11 +1512,11 @@ async def test_drop_athena_table_success(
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._get_or_create_clients")
+@patch("nx_neptune.instance_management._resolve_iam_client")
 @patch("nx_neptune.instance_management.TaskFuture")
 async def test_drop_athena_table_with_catalog_database(
     mock_task_future,
-    mock_get_or_create_clients,
+    mock_resolve_iam,
     mock_get_bucket_encryption,
     mock_execute_athena_query,
     mock_boto3_client,
@@ -1536,11 +1529,7 @@ async def test_drop_athena_table_with_catalog_database(
 
     mock_iam_client = MagicMock()
     mock_iam_client.has_athena_permissions.return_value = True
-    mock_get_or_create_clients.return_value = (
-        mock_iam_client,
-        None,
-        mock_athena_client,
-    )
+    mock_resolve_iam.return_value = mock_iam_client
     mock_get_bucket_encryption.return_value = None
 
     mock_future = AsyncMock()
@@ -1571,11 +1560,11 @@ async def test_drop_athena_table_with_catalog_database(
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._get_or_create_clients")
+@patch("nx_neptune.instance_management._resolve_iam_client")
 @patch("nx_neptune.instance_management.TaskFuture")
 async def test_drop_athena_table_with_polling_params(
     mock_task_future,
-    mock_get_or_create_clients,
+    mock_resolve_iam,
     mock_get_bucket_encryption,
     mock_execute_athena_query,
     mock_boto3_client,
@@ -1588,11 +1577,7 @@ async def test_drop_athena_table_with_polling_params(
 
     mock_iam_client = MagicMock()
     mock_iam_client.has_athena_permissions.return_value = True
-    mock_get_or_create_clients.return_value = (
-        mock_iam_client,
-        None,
-        mock_athena_client,
-    )
+    mock_resolve_iam.return_value = mock_iam_client
     mock_get_bucket_encryption.return_value = None
 
     mock_future = AsyncMock()

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -390,14 +390,14 @@ def test_validate_athena_query(query, projection_type, expected_result):
         ),
     ],
 )
-@patch("boto3.client")
+@patch("nx_neptune.instance_management.ClientFactory")
 def test_get_bucket_encryption_key_arn(
-    mock_boto3_client, mock_response, expected_result
+    mock_factory_cls, mock_response, expected_result
 ):
     """Test the _get_bucket_encryption_key_arn function with various scenarios."""
     # Mock the S3 client
     mock_s3_client = MagicMock()
-    mock_boto3_client.return_value = mock_s3_client
+    mock_factory_cls.return_value.s3.return_value = mock_s3_client
 
     # Configure the mock response
     mock_s3_client.get_bucket_encryption.return_value = mock_response
@@ -409,18 +409,18 @@ def test_get_bucket_encryption_key_arn(
     assert result == expected_result
 
     # Verify the S3 client was called correctly
-    mock_boto3_client.assert_called_once_with("s3")
+    mock_factory_cls.return_value.s3.assert_called_once()
     mock_s3_client.get_bucket_encryption.assert_called_once_with(
         Bucket="my-test-bucket"
     )
 
 
-@patch("boto3.client")
-def test_get_bucket_encryption_key_arn_with_exception(mock_boto3_client):
+@patch("nx_neptune.instance_management.ClientFactory")
+def test_get_bucket_encryption_key_arn_with_exception(mock_factory_cls):
     """Test handling of exceptions when retrieving bucket encryption."""
     # Mock the S3 client to raise an exception
     mock_s3_client = MagicMock()
-    mock_boto3_client.return_value = mock_s3_client
+    mock_factory_cls.return_value.s3.return_value = mock_s3_client
     mock_s3_client.get_bucket_encryption.side_effect = Exception(
         "Bucket encryption not configured"
     )
@@ -432,7 +432,7 @@ def test_get_bucket_encryption_key_arn_with_exception(mock_boto3_client):
     assert result is None
 
     # Verify the S3 client was called correctly
-    mock_boto3_client.assert_called_once_with("s3")
+    mock_factory_cls.return_value.s3.assert_called_once()
     mock_s3_client.get_bucket_encryption.assert_called_once_with(
         Bucket="my-test-bucket"
     )
@@ -1694,11 +1694,11 @@ def test_get_athena_query_results_empty(mock_boto3_client):
     assert rows == []
 
 
-@patch("nx_neptune.instance_management.boto3.client")
-def test_get_athena_query_results_creates_default_client(mock_boto3_client):
+@patch("nx_neptune.instance_management.ClientFactory")
+def test_get_athena_query_results_creates_default_client(mock_factory_cls):
     """Test that a default Athena client is created when none is provided."""
     mock_athena_client = MagicMock()
-    mock_boto3_client.return_value = mock_athena_client
+    mock_factory_cls.return_value.athena.return_value = mock_athena_client
     mock_athena_client.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
     }
@@ -1708,4 +1708,4 @@ def test_get_athena_query_results_creates_default_client(mock_boto3_client):
 
     get_athena_query_results("test-query-id")
 
-    mock_boto3_client.assert_called_once_with("athena")
+    mock_factory_cls.return_value.athena.assert_called_once()

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -1386,9 +1386,7 @@ def test_empty_s3_bucket_folder_success(mock_resolve_iam, mock_boto3_client):
 
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._create_iam_wrapper")
-def test_empty_s3_bucket_specific_key_success(
-    mock_resolve_iam, mock_boto3_client
-):
+def test_empty_s3_bucket_specific_key_success(mock_resolve_iam, mock_boto3_client):
     """Test empty_s3_bucket with specific key path."""
     # Setup mocks
     mock_s3_client = MagicMock()
@@ -1421,9 +1419,7 @@ def test_empty_s3_bucket_invalid_arn(mock_boto3_client):
 
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._create_iam_wrapper")
-def test_empty_s3_bucket_permission_error(
-    mock_resolve_iam, mock_boto3_client
-):
+def test_empty_s3_bucket_permission_error(mock_resolve_iam, mock_boto3_client):
     """Test empty_s3_bucket with permission error."""
     # Setup mocks
     mock_iam_client = MagicMock()

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -19,13 +19,12 @@ from unittest.mock import patch, MagicMock
 import pytest
 from botocore.exceptions import ClientError
 
+from nx_neptune.clients.response_utils import boto_get_status_code, na_get_graph_id
 from nx_neptune.instance_management import (
     _clean_s3_path,
     _get_bucket_encryption_key_arn,
     TaskFuture,
     TaskType,
-    _get_status_code,
-    _get_graph_id,
     create_na_instance,
     import_csv_from_s3,
     export_csv_to_s3,
@@ -465,7 +464,7 @@ def test_get_bucket_encryption_key_arn_with_exception(mock_factory_cls):
 )
 def test_get_status_code(json_str, expected_status_code):
     test_response = json.loads(json_str)
-    assert expected_status_code == _get_status_code(test_response)
+    assert expected_status_code == boto_get_status_code(test_response)
 
 
 @pytest.mark.parametrize(
@@ -506,7 +505,7 @@ def test_get_status_code(json_str, expected_status_code):
 )
 def test_get_graph_id(json_str, expected_status_code):
     test_response = json.loads(json_str)
-    assert expected_status_code == _get_graph_id(test_response)
+    assert expected_status_code == na_get_graph_id(test_response)
 
 
 @pytest.mark.asyncio

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -1202,7 +1202,7 @@ async def test_create_na_instance_from_snapshot_success(mock_boto3_client, mock_
 
 @pytest.mark.asyncio
 @patch("nx_neptune.instance_management._get_status_check_future")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
 async def test_create_na_instance_with_s3_import_success(
     mock_get_bucket_encryption_key_arn,
@@ -1283,7 +1283,7 @@ def test_get_create_instance_with_import_config_custom():
 @pytest.mark.asyncio
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 @patch("boto3.client")
 async def test_export_athena_table_to_s3_success(
     mock_boto3_client,
@@ -1354,7 +1354,7 @@ async def test_update_instance_size_success(mock_boto3_client, mock_get_future):
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 def test_empty_s3_bucket_folder_success(mock_resolve_iam, mock_boto3_client):
     """Test empty_s3_bucket with folder path (ends with /)."""
     # Setup mocks
@@ -1385,7 +1385,7 @@ def test_empty_s3_bucket_folder_success(mock_resolve_iam, mock_boto3_client):
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 def test_empty_s3_bucket_specific_key_success(
     mock_resolve_iam, mock_boto3_client
 ):
@@ -1420,7 +1420,7 @@ def test_empty_s3_bucket_invalid_arn(mock_boto3_client):
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 def test_empty_s3_bucket_permission_error(
     mock_resolve_iam, mock_boto3_client
 ):
@@ -1441,7 +1441,7 @@ def test_empty_s3_bucket_permission_error(
 
 
 @patch("nx_neptune.instance_management.boto3.client")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 def test_empty_s3_bucket_client_error(mock_resolve_iam, mock_boto3_client):
     """Test empty_s3_bucket with S3 client error."""
     # Setup mocks
@@ -1467,7 +1467,7 @@ def test_empty_s3_bucket_client_error(mock_resolve_iam, mock_boto3_client):
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 @patch("nx_neptune.instance_management.TaskFuture")
 async def test_drop_athena_table_success(
     mock_task_future,
@@ -1512,7 +1512,7 @@ async def test_drop_athena_table_success(
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 @patch("nx_neptune.instance_management.TaskFuture")
 async def test_drop_athena_table_with_catalog_database(
     mock_task_future,
@@ -1560,7 +1560,7 @@ async def test_drop_athena_table_with_catalog_database(
 @patch("nx_neptune.instance_management.boto3.client")
 @patch("nx_neptune.instance_management._execute_athena_query")
 @patch("nx_neptune.instance_management._get_bucket_encryption_key_arn")
-@patch("nx_neptune.instance_management._resolve_iam_client")
+@patch("nx_neptune.instance_management._create_iam_wrapper")
 @patch("nx_neptune.instance_management.TaskFuture")
 async def test_drop_athena_table_with_polling_params(
     mock_task_future,

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -397,7 +397,7 @@ def test_get_bucket_encryption_key_arn(
     """Test the _get_bucket_encryption_key_arn function with various scenarios."""
     # Mock the S3 client
     mock_s3_client = MagicMock()
-    mock_factory_cls.return_value.s3.return_value = mock_s3_client
+    mock_factory_cls.default.return_value.s3.return_value = mock_s3_client
 
     # Configure the mock response
     mock_s3_client.get_bucket_encryption.return_value = mock_response
@@ -409,7 +409,7 @@ def test_get_bucket_encryption_key_arn(
     assert result == expected_result
 
     # Verify the S3 client was called correctly
-    mock_factory_cls.return_value.s3.assert_called_once()
+    mock_factory_cls.default.return_value.s3.assert_called_once()
     mock_s3_client.get_bucket_encryption.assert_called_once_with(
         Bucket="my-test-bucket"
     )
@@ -420,7 +420,7 @@ def test_get_bucket_encryption_key_arn_with_exception(mock_factory_cls):
     """Test handling of exceptions when retrieving bucket encryption."""
     # Mock the S3 client to raise an exception
     mock_s3_client = MagicMock()
-    mock_factory_cls.return_value.s3.return_value = mock_s3_client
+    mock_factory_cls.default.return_value.s3.return_value = mock_s3_client
     mock_s3_client.get_bucket_encryption.side_effect = Exception(
         "Bucket encryption not configured"
     )
@@ -432,7 +432,7 @@ def test_get_bucket_encryption_key_arn_with_exception(mock_factory_cls):
     assert result is None
 
     # Verify the S3 client was called correctly
-    mock_factory_cls.return_value.s3.assert_called_once()
+    mock_factory_cls.default.return_value.s3.assert_called_once()
     mock_s3_client.get_bucket_encryption.assert_called_once_with(
         Bucket="my-test-bucket"
     )
@@ -1698,7 +1698,7 @@ def test_get_athena_query_results_empty(mock_boto3_client):
 def test_get_athena_query_results_creates_default_client(mock_factory_cls):
     """Test that a default Athena client is created when none is provided."""
     mock_athena_client = MagicMock()
-    mock_factory_cls.return_value.athena.return_value = mock_athena_client
+    mock_factory_cls.default.return_value.athena.return_value = mock_athena_client
     mock_athena_client.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
     }
@@ -1708,4 +1708,4 @@ def test_get_athena_query_results_creates_default_client(mock_factory_cls):
 
     get_athena_query_results("test-query-id")
 
-    mock_factory_cls.return_value.athena.assert_called_once()
+    mock_factory_cls.default.return_value.athena.assert_called_once()

--- a/tests/clients/test_na_client.py
+++ b/tests/clients/test_na_client.py
@@ -200,7 +200,7 @@ class TestNeptuneAnalyticsClient:
         call_kwargs = mock_na_client.client.execute_query.call_args[1]
         assert "queryTimeoutMilliseconds" not in call_kwargs
 
-    @patch("nx_neptune.clients.na_client.boto3")
+    @patch("nx_neptune.clients.client_factory.boto3")
     def test_init_with_timeout_sets_read_timeout(self, mock_boto3):
         """Test that timeout_seconds sets read_timeout on the boto3 Config."""
         NeptuneAnalyticsClient(graph_id="g-123", timeout_seconds=120)
@@ -209,7 +209,7 @@ class TestNeptuneAnalyticsClient:
         config = mock_boto3.client.call_args[1]["config"]
         assert config.read_timeout == 120
 
-    @patch("nx_neptune.clients.na_client.boto3")
+    @patch("nx_neptune.clients.client_factory.boto3")
     def test_init_without_timeout_uses_default(self, mock_boto3):
         """Test that no timeout_seconds leaves read_timeout at boto3 default (60s)."""
         NeptuneAnalyticsClient(graph_id="g-123")
@@ -218,7 +218,7 @@ class TestNeptuneAnalyticsClient:
         config = mock_boto3.client.call_args[1]["config"]
         assert config.read_timeout == 60
 
-    @patch("nx_neptune.clients.na_client.boto3")
+    @patch("nx_neptune.clients.client_factory.boto3")
     def test_init_with_client_ignores_timeout_seconds(self, mock_boto3):
         """Test that providing a client uses it directly; timeout_seconds does not create a new client."""
         mock_client = MagicMock()

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -81,10 +81,14 @@ class TestCheckBucketEncryption:
     def test_kms_encrypted(self, mock_factory):
         mock_factory.s3.return_value.get_bucket_encryption.return_value = {
             "ServerSideEncryptionConfiguration": {
-                "Rules": [{"ApplyServerSideEncryptionByDefault": {
-                    "SSEAlgorithm": "aws:kms",
-                    "KMSMasterKeyID": "arn:aws:kms:us-west-2:123:key/abc",
-                }}]
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                            "KMSMasterKeyID": "arn:aws:kms:us-west-2:123:key/abc",
+                        }
+                    }
+                ]
             }
         }
         result = check_bucket_encryption("s3://my-bucket/")
@@ -94,7 +98,9 @@ class TestCheckBucketEncryption:
     def test_no_kms(self, mock_factory):
         mock_factory.s3.return_value.get_bucket_encryption.return_value = {
             "ServerSideEncryptionConfiguration": {
-                "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+                "Rules": [
+                    {"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
+                ]
             }
         }
         result = check_bucket_encryption("s3://my-bucket/")
@@ -103,7 +109,9 @@ class TestCheckBucketEncryption:
 
 class TestCheckBucketVersioning:
     def test_versioning_enabled(self, mock_factory):
-        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {
+            "Status": "Enabled"
+        }
         result = check_bucket_versioning("s3://my-bucket/")
         assert result.passed is True
 
@@ -128,7 +136,7 @@ class TestCheckPathEmpty:
 class TestCheckAthenaDatabase:
     def test_database_exists(self, mock_factory):
         mock_factory.athena.return_value.get_database.return_value = {}
-        result = check_athena_database("AwsDataCatalog", "mydb")
+        result = check_athena_database("mydb")
         assert result.passed is True
 
     def test_database_not_found(self, mock_factory):
@@ -136,7 +144,7 @@ class TestCheckAthenaDatabase:
             {"Error": {"Code": "EntityNotFoundException", "Message": "not found"}},
             "GetDatabase",
         )
-        result = check_athena_database("AwsDataCatalog", "missing")
+        result = check_athena_database("missing")
         assert result.passed is False
 
 
@@ -145,7 +153,7 @@ class TestCheckAthenaTable:
         mock_factory.athena.return_value.get_table_metadata.return_value = {
             "TableMetadata": {"Columns": [{"Name": "~id"}, {"Name": "name"}]}
         }
-        result = check_athena_table("AwsDataCatalog", "mydb", "mytable")
+        result = check_athena_table("mydb", "mytable")
         assert result.passed is True
         assert "2 columns" in result.message
 
@@ -158,7 +166,7 @@ class TestCheckGraphNameAvailable:
 
     def test_name_taken(self, mock_factory):
         mock_factory.neptune.return_value.list_graphs.return_value = {
-            "graphs": [{"name": "my-graph-123", "id": "g-abc"}]
+            "graphs": [{"name": "my-graph", "id": "g-abc"}]
         }
         result = check_graph_name_available("my-graph")
         assert result.passed is False
@@ -174,22 +182,30 @@ class TestCheckCredentials:
         assert result.passed is True
 
     def test_invalid_credentials(self, mock_factory):
-        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("expired")
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception(
+            "expired"
+        )
         result = check_credentials()
         assert result.passed is False
 
 
 class TestValidateResources:
     def test_credentials_fail_short_circuits(self, mock_factory):
-        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("no creds")
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception(
+            "no creds"
+        )
         results = validate_resources(s3_staging_bucket="s3://bucket/")
         assert len(results) == 1
         assert results[0]["passed"] is False
 
     def test_s3_checks_run(self, mock_factory):
-        mock_factory.sts.return_value.get_caller_identity.return_value = {"Arn": "arn:aws:iam::123:user/dev"}
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
         mock_factory.s3.return_value.head_bucket.return_value = {}
-        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {
+            "Status": "Enabled"
+        }
         results = validate_resources(s3_staging_bucket="s3://bucket/")
         checks = [r["check"] for r in results]
         assert "credentials" in checks

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -1,0 +1,197 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from nx_neptune.validators import (
+    CheckResult,
+    check_athena_database,
+    check_athena_table,
+    check_bucket_encryption,
+    check_bucket_exists,
+    check_bucket_region,
+    check_bucket_versioning,
+    check_credentials,
+    check_graph_name_available,
+    check_path_empty,
+    validate_resources,
+)
+
+
+@pytest.fixture
+def mock_factory():
+    with patch("nx_neptune.validators.ClientFactory") as mock_cls:
+        factory = MagicMock()
+        mock_cls.default.return_value = factory
+        yield factory
+
+
+class TestCheckBucketExists:
+    def test_bucket_exists(self, mock_factory):
+        mock_factory.s3.return_value.head_bucket.return_value = {}
+        result = check_bucket_exists("s3://my-bucket/path/")
+        assert result.passed is True
+        assert "my-bucket" in result.message
+
+    def test_bucket_not_found(self, mock_factory):
+        mock_factory.s3.return_value.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadBucket"
+        )
+        result = check_bucket_exists("s3://missing-bucket/")
+        assert result.passed is False
+        assert "not found" in result.message
+
+    def test_bucket_access_denied(self, mock_factory):
+        mock_factory.s3.return_value.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "403"}}, "HeadBucket"
+        )
+        result = check_bucket_exists("s3://private-bucket/")
+        assert result.passed is False
+        assert "Access denied" in result.message
+
+
+class TestCheckBucketRegion:
+    def test_correct_region(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": "us-west-2"
+        }
+        result = check_bucket_region("s3://my-bucket/", "us-west-2")
+        assert result.passed is True
+
+    def test_wrong_region(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": "eu-west-1"
+        }
+        result = check_bucket_region("s3://my-bucket/", "us-west-2")
+        assert result.passed is False
+        assert "eu-west-1" in result.message
+
+    def test_us_east_1_null(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": None
+        }
+        result = check_bucket_region("s3://my-bucket/", "us-east-1")
+        assert result.passed is True
+
+
+class TestCheckBucketEncryption:
+    def test_kms_encrypted(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.return_value = {
+            "ServerSideEncryptionConfiguration": {
+                "Rules": [{"ApplyServerSideEncryptionByDefault": {
+                    "SSEAlgorithm": "aws:kms",
+                    "KMSMasterKeyID": "arn:aws:kms:us-west-2:123:key/abc",
+                }}]
+            }
+        }
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is True
+        assert "KMS" in result.message
+
+    def test_no_kms(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.return_value = {
+            "ServerSideEncryptionConfiguration": {
+                "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+            }
+        }
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is False
+
+
+class TestCheckBucketVersioning:
+    def test_versioning_enabled(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        result = check_bucket_versioning("s3://my-bucket/")
+        assert result.passed is True
+
+    def test_versioning_disabled(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {}
+        result = check_bucket_versioning("s3://my-bucket/")
+        assert result.passed is False
+
+
+class TestCheckPathEmpty:
+    def test_path_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 0}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is True
+
+    def test_path_not_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 1}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is False
+
+
+class TestCheckAthenaDatabase:
+    def test_database_exists(self, mock_factory):
+        mock_factory.athena.return_value.get_database.return_value = {}
+        result = check_athena_database("AwsDataCatalog", "mydb")
+        assert result.passed is True
+
+    def test_database_not_found(self, mock_factory):
+        mock_factory.athena.return_value.get_database.side_effect = ClientError(
+            {"Error": {"Code": "EntityNotFoundException", "Message": "not found"}},
+            "GetDatabase",
+        )
+        result = check_athena_database("AwsDataCatalog", "missing")
+        assert result.passed is False
+
+
+class TestCheckAthenaTable:
+    def test_table_exists(self, mock_factory):
+        mock_factory.athena.return_value.get_table_metadata.return_value = {
+            "TableMetadata": {"Columns": [{"Name": "~id"}, {"Name": "name"}]}
+        }
+        result = check_athena_table("AwsDataCatalog", "mydb", "mytable")
+        assert result.passed is True
+        assert "2 columns" in result.message
+
+
+class TestCheckGraphNameAvailable:
+    def test_name_available(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {"graphs": []}
+        result = check_graph_name_available("my-graph")
+        assert result.passed is True
+
+    def test_name_taken(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {
+            "graphs": [{"name": "my-graph-123", "id": "g-abc"}]
+        }
+        result = check_graph_name_available("my-graph")
+        assert result.passed is False
+        assert "already exists" in result.message
+
+
+class TestCheckCredentials:
+    def test_valid_credentials(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        result = check_credentials()
+        assert result.passed is True
+
+    def test_invalid_credentials(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("expired")
+        result = check_credentials()
+        assert result.passed is False
+
+
+class TestValidateResources:
+    def test_credentials_fail_short_circuits(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.side_effect = Exception("no creds")
+        results = validate_resources(s3_staging_bucket="s3://bucket/")
+        assert len(results) == 1
+        assert results[0]["passed"] is False
+
+    def test_s3_checks_run(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {"Arn": "arn:aws:iam::123:user/dev"}
+        mock_factory.s3.return_value.head_bucket.return_value = {}
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        results = validate_resources(s3_staging_bucket="s3://bucket/")
+        checks = [r["check"] for r in results]
+        assert "credentials" in checks
+        assert "s3_bucket_exists" in checks
+        assert "s3_bucket_versioning" in checks

--- a/tests/clients/test_validators.py
+++ b/tests/clients/test_validators.py
@@ -211,3 +211,177 @@ class TestValidateResources:
         assert "credentials" in checks
         assert "s3_bucket_exists" in checks
         assert "s3_bucket_versioning" in checks
+
+    def test_athena_checks_run(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        mock_factory.athena.return_value.get_database.return_value = {}
+        mock_factory.athena.return_value.get_table_metadata.return_value = {
+            "TableMetadata": {"Columns": [{"Name": "~id"}]}
+        }
+        results = validate_resources(athena_database="mydb", athena_table="mytable")
+        checks = [r["check"] for r in results]
+        assert "athena_database" in checks
+        assert "athena_table" in checks
+
+    def test_graph_name_check_runs(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        mock_factory.neptune.return_value.list_graphs.return_value = {"graphs": []}
+        results = validate_resources(graph_name="my-graph")
+        checks = [r["check"] for r in results]
+        assert "graph_name_available" in checks
+
+    def test_region_check_runs(self, mock_factory):
+        mock_factory.sts.return_value.get_caller_identity.return_value = {
+            "Arn": "arn:aws:iam::123:user/dev"
+        }
+        mock_factory.s3.return_value.head_bucket.return_value = {}
+        mock_factory.s3.return_value.get_bucket_location.return_value = {
+            "LocationConstraint": "us-west-2"
+        }
+        mock_factory.s3.return_value.get_bucket_versioning.return_value = {
+            "Status": "Enabled"
+        }
+        results = validate_resources(
+            s3_staging_bucket="s3://bucket/", expected_region="us-west-2"
+        )
+        checks = [r["check"] for r in results]
+        assert "s3_bucket_region" in checks
+
+
+class TestCheckBucketEncryptionErrors:
+    def test_no_encryption_configured(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ServerSideEncryptionConfigurationNotFoundError",
+                    "Message": "",
+                }
+            },
+            "GetBucketEncryption",
+        )
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is False
+        assert "No encryption configured" in result.message
+
+    def test_unexpected_error(self, mock_factory):
+        mock_factory.s3.return_value.get_bucket_encryption.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "Internal"}}, "GetBucketEncryption"
+        )
+        result = check_bucket_encryption("s3://my-bucket/")
+        assert result.passed is False
+
+
+class TestCheckPathEmpty:
+    def test_path_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 0}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is True
+
+    def test_path_not_empty(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.return_value = {"KeyCount": 1}
+        result = check_path_empty("s3://my-bucket/output/")
+        assert result.passed is False
+
+    def test_error(self, mock_factory):
+        mock_factory.s3.return_value.list_objects_v2.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchBucket", "Message": ""}}, "ListObjectsV2"
+        )
+        result = check_path_empty("s3://missing/path/")
+        assert result.passed is False
+
+
+class TestCheckAthenaTableErrors:
+    def test_table_not_found(self, mock_factory):
+        mock_factory.athena.return_value.get_table_metadata.side_effect = ClientError(
+            {"Error": {"Code": "EntityNotFoundException", "Message": "not found"}},
+            "GetTableMetadata",
+        )
+        from nx_neptune.validators import check_athena_table
+
+        result = check_athena_table("mydb", "missing")
+        assert result.passed is False
+        assert "not found" in result.message
+
+
+class TestCheckAthenaQuery:
+    @patch("nx_neptune.validators.wait_until_all_complete")
+    def test_query_succeeds(self, mock_wait, mock_factory):
+        athena = mock_factory.athena.return_value
+        athena.start_query_execution.return_value = {"QueryExecutionId": "qid-1"}
+        mock_wait.return_value = None
+        athena.get_query_execution.return_value = {
+            "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
+        }
+        athena.get_query_results.return_value = {
+            "ResultSet": {
+                "ResultSetMetadata": {"ColumnInfo": [{"Name": "~id"}, {"Name": "name"}]}
+            }
+        }
+        from nx_neptune.validators import check_athena_query
+
+        result = check_athena_query("SELECT * FROM t", "mydb", "s3://output/")
+        assert result.passed is True
+        assert "1 query" in result.message
+
+    @patch("nx_neptune.validators.wait_until_all_complete")
+    def test_query_fails(self, mock_wait, mock_factory):
+        athena = mock_factory.athena.return_value
+        athena.start_query_execution.return_value = {"QueryExecutionId": "qid-1"}
+        mock_wait.return_value = None
+        athena.get_query_execution.return_value = {
+            "QueryExecution": {
+                "Status": {"State": "FAILED", "StateChangeReason": "Syntax error"}
+            }
+        }
+        from nx_neptune.validators import check_athena_query
+
+        result = check_athena_query("SELECT bad", "mydb", "s3://output/")
+        assert result.passed is False
+        assert "Syntax error" in result.message
+
+    @patch("nx_neptune.validators.wait_until_all_complete")
+    def test_query_missing_id_column(self, mock_wait, mock_factory):
+        athena = mock_factory.athena.return_value
+        athena.start_query_execution.return_value = {"QueryExecutionId": "qid-1"}
+        mock_wait.return_value = None
+        athena.get_query_execution.return_value = {
+            "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
+        }
+        athena.get_query_results.return_value = {
+            "ResultSet": {
+                "ResultSetMetadata": {
+                    "ColumnInfo": [{"Name": "name"}, {"Name": "value"}]
+                }
+            }
+        }
+        from nx_neptune.validators import check_athena_query
+
+        result = check_athena_query("SELECT * FROM t", "mydb", "s3://output/")
+        assert result.passed is False
+        assert "~id" in result.message
+
+
+class TestCheckGraphNameAvailable:
+    def test_name_available(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {"graphs": []}
+        result = check_graph_name_available("my-graph")
+        assert result.passed is True
+
+    def test_name_taken(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.return_value = {
+            "graphs": [{"name": "my-graph", "id": "g-abc"}]
+        }
+        result = check_graph_name_available("my-graph")
+        assert result.passed is False
+        assert "already exists" in result.message
+
+    def test_error(self, mock_factory):
+        mock_factory.neptune.return_value.list_graphs.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "err"}}, "ListGraphs"
+        )
+        result = check_graph_name_available("my-graph")
+        assert result.passed is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,13 @@ def go_to_tmpdir(request):
     # Chdir only for the duration of the test.
     with tmpdir.as_cwd():
         yield
+
+
+@pytest.fixture(autouse=True)
+def reset_client_factory():
+    """Reset the ClientFactory singleton between tests to prevent leakage."""
+    from nx_neptune.clients.client_factory import ClientFactory
+
+    ClientFactory._default = None
+    yield
+    ClientFactory._default = None


### PR DESCRIPTION
### Summary

Centralizes all boto3 response parsing into `response_utils.py` and replaces inline dict access across `instance_management.py` and `session_manager.py`. No behavioral changes — same input, same output, just one place to maintain.

### Naming convention

All interpreters now use a product prefix for discoverability:

| Prefix | Service |
|--------|---------|
| `s3_` | S3 |
| `athena_` | Athena |
| `na_` | Neptune Analytics |
| `sts_` | STS |
| `boto_` | Generic boto3 (status code, error classifiers) |

### New interpreters added

- `na_get_graph_id` — `resp.get("graphId") or resp.get("id")`
- `na_get_task_id` — `resp.get("taskId")`
- `na_get_snapshot_id` — `resp["id"]`
- `boto_get_status_code` — `ResponseMetadata.HTTPStatusCode`
- `athena_get_query_execution_id` — `resp["QueryExecutionId"]`
- `s3_get_contents` — `resp.get("Contents", [])`

### Replacements

- **instance_management.py** — removed `_get_status_code` and `_get_graph_id` private wrappers, replaced all 12+ inline response accesses with `response_utils` calls
- **session_manager.py** — replaced `get_caller_identity()["Arn"]` with `sts_get_caller_arn`
- **validators.py** — all function references renamed to prefixed versions
- **tests/clients/test_instance_management.py** — updated to import from `response_utils` directly

### Design

- No behavioral changes — functions return the same values as the original inline code
- Existing function names in validators also renamed to match the new convention
- Error classifiers renamed: `is_not_found` → `boto_is_not_found`, `is_entity_not_found` → `athena_is_entity_not_found`

### Testing

- 380 tests pass, mypy clean