### PR TITLE
Feat: Projection API and import UI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,3 +119,22 @@ jobs:
               issue_number: prNumber,
               body: `📊 **Coverage Report**: Download the HTML report [here](${artifactUrl}).`
             });
+
+  proxy_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.11]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install proxy with test deps
+        run: pip install -e ".[test]"
+        working-directory: proxy
+      - name: Run proxy tests
+        run: pytest tests/ -v
+        working-directory: proxy

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -238,7 +238,7 @@ def check_athena_query(
             exec_id = _execute_athena_query(athena, wrapped, output_location, catalog=catalog, database=database)
 
             asyncio.run(
-                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena, polling_interval=1)
+                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena, polling_interval=3)
             )
 
             resp = athena.get_query_execution(QueryExecutionId=exec_id)

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -16,6 +16,7 @@ from typing import Optional
 from botocore.exceptions import ClientError
 
 from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune.instance_management import _execute_athena_query
 from nx_neptune.clients.response_utils import (
     get_caller_arn,
     get_graph_names,
@@ -215,6 +216,12 @@ def check_athena_table(
     )
 
 
+def wrap_with_limit(query: str, limit: int) -> str:
+    """Strip any existing LIMIT clause and append a new one."""
+    stripped = re.sub(r"\s+LIMIT\s+\d+\s*$", "", query.rstrip(), flags=re.IGNORECASE)
+    return f"{stripped} LIMIT {limit}"
+
+
 def check_athena_query(
     sql_query: str, database: str, output_location: str, catalog: str = "AwsDataCatalog"
 ) -> CheckResult:
@@ -226,19 +233,12 @@ def check_athena_query(
         athena = ClientFactory().athena()
 
         for i, q in enumerate(queries):
-            stripped = re.sub(
-                r"\s+LIMIT\s+\d+\s*$", "", q.rstrip(), flags=re.IGNORECASE
-            )
-            wrapped = f"{stripped} LIMIT 0"
+            wrapped = wrap_with_limit(q, 0)
 
-            exec_id = athena.start_query_execution(
-                QueryString=wrapped,
-                QueryExecutionContext={"Catalog": catalog, "Database": database},
-                ResultConfiguration={"OutputLocation": output_location},
-            )["QueryExecutionId"]
+            exec_id = _execute_athena_query(athena, wrapped, output_location, catalog=catalog, database=database)
 
             asyncio.run(
-                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena, polling_interval=5)
+                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena, polling_interval=1)
             )
 
             resp = athena.get_query_execution(QueryExecutionId=exec_id)

--- a/nx_neptune/validators.py
+++ b/nx_neptune/validators.py
@@ -238,7 +238,7 @@ def check_athena_query(
             )["QueryExecutionId"]
 
             asyncio.run(
-                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena)
+                wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, athena, polling_interval=5)
             )
 
             resp = athena.get_query_execution(QueryExecutionId=exec_id)

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY proxy/ ./proxy/
+RUN pip install --no-cache-dir ./proxy && useradd --create-home appuser
+USER appuser
+EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=3s --retries=3 \
+    CMD wget -qO /dev/null http://localhost:8080/health
+CMD ["uvicorn", "nx_neptune_proxy.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.11-slim
 WORKDIR /app
+COPY nx_neptune/ ./nx_neptune_src/nx_neptune/
+COPY nx_plugin/ ./nx_neptune_src/nx_plugin/
+COPY pyproject.toml ./nx_neptune_src/
 COPY proxy/ ./proxy/
-RUN pip install --no-cache-dir ./proxy && useradd --create-home appuser
+RUN pip install --no-cache-dir ./nx_neptune_src ./proxy && useradd --create-home appuser
 USER appuser
 EXPOSE 8080
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 \

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -1,0 +1,32 @@
+.PHONY: dev install test build run stop clean
+
+RUNTIME ?= finch
+
+dev:              ## Run with auto-reload for development.
+	uvicorn nx_neptune_proxy.app:app --reload --port 8080
+
+install:          ## Install proxy in editable mode with test deps.
+	pip install -e ".[test]"
+
+test:             ## Run tests.
+	pytest tests/ -v
+
+build:            ## Build container image.
+	$(RUNTIME) build -t nx-neptune-proxy -f Dockerfile ..
+
+run:              ## Run container with AWS credentials from environment.
+	$(RUNTIME) run --rm --name nx-neptune-proxy -p 8080:8080 \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e AWS_DEFAULT_REGION \
+		-e CORS_ALLOWED_ORIGINS \
+		-e LOG_LEVEL \
+		nx-neptune-proxy
+
+stop:             ## Stop running container.
+	@$(RUNTIME) stop nx-neptune-proxy 2>/dev/null || true
+
+clean:            ## Remove container and image.
+	@$(RUNTIME) rm nx-neptune-proxy 2>/dev/null || true
+	@$(RUNTIME) rmi nx-neptune-proxy 2>/dev/null || true

--- a/proxy/pyproject.toml
+++ b/proxy/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "fastapi==0.115.12",
     "uvicorn[standard]==0.34.2",
+    "nx-neptune",
 ]
 
 [project.urls]

--- a/proxy/pyproject.toml
+++ b/proxy/pyproject.toml
@@ -1,0 +1,62 @@
+[build-system]
+build-backend = 'setuptools.build_meta'
+requires = ['setuptools>=61.2']
+
+[project]
+name = "nx-neptune-proxy"
+description = "REST proxy for nx-neptune graph-over-data-lake workflows"
+authors = [{name = "Amazon Web Services"}]
+requires-python = ">=3.11"
+version = "0.1.0"
+keywords = ["neptune", "neptune-analytics", "rest", "proxy", "fastapi"]
+license = {text = "Apache-2.0"}
+classifiers = [
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3 :: Only',
+]
+
+dependencies = [
+    "fastapi==0.115.12",
+    "uvicorn[standard]==0.34.2",
+]
+
+[project.urls]
+"Bug Tracker" = 'https://github.com/awslabs/nx-neptune/issues'
+"Source Code" = 'https://github.com/awslabs/nx-neptune'
+
+[project.optional-dependencies]
+test = [
+    'pytest>=7.2',
+    'pytest-asyncio>=0.26.0',
+    'httpx>=0.28,<1',
+]
+
+[tool.setuptools]
+zip-safe = false
+include-package-data = false
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.isort]
+profile = "black"
+
+[tool.flake8]
+max-complexity = 12
+max-line-length = 127
+extend-ignore = ['E203','W503']
+
+[tool.black]
+target-version = ['py311', 'py312', 'py313']
+
+[tool.mypy]
+exclude = []
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/proxy/src/nx_neptune_proxy/__init__.py
+++ b/proxy/src/nx_neptune_proxy/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -1,0 +1,82 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import time
+import uuid
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+from nx_neptune_proxy.config import Settings
+
+settings = Settings.from_env()
+
+# --- Structured logging ---
+
+logging.basicConfig(
+    level=settings.log_level,
+    format='{"time":"%(asctime)s","level":"%(levelname)s","logger":"%(name)s","message":"%(message)s"}',
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("nx_neptune_proxy")
+
+
+# --- App ---
+
+app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url="/docs", redoc_url=None)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_origins,
+    allow_methods=["GET", "POST", "DELETE"],
+    allow_headers=["*"],
+)
+
+
+# --- Request logging middleware ---
+
+
+@app.middleware("http")
+async def request_logging(request: Request, call_next):
+    request_id = request.headers.get("x-request-id", str(uuid.uuid4()))
+    start = time.time()
+    response = await call_next(request)
+    duration_ms = (time.time() - start) * 1000
+    logger.info(
+        f"{request.method} {request.url.path} {response.status_code} {duration_ms:.0f}ms request_id={request_id}"
+    )
+    response.headers["x-request-id"] = request_id
+    return response
+
+
+# --- Global error handler ---
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    logger.exception(f"Unhandled error on {request.method} {request.url.path}")
+    return JSONResponse(
+        status_code=500,
+        content={"error": "internal_server_error", "message": "An unexpected error occurred"},
+    )
+
+
+# --- Health ---
+
+
+@app.get("/health")
+def health():
+    return {"status": "healthy"}
+
+
+# --- Static UI (must be last — catch-all) ---
+
+UI_DIR = Path(__file__).parent.parent.parent / "ui"
+if not UI_DIR.exists():
+    UI_DIR = Path("/app/proxy/ui")
+if UI_DIR.exists():
+    app.mount("/", StaticFiles(directory=UI_DIR, html=True), name="ui")

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -14,6 +14,7 @@ from fastapi.staticfiles import StaticFiles
 
 from nx_neptune_proxy.config import Settings
 from nx_neptune_proxy.routers.metadata import router as metadata_router
+from nx_neptune_proxy.routers.projection import router as projection_router
 
 settings = Settings.from_env()
 
@@ -96,9 +97,15 @@ def health():
     return {"status": "healthy"}
 
 
+@app.get("/api/v0/info", summary="Service info")
+def info():
+    return {"name": "nx-neptune-proxy", "version": "0.1.0"}
+
+
 # --- Routers ---
 
 app.include_router(metadata_router)
+app.include_router(projection_router)
 
 
 # --- Static UI (must be last — catch-all) ---

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -6,12 +6,14 @@ import time
 import uuid
 from pathlib import Path
 
+from botocore.exceptions import ClientError
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.routers.metadata import router as metadata_router
 
 settings = Settings.from_env()
 
@@ -53,7 +55,28 @@ async def request_logging(request: Request, call_next):
     return response
 
 
-# --- Global error handler ---
+# --- Error handlers ---
+
+_AWS_STATUS_MAP = {
+    "AccessDeniedException": 403,
+    "UnauthorizedAccess": 403,
+    "ResourceNotFoundException": 404,
+    "MetadataException": 400,
+    "InvalidRequestException": 400,
+    "ThrottlingException": 503,
+}
+
+
+@app.exception_handler(ClientError)
+async def aws_exception_handler(request: Request, exc: ClientError):
+    code = exc.response["Error"]["Code"]
+    message = exc.response["Error"]["Message"]
+    status = _AWS_STATUS_MAP.get(code, 502)
+    logger.warning(f"AWS {code} on {request.method} {request.url.path}: {message}")
+    return JSONResponse(
+        status_code=status,
+        content={"error": code, "message": message},
+    )
 
 
 @app.exception_handler(Exception)
@@ -71,6 +94,11 @@ async def global_exception_handler(request: Request, exc: Exception):
 @app.get("/health")
 def health():
     return {"status": "healthy"}
+
+
+# --- Routers ---
+
+app.include_router(metadata_router)
 
 
 # --- Static UI (must be last — catch-all) ---

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Application settings loaded from environment variables."""
+
+    log_level: str = "INFO"
+    allowed_origins: list[str] = None  # type: ignore[assignment]
+    port: int = 8080
+
+    def __post_init__(self) -> None:
+        if self.allowed_origins is None:
+            object.__setattr__(self, "allowed_origins", [])
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        origins_raw = os.environ.get("CORS_ALLOWED_ORIGINS", "")
+        origins = [o.strip() for o in origins_raw.split(",") if o.strip()] if origins_raw else []
+        return cls(
+            log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+            allowed_origins=origins,
+            port=int(os.environ.get("PORT", "8080")),
+        )

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -12,6 +12,7 @@ class Settings:
     log_level: str = "INFO"
     allowed_origins: list[str] = None  # type: ignore[assignment]
     port: int = 8080
+    region: str = ""
 
     def __post_init__(self) -> None:
         if self.allowed_origins is None:
@@ -25,4 +26,5 @@ class Settings:
             log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
             allowed_origins=origins,
             port=int(os.environ.get("PORT", "8080")),
+            region=os.environ.get("AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")),
         )

--- a/proxy/src/nx_neptune_proxy/routers/__init__.py
+++ b/proxy/src/nx_neptune_proxy/routers/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from fastapi import APIRouter, Query
+
+from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.routers.schemas import (
+    BucketsResponse,
+    CatalogsResponse,
+    ColumnsResponse,
+    DatabasesResponse,
+    NeptuneAnalyticsGraphsResponse,
+    TablesResponse,
+)
+from nx_neptune_proxy.utils import paginate_aws
+
+router = APIRouter(prefix="/api/v0/metadata", tags=["metadata"])
+
+
+@router.get("/athena/catalogs", summary="List Athena data catalogs", response_model=CatalogsResponse)
+def list_athena_catalogs():
+    """List all Athena data catalogs"""
+    client = ClientFactory().athena()
+    items = paginate_aws(client.list_data_catalogs, "DataCatalogsSummary")
+    return {"catalogs": [{"name": c["CatalogName"], "status": c.get("Status", "")} for c in items]}
+
+
+@router.get("/athena/databases", summary="List Athena databases", response_model=DatabasesResponse)
+def list_athena_databases(catalog: str = Query("AwsDataCatalog", description="Athena catalog name")):
+    """List all databases in the specified Athena catalog"""
+    client = ClientFactory().athena()
+    items = paginate_aws(client.list_databases, "DatabaseList", CatalogName=catalog)
+    return {"databases": [db["Name"] for db in items]}
+
+
+@router.get("/athena/tables", summary="List Athena tables", response_model=TablesResponse)
+def list_athena_tables(
+    database: str = Query(..., description="Database name"),
+    catalog: str = Query("AwsDataCatalog", description="Athena catalog name"),
+):
+    """List all tables in the specified Athena database"""
+    client = ClientFactory().athena()
+    items = paginate_aws(client.list_table_metadata, "TableMetadataList", CatalogName=catalog, DatabaseName=database)
+    return {"tables": [t["Name"] for t in items]}
+
+
+@router.get("/athena/columns", summary="List Athena table columns", response_model=ColumnsResponse)
+def list_athena_columns(
+    database: str = Query(..., description="Database name"),
+    table: str = Query(..., description="Table name"),
+    catalog: str = Query("AwsDataCatalog", description="Athena catalog name"),
+):
+    """List columns and their types for the specified Athena table"""
+    client = ClientFactory().athena()
+    resp = client.get_table_metadata(CatalogName=catalog, DatabaseName=database, TableName=table)
+    columns = resp["TableMetadata"].get("Columns", [])
+    return {"columns": [{"name": c["Name"], "type": c["Type"]} for c in columns]}
+
+
+@router.get("/s3/buckets", summary="List S3 buckets", response_model=BucketsResponse)
+def list_s3_buckets():
+    """List S3 buckets in the configured region"""
+    filter_region = Settings.from_env().region
+    if not filter_region:
+        return {"buckets": []}
+    client = ClientFactory().s3()
+    buckets = [b["Name"] for b in client.list_buckets(BucketRegion=filter_region).get("Buckets", [])]
+    return {"buckets": buckets}
+
+
+@router.get("/neptune/graph-analytics", summary="List Neptune Analytics graphs", response_model=NeptuneAnalyticsGraphsResponse)
+def list_neptune_graphs():
+    """List all Neptune Analytics graphs in the configured region"""
+    client = ClientFactory().neptune()
+    items = paginate_aws(client.list_graphs, "graphs")
+    return {"graphs": [{"id": g["id"], "name": g["name"], "status": g["status"]} for g in items]}

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import re
 
 from dataclasses import asdict
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 
 from nx_neptune.clients.client_factory import ClientFactory
-from nx_neptune.validators import check_athena_query, validate_resources
+from nx_neptune.clients.response_utils import get_query_failure_reason, get_query_state
+from nx_neptune.instance_management import _execute_athena_query, get_athena_query_results
+from nx_neptune.utils.task_future import TaskType, wait_until_all_complete
+from nx_neptune.validators import check_athena_query, validate_resources, wrap_with_limit
 from nx_neptune_proxy.routers.schemas import (
     PreviewResponse,
     ProjectionCreate,
@@ -19,6 +21,7 @@ from nx_neptune_proxy.routers.schemas import (
 )
 from nx_neptune_proxy.services.pipeline import run_pipeline
 from nx_neptune_proxy.services.projection_store import store
+from nx_neptune_proxy.utils import unpack_query_results
 
 router = APIRouter(prefix="/api/v0/projection", tags=["projection"])
 
@@ -99,40 +102,21 @@ def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le=1000)
     all_results = []
 
     for q in queries:
-        stripped = re.sub(r"\s+LIMIT\s+\d+\s*$", "", q.rstrip(), flags=re.IGNORECASE)
-        limited = f"{stripped} LIMIT {limit}"
+        limited = wrap_with_limit(q, limit)
 
-        rows, columns = _run_athena_preview(client, limited, p.catalog, p.database, p.s3_staging_bucket)
-        if columns is None:
-            return {"error": rows, "results": all_results}
-        all_results.append({"columns": columns, "rows": rows})
+        exec_id = _execute_athena_query(client, limited, p.s3_staging_bucket, catalog=p.catalog, database=p.database)
+
+        asyncio.run(wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, client, polling_interval=5))
+
+        resp = client.get_query_execution(QueryExecutionId=exec_id)
+        state = get_query_state(resp)
+        if state != "SUCCEEDED":
+            return {"error": get_query_failure_reason(resp), "results": all_results}
+
+        rows = get_athena_query_results(query_execution_id=exec_id, client=client)
+        all_results.append(unpack_query_results(rows))
 
     return {"error": None, "results": all_results}
-
-
-def _run_athena_preview(client, query: str, catalog: str, database: str, output_location: str):
-    """Run a query and return (rows, columns) or (error_string, None)."""
-    import time
-
-    exec_id = client.start_query_execution(
-        QueryString=query,
-        QueryExecutionContext={"Catalog": catalog, "Database": database},
-        ResultConfiguration={"OutputLocation": output_location},
-    )["QueryExecutionId"]
-
-    while True:
-        resp = client.get_query_execution(QueryExecutionId=exec_id)
-        state = resp["QueryExecution"]["Status"]["State"]
-        if state == "SUCCEEDED":
-            break
-        if state in ("FAILED", "CANCELLED"):
-            return resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error"), None
-        time.sleep(1)
-
-    results = client.get_query_results(QueryExecutionId=exec_id)
-    columns = [c["Name"] for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
-    rows = [[d.get("VarCharValue", "") for d in row["Data"]] for row in results["ResultSet"]["Rows"][1:]]
-    return rows, columns
 
 
 @router.post("/{projection_id}/execute", summary="Start import pipeline", status_code=202)

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -8,7 +8,6 @@ from dataclasses import asdict
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 
 from nx_neptune.clients.client_factory import ClientFactory
-from nx_neptune.instance_management import execute_athena_query, get_athena_query_results
 from nx_neptune.validators import check_athena_query, validate_resources
 from nx_neptune_proxy.routers.schemas import (
     PreviewResponse,
@@ -72,8 +71,7 @@ def validate_projection(projection_id: str):
     checks = validate_resources(
         s3_staging_bucket=p.s3_staging_bucket,
         athena_catalog=p.catalog,
-        athena_database=p.database,
-        sql_query=p.sql_query,
+        athena_database=p.database
     )
     return {"valid": all(c["passed"] for c in checks), "checks": checks}
 
@@ -104,21 +102,37 @@ def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le=1000)
         stripped = re.sub(r"\s+LIMIT\s+\d+\s*$", "", q.rstrip(), flags=re.IGNORECASE)
         limited = f"{stripped} LIMIT {limit}"
 
-        exec_ids = execute_athena_query(
-            sql_statement=limited,
-            output_location=p.s3_staging_bucket,
-            catalog=p.catalog,
-            database=p.database,
-            client=client,
-        )
-        exec_id = exec_ids[0] if isinstance(exec_ids, list) else exec_ids
-
-        rows = get_athena_query_results(query_execution_id=exec_id, client=client)
-        columns = rows[0] if rows else []
-        data_rows = rows[1:] if len(rows) > 1 else []
-        all_results.append({"columns": columns, "rows": data_rows})
+        rows, columns = _run_athena_preview(client, limited, p.catalog, p.database, p.s3_staging_bucket)
+        if columns is None:
+            return {"error": rows, "results": all_results}
+        all_results.append({"columns": columns, "rows": rows})
 
     return {"error": None, "results": all_results}
+
+
+def _run_athena_preview(client, query: str, catalog: str, database: str, output_location: str):
+    """Run a query and return (rows, columns) or (error_string, None)."""
+    import time
+
+    exec_id = client.start_query_execution(
+        QueryString=query,
+        QueryExecutionContext={"Catalog": catalog, "Database": database},
+        ResultConfiguration={"OutputLocation": output_location},
+    )["QueryExecutionId"]
+
+    while True:
+        resp = client.get_query_execution(QueryExecutionId=exec_id)
+        state = resp["QueryExecution"]["Status"]["State"]
+        if state == "SUCCEEDED":
+            break
+        if state in ("FAILED", "CANCELLED"):
+            return resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown error"), None
+        time.sleep(1)
+
+    results = client.get_query_results(QueryExecutionId=exec_id)
+    columns = [c["Name"] for c in results["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]]
+    rows = [[d.get("VarCharValue", "") for d in row["Data"]] for row in results["ResultSet"]["Rows"][1:]]
+    return rows, columns
 
 
 @router.post("/{projection_id}/execute", summary="Start import pipeline", status_code=202)

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -40,6 +40,12 @@ def create_projection(body: ProjectionCreate):
     return asdict(projection)
 
 
+@router.get("", summary="List all projections", response_model=list[ProjectionResponse])
+def list_projections():
+    """List all projections."""
+    return [asdict(p) for p in store.list()]
+
+
 @router.get("/{projection_id}", summary="Get projection state", response_model=ProjectionResponse)
 def get_projection(projection_id: str):
     """Get full projection state including progress."""

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -64,6 +64,7 @@ def get_projection_status(projection_id: str):
         "step_label": p.step_label,
         "progress": p.progress,
         "error": p.error,
+        "graph_endpoint": p.graph_endpoint,
     }
 
 

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -1,0 +1,131 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import re
+
+from dataclasses import asdict
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+
+from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune.instance_management import execute_athena_query, get_athena_query_results
+from nx_neptune.validators import check_athena_query, validate_resources
+from nx_neptune_proxy.routers.schemas import (
+    PreviewResponse,
+    ProjectionCreate,
+    ProjectionResponse,
+    ProjectionStatus,
+    ProjectionUpdate,
+    ValidateResponse,
+)
+from nx_neptune_proxy.services.pipeline import run_pipeline
+from nx_neptune_proxy.services.projection_store import store
+
+router = APIRouter(prefix="/api/v0/projection", tags=["projection"])
+
+
+def _get_projection_or_404(projection_id: str):
+    projection = store.get(projection_id)
+    if projection is None:
+        raise HTTPException(status_code=404, detail="Projection not found")
+    return projection
+
+
+@router.post("", summary="Create a new projection", response_model=ProjectionResponse, status_code=201)
+def create_projection(body: ProjectionCreate):
+    """Create a new projection in draft state."""
+    projection = store.create(**body.model_dump())
+    return asdict(projection)
+
+
+@router.get("/{projection_id}", summary="Get projection state", response_model=ProjectionResponse)
+def get_projection(projection_id: str):
+    """Get full projection state including progress."""
+    return asdict(_get_projection_or_404(projection_id))
+
+
+@router.put("/{projection_id}", summary="Update projection", response_model=ProjectionResponse)
+def update_projection(projection_id: str, body: ProjectionUpdate):
+    _get_projection_or_404(projection_id)
+    projection = store.update(projection_id, **body.model_dump(exclude_unset=True))
+    return asdict(projection)
+
+
+@router.get("/{projection_id}/status", summary="Get pipeline progress", response_model=ProjectionStatus)
+def get_projection_status(projection_id: str):
+    """Get pipeline progress (subset of full state)."""
+    p = _get_projection_or_404(projection_id)
+    return {
+        "id": p.id,
+        "status": p.status,
+        "step": p.step,
+        "step_label": p.step_label,
+        "progress": p.progress,
+        "error": p.error,
+    }
+
+
+@router.post("/{projection_id}/validate", summary="Validate all resources", response_model=ValidateResponse)
+def validate_projection(projection_id: str):
+    """Run all validators against the projection's configuration."""
+    p = _get_projection_or_404(projection_id)
+    checks = validate_resources(
+        s3_staging_bucket=p.s3_staging_bucket,
+        athena_catalog=p.catalog,
+        athena_database=p.database,
+        sql_query=p.sql_query,
+    )
+    return {"valid": all(c["passed"] for c in checks), "checks": checks}
+
+
+@router.post("/{projection_id}/validate-query", summary="Validate query only", response_model=ValidateResponse)
+def validate_query(projection_id: str):
+    """Validate only the Athena query."""
+    p = _get_projection_or_404(projection_id)
+    result = check_athena_query(
+        sql_query=p.sql_query,
+        catalog=p.catalog,
+        database=p.database,
+        output_location=p.s3_staging_bucket,
+    )
+    return {"valid": result.passed, "checks": [result.to_dict()]}
+
+
+@router.post("/{projection_id}/preview", summary="Preview first N rows", response_model=PreviewResponse)
+def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le=1000)):
+    """Run the query with a LIMIT and return preview rows."""
+    p = _get_projection_or_404(projection_id)
+    client = ClientFactory().athena()
+
+    queries = [q.strip() for q in p.sql_query.split(";") if q.strip()]
+    all_results = []
+
+    for q in queries:
+        stripped = re.sub(r"\s+LIMIT\s+\d+\s*$", "", q.rstrip(), flags=re.IGNORECASE)
+        limited = f"{stripped} LIMIT {limit}"
+
+        exec_ids = execute_athena_query(
+            sql_statement=limited,
+            output_location=p.s3_staging_bucket,
+            catalog=p.catalog,
+            database=p.database,
+            client=client,
+        )
+        exec_id = exec_ids[0] if isinstance(exec_ids, list) else exec_ids
+
+        rows = get_athena_query_results(query_execution_id=exec_id, client=client)
+        columns = rows[0] if rows else []
+        data_rows = rows[1:] if len(rows) > 1 else []
+        all_results.append({"columns": columns, "rows": data_rows})
+
+    return {"error": None, "results": all_results}
+
+
+@router.post("/{projection_id}/execute", summary="Start import pipeline", status_code=202)
+def execute_projection(projection_id: str, background_tasks: BackgroundTasks):
+    """Kick off the full import pipeline as a background task."""
+    p = _get_projection_or_404(projection_id)
+    if p.status == "executing":
+        raise HTTPException(status_code=409, detail="Pipeline already running")
+    background_tasks.add_task(asyncio.run, run_pipeline(p))
+    return {"id": p.id, "status": "accepted"}

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pydantic import BaseModel
+
+
+class DatabasesResponse(BaseModel):
+    databases: list[str]
+
+
+class TablesResponse(BaseModel):
+    tables: list[str]
+
+
+class Column(BaseModel):
+    name: str
+    type: str
+
+
+class ColumnsResponse(BaseModel):
+    columns: list[Column]
+
+
+class BucketsResponse(BaseModel):
+    buckets: list[str]
+
+
+class Catalog(BaseModel):
+    name: str
+    status: str
+
+
+class CatalogsResponse(BaseModel):
+    catalogs: list[Catalog]
+
+
+class NeptuneAnalyticsGraph(BaseModel):
+    id: str
+    name: str
+    status: str
+
+
+class NeptuneAnalyticsGraphsResponse(BaseModel):
+    graphs: list[NeptuneAnalyticsGraph]

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -1,7 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
+from typing import Optional
+
 from pydantic import BaseModel
+
+
+# --- Metadata responses ---
 
 
 class DatabasesResponse(BaseModel):
@@ -42,3 +48,73 @@ class NeptuneAnalyticsGraph(BaseModel):
 
 class NeptuneAnalyticsGraphsResponse(BaseModel):
     graphs: list[NeptuneAnalyticsGraph]
+
+
+# --- Projection ---
+
+
+class ProjectionCreate(BaseModel):
+    catalog: str = "AwsDataCatalog"
+    database: Optional[str] = None
+    sql_query: Optional[str] = None
+    graph_name: Optional[str] = None
+    graph_memory_gb: int = 16
+    s3_staging_bucket: Optional[str] = None
+
+
+class ProjectionUpdate(BaseModel):
+    catalog: Optional[str] = None
+    database: Optional[str] = None
+    sql_query: Optional[str] = None
+    graph_name: Optional[str] = None
+    graph_memory_gb: Optional[int] = None
+    s3_staging_bucket: Optional[str] = None
+
+
+class CheckResult(BaseModel):
+    check: str
+    passed: bool
+    message: Optional[str] = None
+
+
+class ValidateResponse(BaseModel):
+    valid: bool
+    checks: list[CheckResult]
+
+
+class PreviewQueryResult(BaseModel):
+    columns: list[str]
+    rows: list[list[str]]
+
+
+class PreviewResponse(BaseModel):
+    error: Optional[str] = None
+    results: list[PreviewQueryResult]
+
+
+class ProjectionStatus(BaseModel):
+    id: str
+    status: str
+    step: Optional[str] = None
+    step_label: Optional[str] = None
+    progress: float = 0
+    error: Optional[str] = None
+    graph_endpoint: Optional[str] = None
+
+
+class ProjectionResponse(BaseModel):
+    id: str
+    status: str
+    catalog: str
+    database: Optional[str] = None
+    sql_query: Optional[str] = None
+    graph_name: Optional[str] = None
+    graph_id: Optional[str] = None
+    graph_endpoint: Optional[str] = None
+    graph_memory_gb: int
+    s3_staging_bucket: Optional[str] = None
+    step: Optional[str] = None
+    step_label: Optional[str] = None
+    progress: float = 0
+    error: Optional[str] = None
+    created_at: datetime

--- a/proxy/src/nx_neptune_proxy/services/__init__.py
+++ b/proxy/src/nx_neptune_proxy/services/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -1,0 +1,57 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from nx_neptune_proxy.services.projection_store import GRAPH_PREFIX, Projection
+
+logger = logging.getLogger(__name__)
+
+
+async def run_pipeline(projection: Projection) -> None:
+    """Execute the full pipeline: create graph → Athena → import."""
+    from nx_neptune.session_manager import SessionManager
+
+    graph_name = f"{GRAPH_PREFIX}{projection.graph_name}"
+    s3_location = projection.s3_staging_bucket.rstrip("/") + f"/{projection.id}/"
+
+    try:
+        projection.status = "executing"
+
+        # Step 1: Create graph
+        _update(projection, step="graph_creation", label="Creating Neptune Analytics graph", progress=5)
+        sm = SessionManager(session_name=graph_name)
+        graph = await sm.get_or_create_graph(
+            config={"provisionedMemory": projection.graph_memory_gb}
+        )
+        projection.graph_id = graph.graph_id
+        projection.graph_endpoint = f"https://{graph.graph_id}.neptune-graph.amazonaws.com"
+        _update(projection, step="graph_creation", label="Graph available", progress=40)
+
+        # Step 2: Athena query + CSV import
+        _update(projection, step="athena_import", label="Running Athena query and importing data", progress=45)
+        sql_queries = [q.strip() for q in projection.sql_query.split(";") if q.strip()]
+        await sm.import_from_table(
+            graph=graph,
+            s3_location=s3_location,
+            sql_queries=sql_queries,
+            catalog=projection.catalog,
+            database=projection.database,
+            remove_buckets=True,
+        )
+        _update(projection, step="athena_import", label="Import complete", progress=90)
+
+        # Step 3: Done
+        _update(projection, step="ready", label="Graph ready", progress=100)
+        projection.status = "complete"
+
+    except Exception as e:
+        logger.exception("Pipeline failed")
+        projection.status = "failed"
+        projection.error = str(e)
+
+
+def _update(projection: Projection, step: str, label: str, progress: float) -> None:
+    projection.step = step
+    projection.step_label = label
+    projection.progress = progress

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -55,6 +55,9 @@ class ProjectionStore:
     def get(self, projection_id: str) -> Optional[Projection]:
         return self._projections.get(projection_id)
 
+    def list(self) -> list[Projection]:
+        return list(self._projections.values())
+
     def update(self, projection_id: str, **kwargs) -> Optional[Projection]:
         projection = self._projections.get(projection_id)
         if projection is None:

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -1,0 +1,72 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+GRAPH_PREFIX = "nxp-"
+
+
+@dataclass
+class Projection:
+    """State for a single projection pipeline."""
+
+    id: str
+    status: str  # draft | validating | validated | executing | complete | failed
+    catalog: str = "AwsDataCatalog"
+    database: Optional[str] = None
+    sql_query: Optional[str] = None
+    graph_name: Optional[str] = None
+    graph_memory_gb: int = 16
+    s3_staging_bucket: Optional[str] = None
+    graph_id: Optional[str] = None
+    graph_endpoint: Optional[str] = None
+    step: Optional[str] = None
+    step_label: Optional[str] = None
+    progress: float = 0
+    error: Optional[str] = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class ProjectionStore:
+    """In-memory projection state store."""
+
+    def __init__(self) -> None:
+        self._projections: dict[str, Projection] = {}
+
+    def create(self, catalog: str = "AwsDataCatalog", database: str = None,
+               sql_query: str = None, graph_name: str = None,
+               graph_memory_gb: int = 16, s3_staging_bucket: str = None) -> Projection:
+        projection = Projection(
+            id=str(uuid.uuid4()),
+            status="draft",
+            catalog=catalog,
+            database=database,
+            sql_query=sql_query,
+            graph_name=graph_name,
+            graph_memory_gb=graph_memory_gb,
+            s3_staging_bucket=s3_staging_bucket,
+        )
+        self._projections[projection.id] = projection
+        return projection
+
+    def get(self, projection_id: str) -> Optional[Projection]:
+        return self._projections.get(projection_id)
+
+    def update(self, projection_id: str, **kwargs) -> Optional[Projection]:
+        projection = self._projections.get(projection_id)
+        if projection is None:
+            return None
+        for key, value in kwargs.items():
+            if value is not None and hasattr(projection, key):
+                setattr(projection, key, value)
+        return projection
+
+    def delete(self, projection_id: str) -> bool:
+        return self._projections.pop(projection_id, None) is not None
+
+
+# Singleton store instance
+store = ProjectionStore()

--- a/proxy/src/nx_neptune_proxy/utils/__init__.py
+++ b/proxy/src/nx_neptune_proxy/utils/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .aws_helper import paginate_aws
+
+__all__ = ["paginate_aws"]

--- a/proxy/src/nx_neptune_proxy/utils/__init__.py
+++ b/proxy/src/nx_neptune_proxy/utils/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from .aws_helper import paginate_aws
+from .aws_helper import paginate_aws, unpack_query_results
 
-__all__ = ["paginate_aws"]
+__all__ = ["paginate_aws", "unpack_query_results"]

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -23,3 +23,10 @@ def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
             break
         kwargs["NextToken"] = resp.get("NextToken") or resp.get("nextToken")
     return items
+
+
+def unpack_query_results(rows: list) -> dict:
+    """Convert raw query rows (header + data) into {columns, rows} dict."""
+    columns = rows[0] if rows else []
+    data_rows = rows[1:] if len(rows) > 1 else []
+    return {"columns": columns, "rows": data_rows}

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Callable
+
+
+def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
+    """Paginate an AWS API call that uses NextToken.
+
+    Args:
+        method: The boto3 client method to call (e.g., client.list_databases).
+        result_key: The key in the response containing the list items.
+        **kwargs: Arguments passed to the API call.
+
+    Returns:
+        Collected list of all items across all pages.
+    """
+    items = []
+    while True:
+        resp = method(**kwargs)
+        items.extend(resp.get(result_key, []))
+        if "NextToken" not in resp and "nextToken" not in resp:
+            break
+        kwargs["NextToken"] = resp.get("NextToken") or resp.get("nextToken")
+    return items

--- a/proxy/tests/test_app.py
+++ b/proxy/tests/test_app.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_health(client):
+    resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "healthy"}
+
+
+@pytest.mark.asyncio
+async def test_health_returns_request_id(client):
+    resp = await client.get("/health")
+    assert "x-request-id" in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_custom_request_id_echoed(client):
+    resp = await client.get("/health", headers={"x-request-id": "abc-123"})
+    assert resp.headers["x-request-id"] == "abc-123"
+
+
+@pytest.mark.asyncio
+async def test_not_found_returns_404(client):
+    resp = await client.get("/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_openapi_docs_available(client):
+    resp = await client.get("/docs")
+    assert resp.status_code == 200

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -1,0 +1,223 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+# --- Athena databases ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_catalogs(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_data_catalogs.return_value = {
+        "DataCatalogsSummary": [
+            {"CatalogName": "AwsDataCatalog", "Status": "CREATE_COMPLETE"},
+            {"CatalogName": "MyCatalog", "Status": "CREATE_COMPLETE"},
+        ]
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/catalogs")
+    assert resp.status_code == 200
+    assert resp.json() == {"catalogs": [
+        {"name": "AwsDataCatalog", "status": "CREATE_COMPLETE"},
+        {"name": "MyCatalog", "status": "CREATE_COMPLETE"},
+    ]}
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.return_value = {
+        "DatabaseList": [{"Name": "db1"}, {"Name": "db2"}]
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases")
+    assert resp.status_code == 200
+    assert resp.json() == {"databases": ["db1", "db2"]}
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases_pagination(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.side_effect = [
+        {"DatabaseList": [{"Name": "db1"}], "NextToken": "tok1"},
+        {"DatabaseList": [{"Name": "db2"}]},
+    ]
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases")
+    assert resp.status_code == 200
+    assert resp.json() == {"databases": ["db1", "db2"]}
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases_custom_catalog(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.return_value = {"DatabaseList": [{"Name": "x"}]}
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases?catalog=MyCatalog")
+    assert resp.status_code == 200
+    mock_athena.list_databases.assert_called_with(CatalogName="MyCatalog")
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_databases_access_denied(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_databases.side_effect = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "No access"}}, "ListDatabases"
+    )
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/databases")
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "AccessDeniedException"
+
+
+# --- Athena tables ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_tables(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.list_table_metadata.return_value = {
+        "TableMetadataList": [{"Name": "t1"}, {"Name": "t2"}]
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/tables?database=mydb")
+    assert resp.status_code == 200
+    assert resp.json() == {"tables": ["t1", "t2"]}
+
+
+@pytest.mark.asyncio
+async def test_list_tables_missing_database(client):
+    resp = await client.get("/api/v0/metadata/athena/tables")
+    assert resp.status_code == 422
+
+
+# --- Athena columns ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_columns(mock_cf, client):
+    mock_athena = MagicMock()
+    mock_athena.get_table_metadata.return_value = {
+        "TableMetadata": {"Columns": [{"Name": "id", "Type": "int"}, {"Name": "name", "Type": "string"}]}
+    }
+    mock_cf.return_value.athena.return_value = mock_athena
+
+    resp = await client.get("/api/v0/metadata/athena/columns?database=mydb&table=mytable")
+    assert resp.status_code == 200
+    assert resp.json() == {"columns": [{"name": "id", "type": "int"}, {"name": "name", "type": "string"}]}
+
+
+@pytest.mark.asyncio
+async def test_list_columns_missing_params(client):
+    resp = await client.get("/api/v0/metadata/athena/columns?database=mydb")
+    assert resp.status_code == 422
+
+
+# --- S3 buckets ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.Settings")
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_s3_buckets(mock_cf, mock_settings, client):
+    mock_s3 = MagicMock()
+    mock_s3.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}, {"Name": "bucket2"}]}
+    mock_cf.return_value.s3.return_value = mock_s3
+    mock_settings.from_env.return_value.region = "us-west-2"
+
+    resp = await client.get("/api/v0/metadata/s3/buckets")
+    assert resp.status_code == 200
+    assert resp.json() == {"buckets": ["bucket1", "bucket2"]}
+    mock_s3.list_buckets.assert_called_with(BucketRegion="us-west-2")
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.Settings")
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_s3_buckets_no_region(mock_cf, mock_settings, client):
+    mock_settings.from_env.return_value.region = ""
+
+    resp = await client.get("/api/v0/metadata/s3/buckets")
+    assert resp.status_code == 200
+    assert resp.json() == {"buckets": []}
+
+
+# --- Neptune graphs ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_neptune_graphs(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.list_graphs.return_value = {
+        "graphs": [
+            {"id": "g-123", "name": "my-graph", "status": "AVAILABLE"},
+            {"id": "g-456", "name": "other", "status": "CREATING"},
+        ]
+    }
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/metadata/neptune/graph-analytics")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "graphs": [
+            {"id": "g-123", "name": "my-graph", "status": "AVAILABLE"},
+            {"id": "g-456", "name": "other", "status": "CREATING"},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_list_neptune_graphs_empty(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.list_graphs.return_value = {"graphs": []}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/metadata/neptune/graph-analytics")
+    assert resp.status_code == 200
+    assert resp.json() == {"graphs": []}
+
+
+# --- Error handler tests ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.metadata.ClientFactory")
+async def test_unknown_aws_error_returns_502(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.list_graphs.side_effect = ClientError(
+        {"Error": {"Code": "InternalServerError", "Message": "Something broke"}}, "ListGraphs"
+    )
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/metadata/neptune/graph-analytics")
+    assert resp.status_code == 502
+    assert resp.json()["error"] == "InternalServerError"

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -1,0 +1,199 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+from nx_neptune_proxy.services.projection_store import store
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    store._projections.clear()
+    yield
+    store._projections.clear()
+
+
+SAMPLE_BODY = {
+    "database": "mydb",
+    "sql_query": "SELECT * FROM t",
+    "graph_name": "test-graph",
+    "s3_staging_bucket": "s3://my-bucket/staging/",
+}
+
+
+# --- CRUD ---
+
+
+@pytest.mark.asyncio
+async def test_create_projection(client):
+    resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "draft"
+    assert data["database"] == "mydb"
+    assert data["catalog"] == "AwsDataCatalog"
+    assert data["graph_memory_gb"] == 16
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_get_projection(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    resp = await client.get(f"/api/v0/projection/{pid}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == pid
+
+
+@pytest.mark.asyncio
+async def test_get_projection_not_found(client):
+    resp = await client.get("/api/v0/projection/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_projection(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    resp = await client.put(f"/api/v0/projection/{pid}", json={"sql_query": "SELECT id FROM t"})
+    assert resp.status_code == 200
+    assert resp.json()["sql_query"] == "SELECT id FROM t"
+    # Other fields unchanged
+    assert resp.json()["database"] == "mydb"
+
+
+@pytest.mark.asyncio
+async def test_update_projection_not_found(client):
+    resp = await client.put("/api/v0/projection/nonexistent", json={"sql_query": "x"})
+    assert resp.status_code == 404
+
+
+# --- Status ---
+
+
+@pytest.mark.asyncio
+async def test_get_status(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    resp = await client.get(f"/api/v0/projection/{pid}/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == pid
+    assert data["status"] == "draft"
+    assert data["progress"] == 0
+
+
+# --- Validate ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.projection.validate_resources")
+async def test_validate_projection(mock_validate, client):
+    mock_validate.return_value = [
+        {"check": "bucket_region", "passed": True, "error": None},
+        {"check": "query_valid", "passed": True, "error": None},
+    ]
+
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    resp = await client.post(f"/api/v0/projection/{pid}/validate")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is True
+    assert len(data["checks"]) == 2
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.projection.validate_resources")
+async def test_validate_projection_fails(mock_validate, client):
+    mock_validate.return_value = [
+        {"check": "bucket_region", "passed": False, "error": "Wrong region"},
+    ]
+
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    resp = await client.post(f"/api/v0/projection/{pid}/validate")
+    assert resp.status_code == 200
+    assert resp.json()["valid"] is False
+
+
+# --- Validate query ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.projection.check_athena_query")
+async def test_validate_query(mock_check, client):
+    mock_result = MagicMock()
+    mock_result.passed = True
+    mock_result.to_dict.return_value = {"check": "athena_query", "passed": True, "error": None}
+    mock_check.return_value = mock_result
+
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    resp = await client.post(f"/api/v0/projection/{pid}/validate-query")
+    assert resp.status_code == 200
+    assert resp.json()["valid"] is True
+
+
+# --- Preview ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.projection.get_athena_query_results")
+@patch("nx_neptune_proxy.routers.projection.execute_athena_query")
+@patch("nx_neptune_proxy.routers.projection.ClientFactory")
+async def test_preview(mock_cf, mock_execute, mock_results, client):
+    mock_athena = MagicMock()
+    mock_cf.return_value.athena.return_value = mock_athena
+    mock_execute.return_value = "exec-1"
+    mock_results.return_value = [["id", "name"], ["1", "Alice"]]
+
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    resp = await client.post(f"/api/v0/projection/{pid}/preview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"] is None
+    assert data["results"][0]["columns"] == ["id", "name"]
+    assert data["results"][0]["rows"] == [["1", "Alice"]]
+
+
+# --- Execute ---
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_202(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    with patch("nx_neptune_proxy.routers.projection.run_pipeline"):
+        resp = await client.post(f"/api/v0/projection/{pid}/execute")
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_execute_conflict_if_already_running(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+    store.get(pid).status = "executing"
+
+    resp = await client.post(f"/api/v0/projection/{pid}/execute")
+    assert resp.status_code == 409

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -155,14 +155,23 @@ async def test_validate_query(mock_check, client):
 
 
 @pytest.mark.asyncio
-@patch("nx_neptune_proxy.routers.projection.get_athena_query_results")
-@patch("nx_neptune_proxy.routers.projection.execute_athena_query")
 @patch("nx_neptune_proxy.routers.projection.ClientFactory")
-async def test_preview(mock_cf, mock_execute, mock_results, client):
+async def test_preview(mock_cf, client):
     mock_athena = MagicMock()
+    mock_athena.start_query_execution.return_value = {"QueryExecutionId": "exec-1"}
+    mock_athena.get_query_execution.return_value = {
+        "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
+    }
+    mock_athena.get_query_results.return_value = {
+        "ResultSet": {
+            "ResultSetMetadata": {"ColumnInfo": [{"Name": "id"}, {"Name": "name"}]},
+            "Rows": [
+                {"Data": [{"VarCharValue": "id"}, {"VarCharValue": "name"}]},
+                {"Data": [{"VarCharValue": "1"}, {"VarCharValue": "Alice"}]},
+            ],
+        }
+    }
     mock_cf.return_value.athena.return_value = mock_athena
-    mock_execute.return_value = "exec-1"
-    mock_results.return_value = [["id", "name"], ["1", "Alice"]]
 
     create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
     pid = create_resp.json()["id"]

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -155,23 +155,17 @@ async def test_validate_query(mock_check, client):
 
 
 @pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.projection.get_athena_query_results")
+@patch("nx_neptune_proxy.routers.projection.wait_until_all_complete")
 @patch("nx_neptune_proxy.routers.projection.ClientFactory")
-async def test_preview(mock_cf, client):
+async def test_preview(mock_cf, mock_wait, mock_results, client):
     mock_athena = MagicMock()
     mock_athena.start_query_execution.return_value = {"QueryExecutionId": "exec-1"}
     mock_athena.get_query_execution.return_value = {
         "QueryExecution": {"Status": {"State": "SUCCEEDED"}}
     }
-    mock_athena.get_query_results.return_value = {
-        "ResultSet": {
-            "ResultSetMetadata": {"ColumnInfo": [{"Name": "id"}, {"Name": "name"}]},
-            "Rows": [
-                {"Data": [{"VarCharValue": "id"}, {"VarCharValue": "name"}]},
-                {"Data": [{"VarCharValue": "1"}, {"VarCharValue": "Alice"}]},
-            ],
-        }
-    }
     mock_cf.return_value.athena.return_value = mock_athena
+    mock_results.return_value = [["id", "name"], ["1", "Alice"]]
 
     create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
     pid = create_resp.json()["id"]

--- a/proxy/ui/index.html
+++ b/proxy/ui/index.html
@@ -247,7 +247,7 @@ async function pollStatus(id) {
 
   if (status.status === 'complete') {
     resultDiv.style.display = 'block';
-    resultDiv.innerHTML = '<strong>✓ Graph ready</strong>';
+    resultDiv.innerHTML = `<strong>✓ Graph ready</strong><br>Endpoint: <code>${status.graph_endpoint}</code>`;
     document.getElementById('run-btn').disabled = false;
     return;
   }

--- a/proxy/ui/index.html
+++ b/proxy/ui/index.html
@@ -1,33 +1,265 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>nx-neptune-proxy</title>
-    <style>
-        body { font-family: system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; }
-        .status { padding: 12px 16px; border-radius: 6px; margin-top: 16px; }
-        .healthy { background: #d4edda; color: #155724; }
-        .unhealthy { background: #f8d7da; color: #721c24; }
-    </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>nx-neptune proxy</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, sans-serif; max-width: 640px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+  h1 { margin-bottom: 1.5rem; }
+  label { display: block; margin-top: 1rem; font-weight: 500; font-size: 0.9rem; }
+  input, textarea, select { width: 100%; padding: 0.5rem; margin-top: 0.25rem; border: 1px solid #ccc; border-radius: 4px; font-size: 0.9rem; }
+  textarea { height: 80px; font-family: monospace; }
+  button { margin-top: 1.5rem; padding: 0.6rem 1.5rem; color: #fff; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
+  button:disabled { background: #999; cursor: not-allowed; }
+  .btn-validate { background: #16a34a; }
+  .btn-query { background: #0e7490; }
+  .btn-preview { background: #7c3aed; }
+  .btn-run { background: #0073bb; }
+  #progress-section { display: none; margin-top: 2rem; }
+  .progress-bar { width: 100%; height: 24px; background: #eee; border-radius: 4px; overflow: hidden; margin-top: 0.5rem; }
+  .progress-fill { height: 100%; background: #0073bb; transition: width 0.3s; }
+  #status-text { margin-top: 0.5rem; font-size: 0.9rem; color: #555; }
+  #error-text { margin-top: 0.5rem; color: #d13212; font-size: 0.9rem; }
+  #result { margin-top: 1rem; padding: 1rem; background: #f0fdf4; border-radius: 4px; display: none; }
+  .check-row { padding: 0.4rem 0; font-size: 0.85rem; border-bottom: 1px solid #eee; }
+  .check-pass { color: #16a34a; }
+  .check-fail { color: #d13212; }
+  #preview-section { margin-top: 1.5rem; display: none; }
+  #preview-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+  #preview-table th, #preview-table td { padding: 0.3rem 0.5rem; border: 1px solid #ddd; text-align: left; white-space: nowrap; }
+  #preview-table th { background: #f8f9fa; font-weight: 600; }
+  .preview-wrap { max-height: 250px; overflow: auto; border: 1px solid #ddd; border-radius: 4px; }
+</style>
 </head>
 <body>
-    <h1>nx-neptune-proxy</h1>
-    <p>REST interface for graph-over-data-lake workflows.</p>
-    <div id="status" class="status">Checking...</div>
-    <script>
-        fetch('/health')
-            .then(r => r.json())
-            .then(data => {
-                const el = document.getElementById('status');
-                el.textContent = `Status: ${data.status}`;
-                el.className = `status ${data.status === 'healthy' ? 'healthy' : 'unhealthy'}`;
-            })
-            .catch(() => {
-                const el = document.getElementById('status');
-                el.textContent = 'Status: unreachable';
-                el.className = 'status unhealthy';
-            });
-    </script>
+<h1>nx-neptune proxy</h1>
+
+<form id="setup-form">
+  <label>Athena Database
+    <select name="database" id="database-select" required>
+      <option value="">Loading...</option>
+    </select>
+  </label>
+  <label>SQL Query
+    <textarea name="sql_query" required placeholder="SELECT ~id, ~label, col1, col2 FROM my_table"></textarea>
+  </label>
+  <label>S3 Staging Bucket
+    <select name="s3_staging_bucket" id="bucket-select" required>
+      <option value="">Loading...</option>
+    </select>
+  </label>
+  <label>Graph Name
+    <input name="graph_name" required placeholder="my-graph">
+  </label>
+  <label>Graph Memory (GB)
+    <input name="graph_memory_gb" type="number" value="16" min="16" step="16">
+  </label>
+  <button type="button" id="validate-btn" class="btn-validate">Validate</button>
+  <button type="button" id="validate-query-btn" class="btn-query">Validate Query</button>
+  <button type="button" id="preview-btn" class="btn-preview">Preview</button>
+</form>
+
+<div id="validation-section" style="margin-top:1.5rem;">
+  <strong>Validation Results</strong>
+  <div id="validation-results" style="height:180px; overflow-y:auto; border:1px solid #ddd; border-radius:4px; padding:0.5rem; margin-top:0.5rem; background:#fafafa;"></div>
+</div>
+
+<div id="preview-section">
+  <strong>Preview (10 rows)</strong>
+  <div class="preview-wrap" style="margin-top:0.5rem;">
+    <table id="preview-table"></table>
+  </div>
+</div>
+
+<div style="margin-top:1.5rem;">
+  <button type="button" id="run-btn" class="btn-run">Run Migration</button>
+</div>
+
+<div id="progress-section">
+  <strong>Pipeline Progress</strong>
+  <div class="progress-bar"><div class="progress-fill" id="progress-fill"></div></div>
+  <div id="status-text"></div>
+  <div id="error-text"></div>
+  <div id="result"></div>
+</div>
+
+<script>
+const form = document.getElementById('setup-form');
+const progressSection = document.getElementById('progress-section');
+const progressFill = document.getElementById('progress-fill');
+const statusText = document.getElementById('status-text');
+const errorText = document.getElementById('error-text');
+const resultDiv = document.getElementById('result');
+const validationResults = document.getElementById('validation-results');
+const previewSection = document.getElementById('preview-section');
+const previewTable = document.getElementById('preview-table');
+
+let projectionId = null;
+
+// --- Load metadata dropdowns ---
+
+async function loadDatabases() {
+  const select = document.getElementById('database-select');
+  try {
+    const res = await fetch('/api/v0/metadata/athena/databases');
+    const data = await res.json();
+    select.innerHTML = '<option value="">Select database...</option>' +
+      data.databases.map(db => `<option value="${db}">${db}</option>`).join('');
+  } catch (e) {
+    select.innerHTML = '<option value="">Failed to load</option>';
+  }
+}
+
+async function loadBuckets() {
+  const select = document.getElementById('bucket-select');
+  try {
+    const res = await fetch('/api/v0/metadata/s3/buckets');
+    const data = await res.json();
+    select.innerHTML = '<option value="">Select bucket...</option>' +
+      data.buckets.map(b => `<option value="s3://${b}/">s3://${b}/</option>`).join('');
+  } catch (e) {
+    select.innerHTML = '<option value="">Failed to load</option>';
+  }
+}
+
+loadDatabases();
+loadBuckets();
+
+function getFormData() {
+  const data = Object.fromEntries(new FormData(form));
+  data.graph_memory_gb = parseInt(data.graph_memory_gb);
+  return data;
+}
+
+async function ensureProjection() {
+  const data = getFormData();
+  if (projectionId) {
+    await fetch(`/api/v0/projection/${projectionId}`, {
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(data),
+    });
+  } else {
+    const res = await fetch('/api/v0/projection', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(data),
+    });
+    const result = await res.json();
+    projectionId = result.id;
+  }
+  return projectionId;
+}
+
+document.getElementById('validate-btn').addEventListener('click', async () => {
+  if (!form.reportValidity()) return;
+  const btn = document.getElementById('validate-btn');
+  btn.disabled = true;
+  btn.textContent = 'Validating...';
+  validationResults.innerHTML = '';
+
+  const id = await ensureProjection();
+  const res = await fetch(`/api/v0/projection/${id}/validate`, { method: 'POST' });
+  const result = await res.json();
+
+  validationResults.innerHTML = result.checks.map(c =>
+    `<div class="check-row ${c.passed ? 'check-pass' : 'check-fail'}">${c.passed ? '✓' : '✗'} <strong>${c.check}</strong>${c.message ? ': ' + c.message : ''}</div>`
+  ).join('');
+
+  btn.disabled = false;
+  btn.textContent = 'Validate';
+});
+
+document.getElementById('validate-query-btn').addEventListener('click', async () => {
+  if (!form.reportValidity()) return;
+  const btn = document.getElementById('validate-query-btn');
+  btn.disabled = true;
+  btn.textContent = 'Testing...';
+  validationResults.innerHTML = '';
+
+  const id = await ensureProjection();
+  const res = await fetch(`/api/v0/projection/${id}/validate-query`, { method: 'POST' });
+  const result = await res.json();
+
+  validationResults.innerHTML = result.checks.map(c =>
+    `<div class="check-row ${c.passed ? 'check-pass' : 'check-fail'}">${c.passed ? '✓' : '✗'} <strong>${c.check}</strong>${c.message ? ': ' + c.message : ''}</div>`
+  ).join('');
+
+  btn.disabled = false;
+  btn.textContent = 'Validate Query';
+});
+
+document.getElementById('preview-btn').addEventListener('click', async () => {
+  if (!form.reportValidity()) return;
+  const btn = document.getElementById('preview-btn');
+  btn.disabled = true;
+  btn.textContent = 'Loading...';
+  previewSection.style.display = 'none';
+
+  const id = await ensureProjection();
+  const res = await fetch(`/api/v0/projection/${id}/preview`, { method: 'POST' });
+  const result = await res.json();
+
+  if (result.error) {
+    validationResults.innerHTML = `<div class="check-row check-fail">✗ <strong>preview</strong>: ${result.error}</div>`;
+  } else {
+    previewTable.innerHTML = result.results.map((r, i) => {
+      const header = '<tr>' + r.columns.map(c => `<th>${c}</th>`).join('') + '</tr>';
+      const rows = r.rows.map(row => '<tr>' + row.map(v => `<td>${v}</td>`).join('') + '</tr>').join('');
+      return `<tr><td colspan="100" style="background:#e2e8f0; font-weight:600; font-size:0.8rem; padding:0.4rem;">Query ${i+1} (${r.rows.length} rows)</td></tr>` + header + rows;
+    }).join('');
+    previewSection.style.display = 'block';
+  }
+
+  btn.disabled = false;
+  btn.textContent = 'Preview';
+});
+
+document.getElementById('run-btn').addEventListener('click', async () => {
+  if (!form.reportValidity()) return;
+  const btn = document.getElementById('run-btn');
+  btn.disabled = true;
+  progressSection.style.display = 'block';
+  errorText.textContent = '';
+  resultDiv.style.display = 'none';
+
+  const id = await ensureProjection();
+  const res = await fetch(`/api/v0/projection/${id}/execute`, { method: 'POST' });
+
+  if (!res.ok) {
+    const err = await res.json();
+    errorText.textContent = err.detail || 'Setup failed';
+    btn.disabled = false;
+    return;
+  }
+
+  pollStatus(id);
+});
+
+async function pollStatus(id) {
+  const res = await fetch(`/api/v0/projection/${id}/status`);
+  const status = await res.json();
+
+  progressFill.style.width = status.progress + '%';
+  statusText.textContent = status.step_label || status.step || '';
+
+  if (status.status === 'complete') {
+    resultDiv.style.display = 'block';
+    resultDiv.innerHTML = '<strong>✓ Graph ready</strong>';
+    document.getElementById('run-btn').disabled = false;
+    return;
+  }
+
+  if (status.status === 'failed') {
+    errorText.textContent = '✗ ' + (status.error || 'Pipeline failed');
+    document.getElementById('run-btn').disabled = false;
+    return;
+  }
+
+  setTimeout(() => pollStatus(id), 10000);
+}
+</script>
 </body>
 </html>

--- a/proxy/ui/index.html
+++ b/proxy/ui/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>nx-neptune-proxy</title>
+    <style>
+        body { font-family: system-ui, sans-serif; max-width: 600px; margin: 80px auto; padding: 0 20px; }
+        .status { padding: 12px 16px; border-radius: 6px; margin-top: 16px; }
+        .healthy { background: #d4edda; color: #155724; }
+        .unhealthy { background: #f8d7da; color: #721c24; }
+    </style>
+</head>
+<body>
+    <h1>nx-neptune-proxy</h1>
+    <p>REST interface for graph-over-data-lake workflows.</p>
+    <div id="status" class="status">Checking...</div>
+    <script>
+        fetch('/health')
+            .then(r => r.json())
+            .then(data => {
+                const el = document.getElementById('status');
+                el.textContent = `Status: ${data.status}`;
+                el.className = `status ${data.status === 'healthy' ? 'healthy' : 'unhealthy'}`;
+            })
+            .catch(() => {
+                const el = document.getElementById('status');
+                el.textContent = 'Status: unreachable';
+                el.className = 'status unhealthy';
+            });
+    </script>
+</body>
+</html>

--- a/proxy/ui/index.html
+++ b/proxy/ui/index.html
@@ -36,6 +36,17 @@
 <body>
 <h1>nx-neptune proxy</h1>
 
+<div style="margin-bottom:1.5rem;">
+  <label style="margin-top:0;">Session
+    <div style="display:flex; gap:0.5rem; margin-top:0.25rem;">
+      <select id="projection-select" style="flex:1; padding:0.5rem; border:1px solid #ccc; border-radius:4px;">
+        <option value="">+ New session</option>
+      </select>
+      <button type="button" id="refresh-sessions-btn" style="margin-top:0; padding:0.5rem 0.75rem; background:#e5e7eb; color:#333; font-size:0.85rem;">↻</button>
+    </div>
+  </label>
+</div>
+
 <form id="setup-form">
   <label>Athena Database
     <select name="database" id="database-select" required>
@@ -127,6 +138,41 @@ async function loadBuckets() {
 loadDatabases();
 loadBuckets();
 
+// --- Load and switch projections ---
+
+async function loadProjections() {
+  const select = document.getElementById('projection-select');
+  try {
+    const res = await fetch('/api/v0/projection');
+    const projections = await res.json();
+    const options = '<option value="">+ New session</option>' +
+      projections.map(p => `<option value="${p.id}">${p.graph_name || p.id.slice(0,8)} (${p.status})</option>`).join('');
+    select.innerHTML = options;
+    if (projectionId) select.value = projectionId;
+  } catch (e) {}
+}
+
+document.getElementById('projection-select').addEventListener('change', async (e) => {
+  const id = e.target.value;
+  if (!id) {
+    projectionId = null;
+    form.reset();
+    return;
+  }
+  const res = await fetch(`/api/v0/projection/${id}`);
+  const p = await res.json();
+  projectionId = p.id;
+  if (p.database) document.getElementById('database-select').value = p.database;
+  if (p.sql_query) form.sql_query.value = p.sql_query;
+  if (p.s3_staging_bucket) document.getElementById('bucket-select').value = p.s3_staging_bucket;
+  if (p.graph_name) form.graph_name.value = p.graph_name;
+  if (p.graph_memory_gb) form.graph_memory_gb.value = p.graph_memory_gb;
+});
+
+document.getElementById('refresh-sessions-btn').addEventListener('click', loadProjections);
+
+loadProjections();
+
 function getFormData() {
   const data = Object.fromEntries(new FormData(form));
   data.graph_memory_gb = parseInt(data.graph_memory_gb);
@@ -149,6 +195,7 @@ async function ensureProjection() {
     });
     const result = await res.json();
     projectionId = result.id;
+    await loadProjections();
   }
   return projectionId;
 }

--- a/proxy/ui/index.html
+++ b/proxy/ui/index.html
@@ -48,6 +48,11 @@
 </div>
 
 <form id="setup-form">
+  <label>Athena Catalog
+    <select name="catalog" id="catalog-select" required>
+      <option value="">Loading...</option>
+    </select>
+  </label>
   <label>Athena Database
     <select name="database" id="database-select" required>
       <option value="">Loading...</option>
@@ -111,16 +116,34 @@ let projectionId = null;
 
 // --- Load metadata dropdowns ---
 
+async function loadCatalogs() {
+  const select = document.getElementById('catalog-select');
+  try {
+    const res = await fetch('/api/v0/metadata/athena/catalogs');
+    const data = await res.json();
+    select.innerHTML = data.catalogs.map(c => `<option value="${c.name}">${c.name}</option>`).join('');
+    loadDatabases();
+  } catch (e) {
+    select.innerHTML = '<option value="">Failed to load</option>';
+  }
+}
+
+document.getElementById('catalog-select').addEventListener('change', loadDatabases);
+
 async function loadDatabases() {
   const select = document.getElementById('database-select');
+  select.disabled = true;
+  select.innerHTML = '<option value="">Loading...</option>';
+  const catalog = document.getElementById('catalog-select').value;
   try {
-    const res = await fetch('/api/v0/metadata/athena/databases');
+    const res = await fetch(`/api/v0/metadata/athena/databases?catalog=${encodeURIComponent(catalog)}`);
     const data = await res.json();
     select.innerHTML = '<option value="">Select database...</option>' +
       data.databases.map(db => `<option value="${db}">${db}</option>`).join('');
   } catch (e) {
     select.innerHTML = '<option value="">Failed to load</option>';
   }
+  select.disabled = false;
 }
 
 async function loadBuckets() {
@@ -135,7 +158,7 @@ async function loadBuckets() {
   }
 }
 
-loadDatabases();
+loadCatalogs();
 loadBuckets();
 
 // --- Load and switch projections ---
@@ -162,11 +185,21 @@ document.getElementById('projection-select').addEventListener('change', async (e
   const res = await fetch(`/api/v0/projection/${id}`);
   const p = await res.json();
   projectionId = p.id;
+  if (p.catalog) document.getElementById('catalog-select').value = p.catalog;
   if (p.database) document.getElementById('database-select').value = p.database;
   if (p.sql_query) form.sql_query.value = p.sql_query;
   if (p.s3_staging_bucket) document.getElementById('bucket-select').value = p.s3_staging_bucket;
   if (p.graph_name) form.graph_name.value = p.graph_name;
   if (p.graph_memory_gb) form.graph_memory_gb.value = p.graph_memory_gb;
+  if (p.status === 'executing') {
+    document.getElementById('progress-section').style.display = 'block';
+    pollStatus(p.id);
+  } else if (p.status === 'complete') {
+    document.getElementById('progress-section').style.display = 'block';
+    document.getElementById('result').style.display = 'block';
+    document.getElementById('result').innerHTML = `<strong>✓ Graph ready</strong><br>Endpoint: <code>${p.graph_endpoint}</code>`;
+    document.getElementById('progress-fill').style.width = '100%';
+  }
 });
 
 document.getElementById('refresh-sessions-btn').addEventListener('click', loadProjections);


### PR DESCRIPTION
## Summary

Implements the projection lifecycle endpoints and a functional import UI. A projection tracks the full pipeline state from draft through execution to completion.

## Endpoints added

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/api/v0/projection` | Create new projection (all fields optional) |
| GET | `/api/v0/projection` | List all projections |
| GET | `/api/v0/projection/{id}` | Full projection state |
| PUT | `/api/v0/projection/{id}` | Update projection fields |
| POST | `/api/v0/projection/{id}/validate` | Validate all resources |
| POST | `/api/v0/projection/{id}/validate-query` | Validate query only |
| POST | `/api/v0/projection/{id}/preview` | Preview first N rows (default 10) |
| POST | `/api/v0/projection/{id}/execute` | Start import pipeline (background) |
| GET | `/api/v0/projection/{id}/status` | Pipeline progress + graph endpoint |

## Architecture

- **`routers/projection.py`** — HTTP layer, no business logic
- **`services/projection_store.py`** — in-memory state (create/get/list/update/delete)
- **`services/pipeline.py`** — background pipeline using `SessionManager` (create graph → Athena import → done)
- **`utils/aws_helper.py`** — added `unpack_query_results` for swappable result packing

## Changes to `nx_neptune`

- **`validators.py`** — extracted `wrap_with_limit(query, n)` utility; switched `check_athena_query` to use `_execute_athena_query` and `polling_interval=1` (was 30s default — validation now responds in ~2-3s instead of 31s)

## Testing

- 62 tests pass (32 validator + 30 proxy)
- Covers: CRUD, validation (pass/fail), preview (mocked), execute (202 + conflict), status, error handling
- proxy/ui/index.html updated as a dev test harness (proper frontend is a separate ticket)


## Files changed (11 files, +879 lines)

- `nx_neptune/validators.py` — `wrap_with_limit`, faster polling, use `_execute_athena_query`
- `proxy/src/nx_neptune_proxy/app.py` — register projection router, add `/info` endpoint
- `proxy/src/nx_neptune_proxy/routers/projection.py` — all projection endpoints
- `proxy/src/nx_neptune_proxy/routers/schemas.py` — projection Pydantic models
- `proxy/src/nx_neptune_proxy/services/` — store + pipeline
- `proxy/src/nx_neptune_proxy/utils/aws_helper.py` — `unpack_query_results`
- `proxy/tests/test_projection.py` — 12 unit tests
- `proxy/ui/index.html` — full import UI