### PR TITLE
Feat: Add graph instance management (start/stop/delete) to Graph Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cloudformation-templates/build/
 # Frontend
 proxy/ui-src/node_modules/
 proxy/ui/
+proxy/docker-compose.override.yml

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -37,6 +37,9 @@ clean:            ## Remove container and image.
 up:               ## Start proxy + Graph Explorer with compose.
 	$(RUNTIME) compose up --build --force-recreate -d
 
+up-ge:            ## Start only Graph Explorer.
+	$(RUNTIME) compose up graph-explorer -d
+
 down:             ## Stop compose services.
 	$(RUNTIME) compose down
 

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   graph-explorer:
-    image: public.ecr.aws/neptune/graph-explorer:latest-SNAPSHOT
+    image: ${GRAPH_EXPLORER_IMAGE:-public.ecr.aws/neptune/graph-explorer:latest}
     ports:
       - "443:443"
       - "80:80"
@@ -31,6 +31,3 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
-    depends_on:
-      proxy:
-        condition: service_healthy

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -14,6 +14,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.routers.graph import router as graph_router
 from nx_neptune_proxy.routers.metadata import router as metadata_router
 from nx_neptune_proxy.routers.preview import router as preview_router
 from nx_neptune_proxy.routers.projection import router as projection_router
@@ -117,6 +118,7 @@ app.include_router(metadata_router)
 app.include_router(projection_router)
 app.include_router(preview_router)
 app.include_router(project_router)
+app.include_router(graph_router)
 
 
 # --- Startup: resume stuck deletions ---

--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -1,0 +1,74 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Router for graph instance actions (start, stop, delete)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+
+from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune_proxy.services.graph_state_machine import (
+    InvalidTransitionError,
+    available_actions,
+    execute_transition,
+    get_inflight,
+    clear_inflight,
+)
+import nx_neptune_proxy.services.graph_ops  # noqa: F401 — registers transitions
+
+router = APIRouter(prefix="/api/v0/graphs", tags=["graphs"])
+
+
+@router.get("/{graph_id}/actions", summary="List available actions for a graph")
+def get_available_actions(graph_id: str):
+    """Return valid actions based on the graph's current Neptune status."""
+    client = ClientFactory().neptune()
+    resp = client.get_graph(graphIdentifier=graph_id)
+    status = resp.get("status", "")
+    actions = available_actions(status)
+    inflight = get_inflight(graph_id)
+    return {
+        "graph_id": graph_id,
+        "status": status,
+        "actions": actions,
+        "inflight": inflight,
+    }
+
+
+@router.post("/{graph_id}/{action}", summary="Execute a graph action", status_code=202)
+def perform_action(graph_id: str, action: str, background_tasks: BackgroundTasks):
+    """Initiate a state transition (stop, start, delete) as a background task."""
+    client = ClientFactory().neptune()
+    resp = client.get_graph(graphIdentifier=graph_id)
+    current_status = resp.get("status", "")
+
+    try:
+        # Validate early (execute_transition also validates, but fail fast for the user)
+        valid = available_actions(current_status)
+        if action not in valid:
+            raise InvalidTransitionError(
+                f"Cannot {action} graph in {current_status} state. "
+                f"Valid actions: {valid or 'none'}"
+            )
+    except InvalidTransitionError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    background_tasks.add_task(execute_transition, graph_id, action, current_status)
+    return {"graph_id": graph_id, "action": action, "status": "accepted"}
+
+
+@router.get("/{graph_id}/inflight", summary="Check in-flight operation status")
+def get_inflight_status(graph_id: str):
+    """Return current in-flight operation info, including any error."""
+    inflight = get_inflight(graph_id)
+    if not inflight:
+        return {"graph_id": graph_id, "inflight": None}
+    return {"graph_id": graph_id, "inflight": inflight}
+
+
+@router.delete("/{graph_id}/inflight", summary="Dismiss inflight error")
+def dismiss_inflight(graph_id: str):
+    """Clear the in-flight error for a graph (user dismissed the alert)."""
+    clear_inflight(graph_id)
+    return {"graph_id": graph_id, "cleared": True}

--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 
 from nx_neptune.clients.client_factory import ClientFactory
@@ -17,6 +19,8 @@ from nx_neptune_proxy.services.graph_state_machine import (
 )
 import nx_neptune_proxy.services.graph_ops  # noqa: F401 — registers transitions
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/v0/graphs", tags=["graphs"])
 
 
@@ -25,7 +29,10 @@ def get_available_actions(graph_id: str):
     """Return valid actions based on the graph's current Neptune status."""
     client = ClientFactory().neptune()
     resp = client.get_graph(graphIdentifier=graph_id)
-    status = resp.get("status", "")
+    status = resp.get("status")
+    if not status:
+        logger.warning(f"Graph {graph_id} returned empty status: {resp}")
+        raise HTTPException(status_code=502, detail="Graph returned no status")
     actions = available_actions(status)
     inflight = get_inflight(graph_id)
     return {
@@ -41,7 +48,10 @@ def perform_action(graph_id: str, action: str, background_tasks: BackgroundTasks
     """Initiate a state transition (stop, start, delete) as a background task."""
     client = ClientFactory().neptune()
     resp = client.get_graph(graphIdentifier=graph_id)
-    current_status = resp.get("status", "")
+    current_status = resp.get("status")
+    if not current_status:
+        logger.warning(f"Graph {graph_id} returned empty status: {resp}")
+        raise HTTPException(status_code=502, detail="Graph returned no status")
 
     try:
         # Validate early (execute_transition also validates, but fail fast for the user)

--- a/proxy/src/nx_neptune_proxy/services/graph_ops.py
+++ b/proxy/src/nx_neptune_proxy/services/graph_ops.py
@@ -1,0 +1,88 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Concrete graph operations — stop, start, delete."""
+
+from __future__ import annotations
+
+import logging
+
+from botocore.exceptions import ClientError
+from nx_neptune.clients.client_factory import ClientFactory
+
+from nx_neptune_proxy.services.graph_state_machine import (
+    Transition,
+    register_transition,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --- Actions ---
+
+async def _stop_graph(graph_id: str) -> None:
+    """Issue stop-graph API call."""
+    client = ClientFactory().neptune()
+    client.stop_graph(graphIdentifier=graph_id)
+
+
+async def _start_graph(graph_id: str) -> None:
+    """Issue start-graph API call."""
+    client = ClientFactory().neptune()
+    client.start_graph(graphIdentifier=graph_id)
+
+
+async def _delete_graph(graph_id: str) -> None:
+    """Issue delete-graph API call (skip snapshot)."""
+    client = ClientFactory().neptune()
+    client.delete_graph(graphIdentifier=graph_id, skipSnapshot=True)
+
+
+# --- Probe ---
+
+async def _poll_graph_status(graph_id: str) -> str | None:
+    """Check the current graph status. Returns None if graph is gone (deleted)."""
+    client = ClientFactory().neptune()
+    try:
+        resp = client.get_graph(graphIdentifier=graph_id)
+        return resp.get("status")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            return "DELETED"
+        raise
+
+
+# --- Register transitions ---
+
+register_transition(
+    "stop",
+    Transition(
+        from_states=("AVAILABLE",),
+        transient_state="STOPPING",
+        target_state="STOPPED",
+        action=_stop_graph,
+        poll=_poll_graph_status,
+    ),
+)
+
+register_transition(
+    "start",
+    Transition(
+        from_states=("STOPPED",),
+        transient_state="STARTING",
+        target_state="AVAILABLE",
+        action=_start_graph,
+        poll=_poll_graph_status,
+    ),
+)
+
+register_transition(
+    "delete",
+    Transition(
+        from_states=("AVAILABLE", "STOPPED"),
+        transient_state="DELETING",
+        target_state="DELETED",
+        action=_delete_graph,
+        poll=_poll_graph_status,
+    ),
+)

--- a/proxy/src/nx_neptune_proxy/services/graph_state_machine.py
+++ b/proxy/src/nx_neptune_proxy/services/graph_state_machine.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph instance state machine — valid transitions, execution, and polling."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+# Poll every 10s, timeout after 10min
+DEFAULT_POLL_INTERVAL = 10.0
+DEFAULT_TIMEOUT = 600.0
+
+
+@dataclass
+class Transition:
+    """Defines a valid state transition for a graph action."""
+
+    from_states: tuple[str, ...]
+    transient_state: str
+    target_state: str
+    action: Callable[[str], Awaitable[None]]
+    poll: Callable[[str], Awaitable[str | None]]
+
+
+# Registry of action name → Transition
+_TRANSITIONS: dict[str, Transition] = {}
+
+# In-flight operations: graph_id → {action, error}
+_inflight: dict[str, dict] = {}
+
+
+def register_transition(action: str, transition: Transition) -> None:
+    """Register a named transition in the global registry."""
+    _TRANSITIONS[action] = transition
+
+
+def available_actions(current_status: str) -> list[str]:
+    """Return action names valid for the given graph status."""
+    return [
+        action
+        for action, t in _TRANSITIONS.items()
+        if current_status in t.from_states
+    ]
+
+
+def get_inflight(graph_id: str) -> dict | None:
+    """Return in-flight operation info for a graph, or None."""
+    return _inflight.get(graph_id)
+
+
+def clear_inflight(graph_id: str) -> None:
+    """Remove in-flight tracking for a graph."""
+    _inflight.pop(graph_id, None)
+
+
+async def execute_transition(
+    graph_id: str,
+    action: str,
+    current_status: str,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> None:
+    """
+    Execute a state transition: validate → kick off action → poll until done.
+
+    Raises InvalidTransitionError if action isn't valid for current_status.
+    Raises TransitionFailed on timeout or unexpected state.
+    """
+    transition = _TRANSITIONS.get(action)
+    if not transition:
+        raise InvalidTransitionError(f"Unknown action: {action}")
+    if current_status not in transition.from_states:
+        raise InvalidTransitionError(
+            f"Cannot {action} graph in {current_status} state"
+        )
+
+    # Track in-flight
+    _inflight[graph_id] = {"action": action, "error": None}
+
+    try:
+        # Kick off the AWS operation
+        await transition.action(graph_id)
+
+        # Poll until terminal state or timeout
+        elapsed = 0.0
+        while elapsed < timeout:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            status = await transition.poll(graph_id)
+
+            if status == transition.target_state:
+                _inflight.pop(graph_id, None)
+                logger.info(f"Graph {graph_id} transition {action} complete → {status}")
+                return
+
+            if status and status not in (transition.transient_state, *transition.from_states):
+                raise TransitionFailed(
+                    f"Graph entered unexpected state '{status}' during {action}"
+                )
+
+        raise TransitionFailed(
+            f"Timeout ({timeout}s) waiting for {action} on graph {graph_id}"
+        )
+
+    except Exception as e:
+        logger.error(f"Transition {action} failed for {graph_id}: {e}")
+        _inflight[graph_id] = {"action": action, "error": str(e)}
+        raise
+
+
+class InvalidTransitionError(Exception):
+    """Raised when an action is not valid for the current graph state."""
+    pass
+
+
+class TransitionFailed(Exception):
+    """Raised when a transition fails or times out."""
+    pass

--- a/proxy/tests/test_graph.py
+++ b/proxy/tests/test_graph.py
@@ -1,0 +1,280 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+from nx_neptune_proxy.services import graph_state_machine
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture(autouse=True)
+def clear_inflight():
+    """Ensure inflight state is clean between tests."""
+    graph_state_machine._inflight.clear()
+    yield
+    graph_state_machine._inflight.clear()
+
+
+# --- GET /{graph_id}/actions ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_actions_available_graph(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/graphs/g-123/actions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["graph_id"] == "g-123"
+    assert data["status"] == "AVAILABLE"
+    assert "stop" in data["actions"]
+    assert "delete" in data["actions"]
+    assert "start" not in data["actions"]
+    assert data["inflight"] is None
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_actions_stopped_graph(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "STOPPED"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/graphs/g-123/actions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "STOPPED"
+    assert "start" in data["actions"]
+    assert "delete" in data["actions"]
+    assert "stop" not in data["actions"]
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_actions_transient_state(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "STOPPING"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/graphs/g-123/actions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "STOPPING"
+    assert data["actions"] == []
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_actions_empty_status_returns_502(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": ""}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/graphs/g-123/actions")
+    assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_actions_missing_status_returns_502(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/graphs/g-123/actions")
+    assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_actions_graph_not_found_returns_404(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.side_effect = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "Graph not found"}},
+        "GetGraph",
+    )
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.get("/api/v0/graphs/g-missing/actions")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_actions_with_inflight(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "STOPPING"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    graph_state_machine._inflight["g-123"] = {"action": "stop", "error": None}
+
+    resp = await client.get("/api/v0/graphs/g-123/actions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["inflight"]["action"] == "stop"
+    assert data["inflight"]["error"] is None
+
+
+# --- POST /{graph_id}/{action} ---
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.execute_transition")
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_perform_stop_accepted(mock_cf, mock_exec, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.post("/api/v0/graphs/g-123/stop")
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["graph_id"] == "g-123"
+    assert data["action"] == "stop"
+    assert data["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.execute_transition")
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_perform_start_accepted(mock_cf, mock_exec, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "STOPPED"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.post("/api/v0/graphs/g-123/start")
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["action"] == "start"
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.execute_transition")
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_perform_delete_accepted(mock_cf, mock_exec, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.post("/api/v0/graphs/g-123/delete")
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["action"] == "delete"
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_perform_invalid_transition_returns_409(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "STOPPED"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.post("/api/v0/graphs/g-123/stop")
+    assert resp.status_code == 409
+    assert "Cannot stop" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_perform_unknown_action_returns_409(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.post("/api/v0/graphs/g-123/restart")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_perform_empty_status_returns_502(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": ""}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.post("/api/v0/graphs/g-123/stop")
+    assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_perform_graph_not_found_returns_404(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.side_effect = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "Graph not found"}},
+        "GetGraph",
+    )
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
+    resp = await client.post("/api/v0/graphs/g-missing/stop")
+    assert resp.status_code == 404
+
+
+# --- GET /{graph_id}/inflight ---
+
+
+@pytest.mark.asyncio
+async def test_get_inflight_no_operation(client):
+    resp = await client.get("/api/v0/graphs/g-123/inflight")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["graph_id"] == "g-123"
+    assert data["inflight"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_inflight_with_operation(client):
+    graph_state_machine._inflight["g-123"] = {"action": "stop", "error": None}
+
+    resp = await client.get("/api/v0/graphs/g-123/inflight")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["inflight"]["action"] == "stop"
+    assert data["inflight"]["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_inflight_with_error(client):
+    graph_state_machine._inflight["g-123"] = {"action": "stop", "error": "Timeout"}
+
+    resp = await client.get("/api/v0/graphs/g-123/inflight")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["inflight"]["action"] == "stop"
+    assert data["inflight"]["error"] == "Timeout"
+
+
+# --- DELETE /{graph_id}/inflight ---
+
+
+@pytest.mark.asyncio
+async def test_dismiss_inflight_clears_error(client):
+    graph_state_machine._inflight["g-123"] = {"action": "stop", "error": "Timeout"}
+
+    resp = await client.request("DELETE", "/api/v0/graphs/g-123/inflight")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["cleared"] is True
+
+    # Verify it's actually cleared
+    assert graph_state_machine._inflight.get("g-123") is None
+
+
+@pytest.mark.asyncio
+async def test_dismiss_inflight_noop_when_nothing(client):
+    resp = await client.request("DELETE", "/api/v0/graphs/g-123/inflight")
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] is True

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -24,6 +24,20 @@ export const metadata = {
   graphSummary: (id: string) => request<{ numNodes: number; numEdges: number; nodeLabels: string[]; edgeLabels: string[] }>(`/metadata/neptune/graph-analytics/${id}/summary`),
 };
 
+// --- Graph Actions ---
+
+export interface Inflight {
+  action: string;
+  error: string | null;
+}
+
+export const graphActions = {
+  getActions: (graphId: string) => request<{ graph_id: string; status: string; actions: string[]; inflight: Inflight | null }>(`/graphs/${graphId}/actions`),
+  perform: (graphId: string, action: string) => request<{ graph_id: string; action: string; status: string }>(`/graphs/${graphId}/${action}`, { method: "POST" }),
+  getInflight: (graphId: string) => request<{ graph_id: string; inflight: Inflight | null }>(`/graphs/${graphId}/inflight`),
+  dismissInflight: (graphId: string) => request<{ graph_id: string; cleared: boolean }>(`/graphs/${graphId}/inflight`, { method: "DELETE" }),
+};;
+
 // --- Projection ---
 
 export interface Projection {

--- a/proxy/ui-src/src/pages/Graphs.tsx
+++ b/proxy/ui-src/src/pages/Graphs.tsx
@@ -68,14 +68,14 @@ export function Graphs() {
     load({ withActions: true, withSummaries: true });
   }, [load]);
 
-  // Poll: 5s during transient states, 30s otherwise
+  // Poll every 30s when any graph is in a transient state
   const hasTransient = graphs.some(g =>
     ["STOPPING", "STARTING", "DELETING", "CREATING"].includes(g.status)
   );
 
   useEffect(() => {
     if (!hasTransient) return;
-    const interval = setInterval(() => load({ withActions: true }), 5000);
+    const interval = setInterval(() => load({ withActions: true }), 30000);
     return () => clearInterval(interval);
   }, [hasTransient, load]);
 

--- a/proxy/ui-src/src/pages/Graphs.tsx
+++ b/proxy/ui-src/src/pages/Graphs.tsx
@@ -43,16 +43,18 @@ export function Graphs() {
     }
   }, []);
 
-  const load = useCallback(async (opts?: { withActions?: boolean }) => {
+  const load = useCallback(async (opts?: { withActions?: boolean; withSummaries?: boolean }) => {
     setLoading(true);
     const data = await metadata.graphs();
     setGraphs(data.graphs);
     setLoading(false);
 
-    // Fetch summaries for available graphs
-    for (const g of data.graphs) {
-      if (g.status === "AVAILABLE") {
-        metadata.graphSummary(g.id).then(s => setSummaries(prev => ({ ...prev, [g.id]: s }))).catch(() => {});
+    // Fetch summaries only on initial load or explicit request
+    if (opts?.withSummaries) {
+      for (const g of data.graphs) {
+        if (g.status === "AVAILABLE") {
+          metadata.graphSummary(g.id).then(s => setSummaries(prev => ({ ...prev, [g.id]: s }))).catch(() => {});
+        }
       }
     }
 
@@ -63,7 +65,7 @@ export function Graphs() {
 
   useEffect(() => {
     metadata.config().then(c => setRegion(c.region));
-    load({ withActions: true });
+    load({ withActions: true, withSummaries: true });
   }, [load]);
 
   // Poll: 5s during transient states, 30s otherwise
@@ -113,7 +115,7 @@ export function Graphs() {
           <h1 className="text-lg font-semibold">Neptune Analytics Graphs</h1>
           <p className="text-sm text-gray-500">Showing graphs with <code className="rounded bg-gray-100 px-1">nxp-</code> prefix</p>
         </div>
-        <RefreshButton onClick={load} />
+        <RefreshButton onClick={() => load({ withActions: true, withSummaries: true })} />
       </div>
 
       {/* Error Alerts */}

--- a/proxy/ui-src/src/pages/Graphs.tsx
+++ b/proxy/ui-src/src/pages/Graphs.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
-import { metadata } from "../api";
+import { useEffect, useState, useCallback } from "react";
+import { metadata, graphActions, Inflight } from "../api";
 import { Card, RefreshButton } from "../components/ui";
-import { Trash2, ExternalLink } from "lucide-react";
+import { Trash2, ExternalLink, Square, Play, X, AlertTriangle } from "lucide-react";
 
 interface Graph {
   id: string;
@@ -16,29 +16,95 @@ interface Summary {
   edgeLabels: string[];
 }
 
+interface GraphActionState {
+  actions: string[];
+  inflight: Inflight | null;
+}
+
 export function Graphs() {
   const [graphs, setGraphs] = useState<Graph[]>([]);
   const [loading, setLoading] = useState(true);
   const [summaries, setSummaries] = useState<Record<string, Summary>>({});
   const [region, setRegion] = useState("");
+  const [actionStates, setActionStates] = useState<Record<string, GraphActionState>>({});
+  const [alerts, setAlerts] = useState<{ graphId: string; graphName: string; message: string }[]>([]);
 
-  useEffect(() => {
-    metadata.config().then(c => setRegion(c.region));
-    load();
+  const loadActions = useCallback(async (graphList: Graph[]) => {
+    for (const g of graphList) {
+      graphActions.getActions(g.id).then(r => {
+        setActionStates(prev => ({ ...prev, [g.id]: { actions: r.actions, inflight: r.inflight } }));
+        if (r.inflight?.error) {
+          setAlerts(prev => {
+            if (prev.some(a => a.graphId === g.id)) return prev;
+            return [...prev, { graphId: g.id, graphName: g.name, message: r.inflight!.error! }];
+          });
+        }
+      }).catch(() => {});
+    }
   }, []);
 
-  async function load() {
+  const load = useCallback(async (opts?: { withActions?: boolean }) => {
     setLoading(true);
     const data = await metadata.graphs();
     setGraphs(data.graphs);
     setLoading(false);
+
     // Fetch summaries for available graphs
     for (const g of data.graphs) {
       if (g.status === "AVAILABLE") {
         metadata.graphSummary(g.id).then(s => setSummaries(prev => ({ ...prev, [g.id]: s }))).catch(() => {});
       }
     }
+
+    if (opts?.withActions) {
+      loadActions(data.graphs);
+    }
+  }, [loadActions]);
+
+  useEffect(() => {
+    metadata.config().then(c => setRegion(c.region));
+    load({ withActions: true });
+  }, [load]);
+
+  // Poll: 5s during transient states, 30s otherwise
+  const hasTransient = graphs.some(g =>
+    ["STOPPING", "STARTING", "DELETING", "CREATING"].includes(g.status)
+  );
+
+  useEffect(() => {
+    if (!hasTransient) return;
+    const interval = setInterval(() => load({ withActions: true }), 5000);
+    return () => clearInterval(interval);
+  }, [hasTransient, load]);
+
+  async function performAction(graphId: string, action: string, graphName: string) {
+    if (action === "delete" && !confirm(`Delete graph ${graphName}? This cannot be undone.`)) return;
+    if (action === "stop" && !confirm(`Stop graph ${graphName}? It will become unavailable until restarted.`)) return;
+
+    try {
+      await graphActions.perform(graphId, action);
+      load({ withActions: true });
+    } catch (e: any) {
+      setAlerts(prev => [...prev, { graphId, graphName, message: e.message || `Failed to ${action}` }]);
+    }
   }
+
+  function dismissAlert(graphId: string) {
+    setAlerts(prev => prev.filter(a => a.graphId !== graphId));
+    graphActions.dismissInflight(graphId).catch(() => {});
+  }
+
+  const statusStyle = (status: string) => {
+    switch (status) {
+      case "AVAILABLE": return "bg-green-100 text-green-700";
+      case "CREATING":
+      case "STARTING": return "bg-blue-100 text-blue-700";
+      case "DELETING":
+      case "STOPPING": return "bg-red-100 text-red-700";
+      case "STOPPED": return "bg-yellow-100 text-yellow-700";
+      default: return "bg-gray-100 text-gray-700";
+    }
+  };
 
   return (
     <div className="space-y-4">
@@ -49,6 +115,20 @@ export function Graphs() {
         </div>
         <RefreshButton onClick={load} />
       </div>
+
+      {/* Error Alerts */}
+      {alerts.map((alert) => (
+        <div key={alert.graphId} className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-3">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-600" />
+          <div className="flex-1 text-sm">
+            <p className="font-medium text-red-800">Action failed on {alert.graphName}</p>
+            <p className="text-red-700">{alert.message}</p>
+          </div>
+          <button onClick={() => dismissAlert(alert.graphId)} className="text-red-400 hover:text-red-600">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
 
       {loading ? (
         <p className="text-sm text-gray-500">Loading...</p>
@@ -64,12 +144,16 @@ export function Graphs() {
                 <th className="px-4 py-3 font-medium">Nodes</th>
                 <th className="px-4 py-3 font-medium">Edges</th>
                 <th className="px-4 py-3 font-medium">Status</th>
-                <th className="px-4 py-3 font-medium"></th>
+                <th className="px-4 py-3 font-medium">Actions</th>
               </tr>
             </thead>
             <tbody>
               {graphs.map((g) => {
                 const s = summaries[g.id];
+                const state = actionStates[g.id];
+                const actions = state?.actions || [];
+                const isTransient = ["STOPPING", "STARTING", "DELETING", "CREATING"].includes(g.status);
+
                 return (
                   <tr key={g.id} className="border-b last:border-0">
                     <td className="px-4 py-3 font-medium">{g.name}</td>
@@ -77,36 +161,63 @@ export function Graphs() {
                     <td className="px-4 py-3">{s ? s.numNodes.toLocaleString() : "—"}</td>
                     <td className="px-4 py-3">{s ? s.numEdges.toLocaleString() : "—"}</td>
                     <td className="px-4 py-3">
-                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
-                        g.status === "AVAILABLE" ? "bg-green-100 text-green-700" :
-                        g.status === "CREATING" ? "bg-blue-100 text-blue-700" :
-                        g.status === "DELETING" ? "bg-red-100 text-red-700" :
-                        "bg-gray-100 text-gray-700"
-                      }`}>{g.status}</span>
+                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusStyle(g.status)}`}>
+                        {g.status}
+                      </span>
                     </td>
-                    <td className="px-4 py-3 flex gap-2">
-                      <button
-                        className="text-gray-400 hover:text-blue-600 disabled:opacity-30"
-                        disabled={g.status !== "AVAILABLE"}
-                        title="Open in Graph Explorer"
-                        onClick={() => {
-                          const graphDbUrl = `https://${g.id}.${region}.neptune-graph.amazonaws.com`;
-                          const params = new URLSearchParams({
-                            graphDbUrl,
-                            queryEngine: "openCypher",
-                            awsRegion: region,
-                            serviceType: "neptune-graph",
-                            name: g.name,
-                          });
-                          const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost";
-                          window.open(`${geBase}/#/connect?${params}`, "_blank");
-                        }}
-                      ><ExternalLink className="h-4 w-4" /></button>
-                      <button
-                        className="text-gray-400 hover:text-red-600 disabled:opacity-30"
-                        disabled={g.status === "DELETING"}
-                        onClick={async () => { if (confirm(`Delete graph ${g.name}?`)) { await metadata.deleteGraph(g.id); load(); } }}
-                      ><Trash2 className="h-4 w-4" /></button>
+                    <td className="px-4 py-3">
+                      <div className="flex gap-1">
+                        {/* Graph Explorer */}
+                        <button
+                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-blue-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                          disabled={g.status !== "AVAILABLE"}
+                          title="Open in Graph Explorer"
+                          onClick={() => {
+                            const graphDbUrl = `https://${g.id}.${region}.neptune-graph.amazonaws.com`;
+                            const params = new URLSearchParams({
+                              graphDbUrl,
+                              queryEngine: "openCypher",
+                              awsRegion: region,
+                              serviceType: "neptune-graph",
+                              name: g.name,
+                            });
+                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost";
+                            window.open(`${geBase}/#/connect?${params}`, "_blank");
+                          }}
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </button>
+
+                        {/* Stop */}
+                        <button
+                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-amber-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                          disabled={!actions.includes("stop") || isTransient}
+                          title="Stop graph"
+                          onClick={() => performAction(g.id, "stop", g.name)}
+                        >
+                          <Square className="h-4 w-4" />
+                        </button>
+
+                        {/* Start */}
+                        <button
+                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-green-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                          disabled={!actions.includes("start") || isTransient}
+                          title="Start graph"
+                          onClick={() => performAction(g.id, "start", g.name)}
+                        >
+                          <Play className="h-4 w-4" />
+                        </button>
+
+                        {/* Delete */}
+                        <button
+                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                          disabled={!actions.includes("delete") || isTransient}
+                          title="Delete graph"
+                          onClick={() => performAction(g.id, "delete", g.name)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## Summary

Adds the ability to manage Neptune Analytics graph lifecycle directly from the Graph Studio UI — start, stop, and delete graphs with proper state validation and async execution.

## Changes

**Backend — state machine pattern**
- `services/graph_state_machine.py` — Generic transition engine with validation, async polling, in-flight error tracking
- `services/graph_ops.py` — Concrete operations (stop, start, delete) registered as transitions. Adding new actions only requires changes here.
- `routers/graph.py` — REST endpoints: `GET /{graph_id}/actions`, `POST /{graph_id}/{action}`, `GET/DELETE /{graph_id}/inflight`
- `app.py` — Register graph router

**Frontend**
- `api/index.ts` — Added `graphActions` API namespace
- `Graphs.tsx` — Action buttons (start/stop/delete) driven by backend state, disabled when invalid, auto-poll during transient states (30s), error alerts with dismiss

**Infra**
- `docker-compose.yml` — Use `GRAPH_EXPLORER_IMAGE` variable for flexible local testing
- `Makefile` — Added `make up-ge` target for running only Graph Explorer

## Valid transitions

| Current State | Available Actions |
|--------------|-------------------|
| AVAILABLE | stop, delete |
| STOPPED | start, delete |
| Other | none (buttons disabled) |

<img width="1478" height="257" alt="Screenshot 2026-07-03 at 2 06 06 PM" src="https://github.com/user-attachments/assets/91b681cd-0f1d-466a-9ce0-09a6fa9ad7bf" />
<img width="1467" height="294" alt="Screenshot 2026-07-03 at 2 09 12 PM" src="https://github.com/user-attachments/assets/299c0d41-fae6-4fdd-8e9e-bb56b9bbc3ff" />
<img width="1457" height="255" alt="Screenshot 2026-07-03 at 2 12 27 PM" src="https://github.com/user-attachments/assets/9e1a90d4-c2b6-4b61-9c30-fe77968b8063" />


## Testing

- All 34 existing tests pass
- Python import verification passes
- UI builds successfully
