### PR TITLE
Feat: Metadata API endpoints for proxy

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.11-slim
 WORKDIR /app
+COPY nx_neptune/ ./nx_neptune_src/nx_neptune/
+COPY nx_plugin/ ./nx_neptune_src/nx_plugin/
+COPY pyproject.toml ./nx_neptune_src/
 COPY proxy/ ./proxy/
-RUN pip install --no-cache-dir ./proxy && useradd --create-home appuser
+RUN pip install --no-cache-dir ./nx_neptune_src ./proxy && useradd --create-home appuser
 USER appuser
 EXPOSE 8080
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 \

--- a/proxy/pyproject.toml
+++ b/proxy/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "fastapi==0.115.12",
     "uvicorn[standard]==0.34.2",
+    "nx-neptune",
 ]
 
 [project.urls]

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.routers.metadata import router as metadata_router
 
 settings = Settings.from_env()
 
@@ -93,6 +94,11 @@ async def global_exception_handler(request: Request, exc: Exception):
 @app.get("/health")
 def health():
     return {"status": "healthy"}
+
+
+# --- Routers ---
+
+app.include_router(metadata_router)
 
 
 # --- Static UI (must be last — catch-all) ---

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -6,6 +6,7 @@ import time
 import uuid
 from pathlib import Path
 
+from botocore.exceptions import ClientError
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -53,7 +54,28 @@ async def request_logging(request: Request, call_next):
     return response
 
 
-# --- Global error handler ---
+# --- Error handlers ---
+
+_AWS_STATUS_MAP = {
+    "AccessDeniedException": 403,
+    "UnauthorizedAccess": 403,
+    "ResourceNotFoundException": 404,
+    "MetadataException": 400,
+    "InvalidRequestException": 400,
+    "ThrottlingException": 503,
+}
+
+
+@app.exception_handler(ClientError)
+async def aws_exception_handler(request: Request, exc: ClientError):
+    code = exc.response["Error"]["Code"]
+    message = exc.response["Error"]["Message"]
+    status = _AWS_STATUS_MAP.get(code, 502)
+    logger.warning(f"AWS {code} on {request.method} {request.url.path}: {message}")
+    return JSONResponse(
+        status_code=status,
+        content={"error": code, "message": message},
+    )
 
 
 @app.exception_handler(Exception)

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -12,6 +12,7 @@ class Settings:
     log_level: str = "INFO"
     allowed_origins: list[str] = None  # type: ignore[assignment]
     port: int = 8080
+    region: str = ""
 
     def __post_init__(self) -> None:
         if self.allowed_origins is None:
@@ -25,4 +26,5 @@ class Settings:
             log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
             allowed_origins=origins,
             port=int(os.environ.get("PORT", "8080")),
+            region=os.environ.get("AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")),
         )

--- a/proxy/src/nx_neptune_proxy/routers/__init__.py
+++ b/proxy/src/nx_neptune_proxy/routers/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -61,12 +61,11 @@ def list_athena_columns(
 @router.get("/s3/buckets", summary="List S3 buckets", response_model=BucketsResponse)
 def list_s3_buckets():
     """List S3 buckets in the configured region"""
-    client = ClientFactory().s3()
     filter_region = Settings.from_env().region
-    kwargs = {}
-    if filter_region:
-        kwargs["BucketRegion"] = filter_region
-    buckets = [b["Name"] for b in client.list_buckets(**kwargs).get("Buckets", [])]
+    if not filter_region:
+        return {"buckets": []}
+    client = ClientFactory().s3()
+    buckets = [b["Name"] for b in client.list_buckets(BucketRegion=filter_region).get("Buckets", [])]
     return {"buckets": buckets}
 
 

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from fastapi import APIRouter, Query
+
+from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.routers.schemas import (
+    BucketsResponse,
+    ColumnsResponse,
+    DatabasesResponse,
+    GraphsResponse,
+    TablesResponse,
+)
+from nx_neptune_proxy.utils import paginate_aws
+
+router = APIRouter(prefix="/api/v0/metadata", tags=["metadata"])
+
+
+@router.get("/athena/databases", summary="List Athena databases", response_model=DatabasesResponse)
+def list_athena_databases(catalog: str = Query("AwsDataCatalog", description="Athena catalog name")):
+    """List all databases in the specified Athena catalog."""
+    client = ClientFactory().athena()
+    items = paginate_aws(client.list_databases, "DatabaseList", CatalogName=catalog)
+    return {"databases": [db["Name"] for db in items]}
+
+
+@router.get("/athena/tables", summary="List Athena tables", response_model=TablesResponse)
+def list_athena_tables(
+    database: str = Query(..., description="Database name"),
+    catalog: str = Query("AwsDataCatalog", description="Athena catalog name"),
+):
+    """List all tables in the specified Athena database."""
+    client = ClientFactory().athena()
+    items = paginate_aws(client.list_table_metadata, "TableMetadataList", CatalogName=catalog, DatabaseName=database)
+    return {"tables": [t["Name"] for t in items]}
+
+
+@router.get("/athena/columns", summary="List Athena table columns", response_model=ColumnsResponse)
+def list_athena_columns(
+    database: str = Query(..., description="Database name"),
+    table: str = Query(..., description="Table name"),
+    catalog: str = Query("AwsDataCatalog", description="Athena catalog name"),
+):
+    """List columns and their types for the specified Athena table."""
+    client = ClientFactory().athena()
+    resp = client.get_table_metadata(CatalogName=catalog, DatabaseName=database, TableName=table)
+    columns = resp["TableMetadata"].get("Columns", [])
+    return {"columns": [{"name": c["Name"], "type": c["Type"]} for c in columns]}
+
+
+@router.get("/s3/buckets", summary="List S3 buckets", response_model=BucketsResponse)
+def list_s3_buckets():
+    """List S3 buckets in the configured region."""
+    client = ClientFactory().s3()
+    filter_region = Settings.from_env().region
+    kwargs = {}
+    if filter_region:
+        kwargs["BucketRegion"] = filter_region
+    buckets = [b["Name"] for b in client.list_buckets(**kwargs).get("Buckets", [])]
+    return {"buckets": buckets}
+
+
+@router.get("/neptune/graphs", summary="List Neptune Analytics graphs", response_model=GraphsResponse)
+def list_neptune_graphs():
+    """List all Neptune Analytics graphs in the configured region."""
+    client = ClientFactory().neptune()
+    items = paginate_aws(client.list_graphs, "graphs")
+    return {"graphs": [{"id": g["id"], "name": g["name"], "status": g["status"]} for g in items]}

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -23,7 +23,7 @@ def list_athena_catalogs():
     """List all Athena data catalogs"""
     client = ClientFactory().athena()
     items = paginate_aws(client.list_data_catalogs, "DataCatalogsSummary")
-    return {"catalogs": [c["CatalogName"] for c in items]}
+    return {"catalogs": [{"name": c["CatalogName"], "status": c.get("Status", "")} for c in items]}
 
 
 @router.get("/athena/databases", summary="List Athena databases", response_model=DatabasesResponse)

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -7,9 +7,10 @@ from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune_proxy.config import Settings
 from nx_neptune_proxy.routers.schemas import (
     BucketsResponse,
+    CatalogsResponse,
     ColumnsResponse,
     DatabasesResponse,
-    GraphsResponse,
+    NeptuneAnalyticsGraphsResponse,
     TablesResponse,
 )
 from nx_neptune_proxy.utils import paginate_aws
@@ -17,9 +18,17 @@ from nx_neptune_proxy.utils import paginate_aws
 router = APIRouter(prefix="/api/v0/metadata", tags=["metadata"])
 
 
+@router.get("/athena/catalogs", summary="List Athena data catalogs", response_model=CatalogsResponse)
+def list_athena_catalogs():
+    """List all Athena data catalogs"""
+    client = ClientFactory().athena()
+    items = paginate_aws(client.list_data_catalogs, "DataCatalogsSummary")
+    return {"catalogs": [c["CatalogName"] for c in items]}
+
+
 @router.get("/athena/databases", summary="List Athena databases", response_model=DatabasesResponse)
 def list_athena_databases(catalog: str = Query("AwsDataCatalog", description="Athena catalog name")):
-    """List all databases in the specified Athena catalog."""
+    """List all databases in the specified Athena catalog"""
     client = ClientFactory().athena()
     items = paginate_aws(client.list_databases, "DatabaseList", CatalogName=catalog)
     return {"databases": [db["Name"] for db in items]}
@@ -30,7 +39,7 @@ def list_athena_tables(
     database: str = Query(..., description="Database name"),
     catalog: str = Query("AwsDataCatalog", description="Athena catalog name"),
 ):
-    """List all tables in the specified Athena database."""
+    """List all tables in the specified Athena database"""
     client = ClientFactory().athena()
     items = paginate_aws(client.list_table_metadata, "TableMetadataList", CatalogName=catalog, DatabaseName=database)
     return {"tables": [t["Name"] for t in items]}
@@ -42,7 +51,7 @@ def list_athena_columns(
     table: str = Query(..., description="Table name"),
     catalog: str = Query("AwsDataCatalog", description="Athena catalog name"),
 ):
-    """List columns and their types for the specified Athena table."""
+    """List columns and their types for the specified Athena table"""
     client = ClientFactory().athena()
     resp = client.get_table_metadata(CatalogName=catalog, DatabaseName=database, TableName=table)
     columns = resp["TableMetadata"].get("Columns", [])
@@ -51,7 +60,7 @@ def list_athena_columns(
 
 @router.get("/s3/buckets", summary="List S3 buckets", response_model=BucketsResponse)
 def list_s3_buckets():
-    """List S3 buckets in the configured region."""
+    """List S3 buckets in the configured region"""
     client = ClientFactory().s3()
     filter_region = Settings.from_env().region
     kwargs = {}
@@ -61,9 +70,9 @@ def list_s3_buckets():
     return {"buckets": buckets}
 
 
-@router.get("/neptune/graphs", summary="List Neptune Analytics graphs", response_model=GraphsResponse)
+@router.get("/neptune/graph-analytics", summary="List Neptune Analytics graphs", response_model=NeptuneAnalyticsGraphsResponse)
 def list_neptune_graphs():
-    """List all Neptune Analytics graphs in the configured region."""
+    """List all Neptune Analytics graphs in the configured region"""
     client = ClientFactory().neptune()
     items = paginate_aws(client.list_graphs, "graphs")
     return {"graphs": [{"id": g["id"], "name": g["name"], "status": g["status"]} for g in items]}

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -25,11 +25,15 @@ class BucketsResponse(BaseModel):
     buckets: list[str]
 
 
-class Graph(BaseModel):
+class CatalogsResponse(BaseModel):
+    catalogs: list[str]
+
+
+class NeptuneAnalyticsGraph(BaseModel):
     id: str
     name: str
     status: str
 
 
-class GraphsResponse(BaseModel):
-    graphs: list[Graph]
+class NeptuneAnalyticsGraphsResponse(BaseModel):
+    graphs: list[NeptuneAnalyticsGraph]

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pydantic import BaseModel
+
+
+class DatabasesResponse(BaseModel):
+    databases: list[str]
+
+
+class TablesResponse(BaseModel):
+    tables: list[str]
+
+
+class Column(BaseModel):
+    name: str
+    type: str
+
+
+class ColumnsResponse(BaseModel):
+    columns: list[Column]
+
+
+class BucketsResponse(BaseModel):
+    buckets: list[str]
+
+
+class Graph(BaseModel):
+    id: str
+    name: str
+    status: str
+
+
+class GraphsResponse(BaseModel):
+    graphs: list[Graph]

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -25,8 +25,13 @@ class BucketsResponse(BaseModel):
     buckets: list[str]
 
 
+class Catalog(BaseModel):
+    name: str
+    status: str
+
+
 class CatalogsResponse(BaseModel):
-    catalogs: list[str]
+    catalogs: list[Catalog]
 
 
 class NeptuneAnalyticsGraph(BaseModel):

--- a/proxy/src/nx_neptune_proxy/utils/__init__.py
+++ b/proxy/src/nx_neptune_proxy/utils/__init__.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Callable
+
+
+def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
+    """Paginate an AWS API call that uses NextToken.
+
+    Args:
+        method: The boto3 client method to call (e.g., client.list_databases).
+        result_key: The key in the response containing the list items.
+        **kwargs: Arguments passed to the API call.
+
+    Returns:
+        Collected list of all items across all pages.
+    """
+    items = []
+    while True:
+        resp = method(**kwargs)
+        items.extend(resp.get(result_key, []))
+        if "NextToken" not in resp and "nextToken" not in resp:
+            break
+        kwargs["NextToken"] = resp.get("NextToken") or resp.get("nextToken")
+    return items

--- a/proxy/src/nx_neptune_proxy/utils/__init__.py
+++ b/proxy/src/nx_neptune_proxy/utils/__init__.py
@@ -1,25 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Callable
+from .aws_helper import paginate_aws
 
-
-def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
-    """Paginate an AWS API call that uses NextToken.
-
-    Args:
-        method: The boto3 client method to call (e.g., client.list_databases).
-        result_key: The key in the response containing the list items.
-        **kwargs: Arguments passed to the API call.
-
-    Returns:
-        Collected list of all items across all pages.
-    """
-    items = []
-    while True:
-        resp = method(**kwargs)
-        items.extend(resp.get(result_key, []))
-        if "NextToken" not in resp and "nextToken" not in resp:
-            break
-        kwargs["NextToken"] = resp.get("NextToken") or resp.get("nextToken")
-    return items
+__all__ = ["paginate_aws"]

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Callable
+
+
+def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
+    """Paginate an AWS API call that uses NextToken.
+
+    Args:
+        method: The boto3 client method to call (e.g., client.list_databases).
+        result_key: The key in the response containing the list items.
+        **kwargs: Arguments passed to the API call.
+
+    Returns:
+        Collected list of all items across all pages.
+    """
+    items = []
+    while True:
+        resp = method(**kwargs)
+        items.extend(resp.get(result_key, []))
+        if "NextToken" not in resp and "nextToken" not in resp:
+            break
+        kwargs["NextToken"] = resp.get("NextToken") or resp.get("nextToken")
+    return items

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -167,7 +167,7 @@ async def test_list_neptune_graphs(mock_cf, client):
     }
     mock_cf.return_value.neptune.return_value = mock_neptune
 
-    resp = await client.get("/api/v0/metadata/neptune/graphs")
+    resp = await client.get("/api/v0/metadata/neptune/graph-analytics")
     assert resp.status_code == 200
     assert resp.json() == {
         "graphs": [
@@ -184,7 +184,7 @@ async def test_list_neptune_graphs_empty(mock_cf, client):
     mock_neptune.list_graphs.return_value = {"graphs": []}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
-    resp = await client.get("/api/v0/metadata/neptune/graphs")
+    resp = await client.get("/api/v0/metadata/neptune/graph-analytics")
     assert resp.status_code == 200
     assert resp.json() == {"graphs": []}
 
@@ -201,6 +201,6 @@ async def test_unknown_aws_error_returns_502(mock_cf, client):
     )
     mock_cf.return_value.neptune.return_value = mock_neptune
 
-    resp = await client.get("/api/v0/metadata/neptune/graphs")
+    resp = await client.get("/api/v0/metadata/neptune/graph-analytics")
     assert resp.status_code == 502
     assert resp.json()["error"] == "InternalServerError"

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -21,6 +21,20 @@ def client():
 
 @pytest.mark.asyncio
 @patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_catalogs(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_data_catalogs.return_value = {
+        "DataCatalogsSummary": [{"CatalogName": "AwsDataCatalog"}, {"CatalogName": "MyCatalog"}]
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/catalogs")
+    assert resp.status_code == 200
+    assert resp.json() == {"catalogs": ["AwsDataCatalog", "MyCatalog"]}
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
 async def test_list_databases(mock_cf, client):
     mock_athena = MagicMock()
     mock_athena.list_databases.return_value = {
@@ -142,14 +156,11 @@ async def test_list_s3_buckets(mock_cf, mock_settings, client):
 @patch("nx_neptune_proxy.routers.metadata.Settings")
 @patch("nx_neptune_proxy.routers.metadata.ClientFactory")
 async def test_list_s3_buckets_no_region(mock_cf, mock_settings, client):
-    mock_s3 = MagicMock()
-    mock_s3.list_buckets.return_value = {"Buckets": [{"Name": "b1"}]}
-    mock_cf.return_value.s3.return_value = mock_s3
     mock_settings.from_env.return_value.region = ""
 
     resp = await client.get("/api/v0/metadata/s3/buckets")
     assert resp.status_code == 200
-    mock_s3.list_buckets.assert_called_with()
+    assert resp.json() == {"buckets": []}
 
 
 # --- Neptune graphs ---

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -24,13 +24,19 @@ def client():
 async def test_list_catalogs(mock_cf, client):
     mock_athena = MagicMock()
     mock_athena.list_data_catalogs.return_value = {
-        "DataCatalogsSummary": [{"CatalogName": "AwsDataCatalog"}, {"CatalogName": "MyCatalog"}]
+        "DataCatalogsSummary": [
+            {"CatalogName": "AwsDataCatalog", "Status": "CREATE_COMPLETE"},
+            {"CatalogName": "MyCatalog", "Status": "CREATE_COMPLETE"},
+        ]
     }
     mock_cf.return_value.athena.return_value = mock_athena
 
     resp = await client.get("/api/v0/metadata/athena/catalogs")
     assert resp.status_code == 200
-    assert resp.json() == {"catalogs": ["AwsDataCatalog", "MyCatalog"]}
+    assert resp.json() == {"catalogs": [
+        {"name": "AwsDataCatalog", "status": "CREATE_COMPLETE"},
+        {"name": "MyCatalog", "status": "CREATE_COMPLETE"},
+    ]}
 
 
 @pytest.mark.asyncio

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -1,0 +1,206 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+# --- Athena databases ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.return_value = {
+        "DatabaseList": [{"Name": "db1"}, {"Name": "db2"}]
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases")
+    assert resp.status_code == 200
+    assert resp.json() == {"databases": ["db1", "db2"]}
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases_pagination(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.side_effect = [
+        {"DatabaseList": [{"Name": "db1"}], "NextToken": "tok1"},
+        {"DatabaseList": [{"Name": "db2"}]},
+    ]
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases")
+    assert resp.status_code == 200
+    assert resp.json() == {"databases": ["db1", "db2"]}
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases_custom_catalog(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.return_value = {"DatabaseList": [{"Name": "x"}]}
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases?catalog=MyCatalog")
+    assert resp.status_code == 200
+    mock_athena.list_databases.assert_called_with(CatalogName="MyCatalog")
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases_access_denied(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.side_effect = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "No access"}}, "ListDatabases"
+    )
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases")
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "AccessDeniedException"
+
+
+# --- Athena tables ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_tables(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_table_metadata.return_value = {
+        "TableMetadataList": [{"Name": "t1"}, {"Name": "t2"}]
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/tables?database=mydb")
+    assert resp.status_code == 200
+    assert resp.json() == {"tables": ["t1", "t2"]}
+
+
+@pytest.mark.asyncio
+async def test_list_tables_missing_database(client):
+    resp = await client.get("/api/v0/metadata/athena/tables")
+    assert resp.status_code == 422
+
+
+# --- Athena columns ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_columns(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.get_table_metadata.return_value = {
+        "TableMetadata": {"Columns": [{"Name": "id", "Type": "int"}, {"Name": "name", "Type": "string"}]}
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/columns?database=mydb&table=mytable")
+    assert resp.status_code == 200
+    assert resp.json() == {"columns": [{"name": "id", "type": "int"}, {"name": "name", "type": "string"}]}
+
+
+@pytest.mark.asyncio
+async def test_list_columns_missing_params(client):
+    resp = await client.get("/api/v0/metadata/athena/columns?database=mydb")
+    assert resp.status_code == 422
+
+
+# --- S3 buckets ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.Settings")
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_s3_buckets(mock_cf, mock_settings, client):
+    mock_s3 = MagicMock()
+    mock_s3.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}, {"Name": "bucket2"}]}
+    mock_cf.return_value.s3.return_value = mock_s3
+    mock_settings.from_env.return_value.region = "us-west-2"
+
+    resp = await client.get("/api/v0/metadata/s3/buckets")
+    assert resp.status_code == 200
+    assert resp.json() == {"buckets": ["bucket1", "bucket2"]}
+    mock_s3.list_buckets.assert_called_with(BucketRegion="us-west-2")
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.Settings")
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_s3_buckets_no_region(mock_cf, mock_settings, client):
+    mock_s3 = MagicMock()
+    mock_s3.list_buckets.return_value = {"Buckets": [{"Name": "b1"}]}
+    mock_cf.return_value.s3.return_value = mock_s3
+    mock_settings.from_env.return_value.region = ""
+
+    resp = await client.get("/api/v0/metadata/s3/buckets")
+    assert resp.status_code == 200
+    mock_s3.list_buckets.assert_called_with()
+
+
+# --- Neptune graphs ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_neptune_graphs(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.list_graphs.return_value = {
+        "graphs": [
+            {"id": "g-123", "name": "my-graph", "status": "AVAILABLE"},
+            {"id": "g-456", "name": "other", "status": "CREATING"},
+        ]
+    }
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/metadata/neptune/graphs")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "graphs": [
+            {"id": "g-123", "name": "my-graph", "status": "AVAILABLE"},
+            {"id": "g-456", "name": "other", "status": "CREATING"},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_neptune_graphs_empty(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.list_graphs.return_value = {"graphs": []}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/metadata/neptune/graphs")
+    assert resp.status_code == 200
+    assert resp.json() == {"graphs": []}
+
+
+# --- Error handler tests ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_unknown_aws_error_returns_502(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.list_graphs.side_effect = ClientError(
+        {"Error": {"Code": "InternalServerError", "Message": "Something broke"}}, "ListGraphs"
+    )
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/metadata/neptune/graphs")
+    assert resp.status_code == 502
+    assert resp.json()["error"] == "InternalServerError"


### PR DESCRIPTION
## Summary

Adds metadata REST endpoints to the nx-neptune proxy, providing the API contract for the import UI to discover AWS resources.

## Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/v0/metadata/athena/databases` | List Athena databases |
| GET | `/api/v0/metadata/athena/tables` | List tables in a database |
| GET | `/api/v0/metadata/athena/columns` | List columns for a table |
| GET | `/api/v0/metadata/s3/buckets` | List S3 buckets (region-filtered) |
| GET | `/api/v0/metadata/neptune/graphs` | List Neptune Analytics graphs |

## Architecture

- **App-level `ClientError` handler** — maps AWS errors to HTTP status codes (403, 404, 400, 502, 503). Endpoints don't need try/except.
- **`paginate_aws()` utility** — reusable pagination for any AWS list API with `NextToken`.
- **Pydantic response models** — typed contracts, auto-documented in `/docs`.
- **`ClientFactory()`** from `nx_neptune` — consistent AWS client configuration.
- Region sourced from `AWS_DEFAULT_REGION` env var.

## Files changed (9 files, +373 lines)

- `proxy/Dockerfile` — installs `nx_neptune` from source
- `proxy/pyproject.toml` — adds `nx-neptune` dependency
- `proxy/src/nx_neptune_proxy/app.py` — error handlers, router registration
- `proxy/src/nx_neptune_proxy/config.py` — adds `region` setting
- `proxy/src/nx_neptune_proxy/routers/metadata.py` — endpoint logic
- `proxy/src/nx_neptune_proxy/routers/schemas.py` — Pydantic response models
- `proxy/src/nx_neptune_proxy/utils/__init__.py` — `paginate_aws()` helper
- `proxy/tests/test_metadata.py` — 13 unit tests

## Testing

- 18 tests pass (5 existing + 13 new)
- Covers: happy path, pagination, custom catalog, missing params (422), access denied (403), unknown AWS errors (502)
- Verify the API over swagger 


<img width="851" height="591" alt="image" src="https://github.com/user-attachments/assets/3d6b4a98-5bca-4ea6-a7ce-1fb8ce87891e" />
