### PR TITLE
CI: Ignore JUnit vintage engine in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,14 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "org.junit.jupiter:*"
+      - dependency-name: "org.junit.vintage:*"
   - package-ecosystem: "maven"
     directory: "/connectors/athena-s3vector-connector"
     schedule:
       interval: "weekly"
     ignore:
       - dependency-name: "org.junit.jupiter:*"
+      - dependency-name: "org.junit.vintage:*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
**Description:**

Add `org.junit.vintage:*` to the Dependabot ignore list for both Maven connectors.
The `org.junit.jupiter:*` ignore was already in place but didn't cover the vintage engine, which allowed PRs like #306 (JUnit 5→6 major bump) to still be created.