### PR TITLE
Feat: Docker compose setup

### DIFF
--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -33,3 +33,12 @@ stop:             ## Stop running container.
 clean:            ## Remove container and image.
 	@$(RUNTIME) rm nx-neptune-proxy 2>/dev/null || true
 	@$(RUNTIME) rmi nx-neptune-proxy 2>/dev/null || true
+
+up:               ## Start proxy + Graph Explorer with compose.
+	$(RUNTIME) compose up --build -d
+
+down:             ## Stop compose services.
+	$(RUNTIME) compose down
+
+logs:             ## Tail compose logs.
+	$(RUNTIME) compose logs -f

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -35,7 +35,7 @@ clean:            ## Remove container and image.
 	@$(RUNTIME) rmi nx-neptune-proxy 2>/dev/null || true
 
 up:               ## Start proxy + Graph Explorer with compose.
-	$(RUNTIME) compose up --build -d
+	$(RUNTIME) compose up --build --force-recreate -d
 
 down:             ## Stop compose services.
 	$(RUNTIME) compose down

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  proxy:
+    build:
+      context: ..
+      dockerfile: proxy/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
+      - CORS_ALLOWED_ORIGINS=http://localhost:8080,https://localhost:6373
+      - LOG_LEVEL=info
+    healthcheck:
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  graph-explorer:
+    image: public.ecr.aws/neptune/graph-explorer:latest
+    ports:
+      - "6373:443"
+    environment:
+      - HOST=localhost
+      - PUBLIC_OR_PROXY_ENDPOINT=https://localhost:6373
+      - GRAPH_CONNECTION_URL=http://proxy:8080
+      - USING_PROXY_SERVER=true
+      - IAM=false
+      - GRAPH_TYPE=neptune-graph
+    depends_on:
+      proxy:
+        condition: service_healthy

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   graph-explorer:
-    image: public.ecr.aws/neptune/graph-explorer:latest
+    image: public.ecr.aws/neptune/graph-explorer:latest-SNAPSHOT
     ports:
       - "443:443"
       - "80:80"

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -21,14 +21,16 @@ services:
   graph-explorer:
     image: public.ecr.aws/neptune/graph-explorer:latest
     ports:
-      - "6373:443"
+      - "443:443"
+      - "80:80"
     environment:
       - HOST=localhost
-      - PUBLIC_OR_PROXY_ENDPOINT=https://localhost:6373
-      - GRAPH_CONNECTION_URL=http://proxy:8080
-      - USING_PROXY_SERVER=true
-      - IAM=false
-      - GRAPH_TYPE=neptune-graph
+      - AWS_REGION=${AWS_DEFAULT_REGION:-us-west-2}
+      - IAM=true
+      - SERVICE_TYPE=neptune-graph
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
     depends_on:
       proxy:
         condition: service_healthy

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -16,7 +16,7 @@ async def run_pipeline(projection: Projection) -> None:
     s3_location = projection.s3_staging_bucket.rstrip("/") + f"/{projection.id}/"
 
     try:
-        projection.status = "executing"
+        projection.status = "importing"
 
         # Step 1: Create graph
         _update(projection, step="graph_creation", label="Creating Neptune Analytics graph", progress=5)

--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -248,7 +248,7 @@ export function Import() {
 
       {/* Actions */}
       <div className="flex gap-2">
-        <Button variant="secondary" onClick={handleValidate} disabled={!!loading}><CheckCircle className="h-4 w-4" /> {loading === "validate" ? "Validating..." : "Validate"}</Button>
+        <Button variant="secondary" onClick={handleValidate} disabled={!!loading}><CheckCircle className="h-4 w-4" /> {loading === "validate" ? "Validating..." : "Validate Resources"}</Button>
         <Button variant="secondary" onClick={handleValidateQuery} disabled={!!loading}><CheckCircle className="h-4 w-4" /> {loading === "validate-query" ? "Validating..." : "Validate Query"}</Button>
         <Button variant="secondary" onClick={handlePreview} disabled={!!loading}><Eye className="h-4 w-4" /> {loading === "preview" ? "Loading..." : "Preview"}</Button>
         <Button onClick={handleExecute} disabled={polling || !!loading}><Play className="h-4 w-4" /> Execute</Button>


### PR DESCRIPTION
**Description:**

Adds a `docker-compose.yml` to run the nx-neptune proxy and Graph Explorer together with a single command.

### Changes

**proxy/docker-compose.yml** (new)
- `proxy` service: builds from Dockerfile, exposes port 8080, passes AWS credentials and region
- `graph-explorer` service: uses official Neptune Graph Explorer image, exposes ports 443/80, configured for IAM + neptune-graph

**proxy/Makefile**
- `make up` — start both services with compose
- `make down` — stop
- `make logs` — tail logs

### Usage

```bash
cd proxy
make up      # proxy at :8080, Graph Explorer at https://localhost
make down
```

AWS credentials must be exported in the shell before running. After importing a graph via the proxy UI, add the Neptune endpoint as a connection in Graph Explorer to visualize it.


<img width="1727" height="869" alt="Screenshot 2026-06-04 at 4 43 35 PM" src="https://github.com/user-attachments/assets/dea0c94d-6e6d-439d-af6b-ca892d11fb08" />


