### PR TITLE
CI: Ignore junit-jupiter in dependabot for Maven connectors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,14 @@ updates:
     directory: "/connectors/athena-databricks-connector"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.junit.jupiter:*"
   - package-ecosystem: "maven"
     directory: "/connectors/athena-s3vector-connector"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.junit.jupiter:*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
Suppress dependabot PRs for `org.junit.jupiter:*` in both Maven connector directories. JUnit 6.x is a major version bump that requires migration effort and shouldn't be auto-proposed.

**Changes**

- Added `org.junit.jupiter:*` to ignore list for `/connectors/athena-s3vector-connector`
- Added `org.junit.jupiter:*` to ignore list for `/connectors/athena-databricks-connector`