### PR TITLE
Feat: Graph Exploration integration

### DIFF
--- a/proxy/ui-src/src/pages/Graphs.tsx
+++ b/proxy/ui-src/src/pages/Graphs.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { metadata } from "../api";
 import { Card, RefreshButton } from "../components/ui";
-import { Trash2, Download } from "lucide-react";
+import { Trash2, ExternalLink } from "lucide-react";
 
 interface Graph {
   id: string;
@@ -88,31 +88,20 @@ export function Graphs() {
                       <button
                         className="text-gray-400 hover:text-blue-600 disabled:opacity-30"
                         disabled={g.status !== "AVAILABLE"}
-                        title="Export for Graph Explorer"
+                        title="Open in Graph Explorer"
                         onClick={() => {
-                          const config = {
-                            id: g.id,
-                            displayLabel: g.name,
-                            connection: {
-                              url: "https://localhost",
-                              queryEngine: "openCypher",
-                              proxyConnection: true,
-                              graphDbUrl: `https://${g.id}.${region}.neptune-graph.amazonaws.com`,
-                              awsAuthEnabled: true,
-                              serviceType: "neptune-graph",
-                              awsRegion: region,
-                            },
-                            schema: { vertices: [], edges: [] },
-                          };
-                          const blob = new Blob([JSON.stringify(config, null, 2)], { type: "application/json" });
-                          const url = URL.createObjectURL(blob);
-                          const a = document.createElement("a");
-                          a.href = url;
-                          a.download = `${g.name}.json`;
-                          a.click();
-                          URL.revokeObjectURL(url);
+                          const graphDbUrl = `https://${g.id}.${region}.neptune-graph.amazonaws.com`;
+                          const params = new URLSearchParams({
+                            graphDbUrl,
+                            queryEngine: "openCypher",
+                            awsRegion: region,
+                            serviceType: "neptune-graph",
+                            name: g.name,
+                          });
+                          const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost";
+                          window.open(`${geBase}?${params}`, "_blank");
                         }}
-                      ><Download className="h-4 w-4" /></button>
+                      ><ExternalLink className="h-4 w-4" /></button>
                       <button
                         className="text-gray-400 hover:text-red-600 disabled:opacity-30"
                         disabled={g.status === "DELETING"}

--- a/proxy/ui-src/src/pages/Sessions.tsx
+++ b/proxy/ui-src/src/pages/Sessions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { projection, metadata, type Projection } from "../api";
 import { Card, Button, RefreshButton } from "../components/ui";
-import { X, Download } from "lucide-react";
+import { X, ExternalLink } from "lucide-react";
 import { useNavigate } from "react-router";
 
 export function Sessions() {
@@ -98,29 +98,18 @@ export function Sessions() {
           </Button>
           {selected.graph_id && selected.status === "complete" && (
             <Button variant="ghost" className="w-full" onClick={() => {
-              const config = {
-                id: selected.graph_id,
-                displayLabel: selected.graph_name || selected.graph_id,
-                connection: {
-                  url: "https://localhost",
-                  queryEngine: "openCypher",
-                  proxyConnection: true,
-                  graphDbUrl: `https://${selected.graph_id}.${region}.neptune-graph.amazonaws.com`,
-                  awsAuthEnabled: true,
-                  serviceType: "neptune-graph",
-                  awsRegion: region,
-                },
-                schema: { vertices: [], edges: [] },
-              };
-              const blob = new Blob([JSON.stringify(config, null, 2)], { type: "application/json" });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement("a");
-              a.href = url;
-              a.download = `${selected.graph_name || selected.graph_id}.json`;
-              a.click();
-              URL.revokeObjectURL(url);
+              const graphDbUrl = `https://${selected.graph_id}.${region}.neptune-graph.amazonaws.com`;
+              const params = new URLSearchParams({
+                graphDbUrl,
+                queryEngine: "openCypher",
+                awsRegion: region,
+                serviceType: "neptune-graph",
+                name: selected.graph_name || selected.graph_id || "",
+              } as Record<string, string>);
+              const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost";
+              window.open(`${geBase}?${params}`, "_blank");
             }}>
-              <Download className="h-3 w-3" /> Export for Graph Explorer
+              <ExternalLink className="h-3 w-3" /> Open in Graph Explorer
             </Button>
           )}
         </Card>


### PR DESCRIPTION
**Description:**

Replaces the JSON download export with a direct "Open in Graph Explorer" button that opens GE in a new tab with connection parameters in the URL.

### What changed

- **Sessions page**: "Export for Graph Explorer" → "Open in Graph Explorer" (opens GE with URL params)
- **Graphs page**: Same change
- Icon updated from `Download` to `ExternalLink`

### How it works

Instead of downloading a `.json` config file that users manually import into GE, the button constructs a URL like:

```
https://localhost?graphDbUrl=https%3A%2F%2Fg-xxx.us-west-2.neptune-graph.amazonaws.com&queryEngine=openCypher&awsRegion=us-west-2&serviceType=neptune-graph&name=my-graph
```

Graph Explorer (with aws/graph-explorer#1788) parses these params and prompts the user to create/activate the connection — zero manual configuration.

### Configuration

`VITE_GRAPH_EXPLORER_URL` env var controls the GE base URL:
- Dev: `http://localhost:5173` (set in `proxy/ui-src/.env`)
- Docker: falls back to `https://localhost`

### Testing

- Verified type-checks pass
- Manual: button opens correct URL in new tab, GE shows connection dialog