### PR TITLE
Feat: Introduce the concept of projection archive 

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -146,35 +146,46 @@ def execute_projection(projection_id: str, background_tasks: BackgroundTasks):
     return {"id": p.id, "status": "accepted"}
 
 
-@router.delete("/{projection_id}", summary="Delete projection and its graph", status_code=202)
-def delete_projection(projection_id: str, background_tasks: BackgroundTasks):
-    """Set status to deleting, delete graph in background, then remove record."""
+@router.delete("/{projection_id}", summary="Delete projection record", status_code=200)
+def delete_projection(projection_id: str):
+    """Permanently remove the projection record from the database."""
     p = _get_projection_or_404(projection_id)
+    if p.status == "deleting":
+        raise HTTPException(status_code=409, detail="Graph deletion in progress, cannot purge yet")
+    store.delete(projection_id)
+    return {"id": p.id, "status": "deleted"}
+
+
+@router.post("/{projection_id}/delete-graph", summary="Delete associated graph and archive projection", status_code=202)
+def delete_projection_graph(projection_id: str, background_tasks: BackgroundTasks):
+    """Delete the Neptune graph in background, then mark projection as archived."""
+    p = _get_projection_or_404(projection_id)
+    if not p.graph_id:
+        raise HTTPException(status_code=409, detail="No graph associated with this projection")
     if p.status == "deleting":
         raise HTTPException(status_code=409, detail="Already deleting")
     store.update(projection_id, status="deleting", step="graph_delete", step_label="Deleting graph")
 
-    async def _delete():
-        if p.graph_id:
-            client = ClientFactory().neptune()
-            try:
-                client.delete_graph(graphIdentifier=p.graph_id, skipSnapshot=True)
-            except ClientError as e:
-                if e.response["Error"]["Code"] != "ResourceNotFoundException":
-                    store.update(projection_id, status="failed", error=str(e))
-                    return
-            # Poll until gone
-            for _ in range(60):
-                await asyncio.sleep(10)
-                try:
-                    client.get_graph(graphIdentifier=p.graph_id)
-                except ClientError:
-                    break
-            else:
-                # Timeout — graph may still exist
-                store.update(projection_id, status="failed", error="Timeout waiting for graph deletion")
+    async def _delete_graph():
+        client = ClientFactory().neptune()
+        try:
+            client.delete_graph(graphIdentifier=p.graph_id, skipSnapshot=True)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "ResourceNotFoundException":
+                store.update(projection_id, status="failed", error=str(e))
                 return
-        store.delete(projection_id)
+        # Poll until gone
+        for _ in range(60):
+            await asyncio.sleep(10)
+            try:
+                client.get_graph(graphIdentifier=p.graph_id)
+            except ClientError:
+                break
+        else:
+            store.update(projection_id, status="failed", error="Timeout waiting for graph deletion")
+            return
+        store.update(projection_id, status="archived", graph_id=None, graph_endpoint=None,
+                     step=None, step_label=None, progress=0)
 
-    background_tasks.add_task(_delete)
+    background_tasks.add_task(_delete_graph)
     return {"id": p.id, "status": "deleting"}

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -82,6 +82,7 @@ export const projection = {
   preview: (id: string, limit = 10) => request<{ error?: string; results: { columns: string[]; rows: string[][] }[] }>(`/projection/${id}/preview?limit=${limit}`, { method: "POST" }),
   execute: (id: string) => request<{ message: string }>(`/projection/${id}/execute`, { method: "POST" }),
   delete: (id: string) => request<{ id: string; status: string }>(`/projection/${id}`, { method: "DELETE" }),
+  deleteGraph: (id: string) => request<{ id: string; status: string }>(`/projection/${id}/delete-graph`, { method: "POST" }),
 };
 
 // --- Project ---

--- a/proxy/ui-src/src/pages/Graphs.tsx
+++ b/proxy/ui-src/src/pages/Graphs.tsx
@@ -183,7 +183,7 @@ export function Graphs() {
                               serviceType: "neptune-graph",
                               name: g.name,
                             });
-                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost/explorer";
+                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
                             window.open(`${geBase}/#/connect?${params}`, "_blank");
                           }}
                         >

--- a/proxy/ui-src/src/pages/Graphs.tsx
+++ b/proxy/ui-src/src/pages/Graphs.tsx
@@ -183,7 +183,7 @@ export function Graphs() {
                               serviceType: "neptune-graph",
                               name: g.name,
                             });
-                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
+                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost/explorer";
                             window.open(`${geBase}/#/connect?${params}`, "_blank");
                           }}
                         >

--- a/proxy/ui-src/src/pages/Sessions.tsx
+++ b/proxy/ui-src/src/pages/Sessions.tsx
@@ -231,7 +231,7 @@ export function Sessions() {
                             serviceType: "neptune-graph",
                             name: s.graph_name || s.graph_id || "",
                           });
-                          const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
+                          const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost/explorer";
                           window.open(`${geBase}/#/connect?${params}`, "_blank");
                         }}
                       >
@@ -390,7 +390,7 @@ export function Sessions() {
                   serviceType: "neptune-graph",
                   name: selected.graph_name || selected.graph_id || "",
                 } as Record<string, string>);
-                const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
+                const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost/explorer";
                 window.open(`${geBase}/#/connect?${params}`, "_blank");
               }}>
                 <ExternalLink className="h-3 w-3" /> Open in Graph Explorer

--- a/proxy/ui-src/src/pages/Sessions.tsx
+++ b/proxy/ui-src/src/pages/Sessions.tsx
@@ -83,6 +83,18 @@ export function Sessions() {
     }
   }
 
+  async function deleteSession(sessionId: string, name: string) {
+    if (!confirm(`Delete session "${name}"? This will also delete the associated graph.`)) return;
+    try {
+      await projection.delete(sessionId);
+      setSelected(null);
+      load();
+      window.dispatchEvent(new Event("projects-changed"));
+    } catch (e: any) {
+      setAlerts(prev => [...prev, { graphId: sessionId, graphName: name, message: e.message || "Failed to delete" }]);
+    }
+  }
+
   function dismissAlert(graphId: string) {
     setAlerts(prev => prev.filter(a => a.graphId !== graphId));
     graphActions.dismissInflight(graphId).catch(() => {});
@@ -221,12 +233,12 @@ export function Sessions() {
                           <Play className="h-4 w-4" />
                         </button>
 
-                        {/* Delete */}
+                        {/* Delete session + graph */}
                         <button
                           className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={!actions.includes("delete") || isTransient}
-                          title="Delete graph"
-                          onClick={(e) => { e.stopPropagation(); performGraphAction(s.graph_id!, "delete", s.graph_name || s.graph_id!); }}
+                          disabled={isTransient}
+                          title="Delete session and graph"
+                          onClick={(e) => { e.stopPropagation(); deleteSession(s.id, s.graph_name || s.id.slice(0, 8)); }}
                         >
                           <Trash2 className="h-4 w-4" />
                         </button>
@@ -322,8 +334,7 @@ export function Sessions() {
               <Button
                 variant="ghost"
                 className="flex-1 text-red-600 hover:text-red-700"
-                disabled={!actionStates[selected.graph_id]?.actions.includes("delete")}
-                onClick={() => performGraphAction(selected.graph_id!, "delete", selected.graph_name || selected.graph_id!)}
+                onClick={() => deleteSession(selected.id, selected.graph_name || selected.id.slice(0, 8))}
               >
                 <Trash2 className="h-3 w-3" /> Delete
               </Button>

--- a/proxy/ui-src/src/pages/Sessions.tsx
+++ b/proxy/ui-src/src/pages/Sessions.tsx
@@ -277,62 +277,62 @@ export function Sessions() {
         </Card>
 
         {/* Archived Sessions (collapsible) */}
-        {archived.length > 0 && (
-          <div>
-            <button
-              className="flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900"
-              onClick={() => setArchivedOpen(!archivedOpen)}
-            >
-              {archivedOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-              Archived ({archived.length})
-            </button>
+        <div>
+          <button
+            className="flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900"
+            onClick={() => setArchivedOpen(!archivedOpen)}
+          >
+            {archivedOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+            Archived ({archived.length})
+          </button>
 
-            {archivedOpen && (
-              <Card className="mt-2 overflow-hidden p-0">
-                <table className="w-full text-left text-sm">
-                  <thead className="border-b bg-gray-50">
-                    <tr>
-                      <th className="px-4 py-3 font-medium">Name</th>
-                      <th className="px-4 py-3 font-medium">Project</th>
-                      <th className="px-4 py-3 font-medium">Import Status</th>
-                      <th className="px-4 py-3 font-medium">Progress</th>
-                      <th className="px-4 py-3 font-medium">Created</th>
-                      <th className="px-4 py-3 font-medium">Graph Status</th>
-                      <th className="px-4 py-3 font-medium">Actions</th>
+          {archivedOpen && (
+            <Card className="mt-2 overflow-hidden p-0">
+              <table className="w-full text-left text-sm">
+                <thead className="border-b bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Name</th>
+                    <th className="px-4 py-3 font-medium">Project</th>
+                    <th className="px-4 py-3 font-medium">Import Status</th>
+                    <th className="px-4 py-3 font-medium">Progress</th>
+                    <th className="px-4 py-3 font-medium">Created</th>
+                    <th className="px-4 py-3 font-medium">Graph Status</th>
+                    <th className="px-4 py-3 font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {archived.length === 0 ? (
+                    <tr><td colSpan={7} className="px-4 py-6 text-center text-sm text-gray-500">No archived sessions</td></tr>
+                  ) : archived.map((s) => (
+                    <tr
+                      key={s.id}
+                      className={`cursor-pointer border-b last:border-0 hover:bg-gray-50 ${selected?.id === s.id ? "bg-blue-50" : ""}`}
+                      onClick={() => setSelected(s)}
+                      onDoubleClick={() => navigate(`/import?session=${s.id}`)}
+                    >
+                      <td className="px-4 py-3 font-medium text-gray-500">{s.graph_name || s.id.slice(0, 8)}</td>
+                      <td className="px-4 py-3 text-gray-500">{s.project_id ? projects.get(s.project_id)?.name || "—" : "—"}</td>
+                      <td className="px-4 py-3">
+                        <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">archived</span>
+                      </td>
+                      <td className="px-4 py-3 text-gray-400">—</td>
+                      <td className="px-4 py-3 text-gray-500">{new Date(s.created_at).toLocaleString()}</td>
+                      <td className="px-4 py-3"><span className="text-gray-400">—</span></td>
+                      <td className="px-4 py-3">
+                        <button
+                          className="rounded-md border border-red-200 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 hover:border-red-300"
+                          onClick={(e) => { e.stopPropagation(); purgeSession(s.id, s.graph_name || s.id.slice(0, 8)); }}
+                        >
+                          Delete projection job
+                        </button>
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    {archived.map((s) => (
-                      <tr
-                        key={s.id}
-                        className={`cursor-pointer border-b last:border-0 hover:bg-gray-50 ${selected?.id === s.id ? "bg-blue-50" : ""}`}
-                        onClick={() => setSelected(s)}
-                        onDoubleClick={() => navigate(`/import?session=${s.id}`)}
-                      >
-                        <td className="px-4 py-3 font-medium text-gray-500">{s.graph_name || s.id.slice(0, 8)}</td>
-                        <td className="px-4 py-3 text-gray-500">{s.project_id ? projects.get(s.project_id)?.name || "—" : "—"}</td>
-                        <td className="px-4 py-3">
-                          <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">archived</span>
-                        </td>
-                        <td className="px-4 py-3 text-gray-400">—</td>
-                        <td className="px-4 py-3 text-gray-500">{new Date(s.created_at).toLocaleString()}</td>
-                        <td className="px-4 py-3"><span className="text-gray-400">—</span></td>
-                        <td className="px-4 py-3">
-                          <button
-                            className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
-                            onClick={(e) => { e.stopPropagation(); purgeSession(s.id, s.graph_name || s.id.slice(0, 8)); }}
-                          >
-                            Delete projection job
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </Card>
-            )}
-          </div>
-        )}
+                  ))}
+                </tbody>
+              </table>
+            </Card>
+          )}
+        </div>
       </div>
 
       {/* Detail Panel */}

--- a/proxy/ui-src/src/pages/Sessions.tsx
+++ b/proxy/ui-src/src/pages/Sessions.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams, NavLink } from "react-router";
 import { projection, metadata, projectApi, graphActions, type Projection, type Project, type Inflight } from "../api";
 import { Card, Button, RefreshButton } from "../components/ui";
-import { X, ExternalLink, Trash2, Square, Play, AlertTriangle } from "lucide-react";
+import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown } from "lucide-react";
 import { useNavigate } from "react-router";
 
 export function Sessions() {
@@ -15,6 +15,7 @@ export function Sessions() {
   const [graphStatuses, setGraphStatuses] = useState<Map<string, string>>(new Map());
   const [actionStates, setActionStates] = useState<Record<string, { actions: string[]; inflight: Inflight | null }>>({});
   const [alerts, setAlerts] = useState<{ graphId: string; graphName: string; message: string }[]>([]);
+  const [archivedOpen, setArchivedOpen] = useState(false);
   const navigate = useNavigate();
   const filterProjectId = searchParams.get("project");
 
@@ -58,9 +59,11 @@ export function Sessions() {
     setSummaries(new Map(entries));
   }
 
-  const filtered = filterProjectId
+  const allFiltered = filterProjectId
     ? sessions.filter(s => s.project_id === filterProjectId)
     : sessions;
+  const active = allFiltered.filter(s => s.status !== "archived");
+  const archived = allFiltered.filter(s => s.status === "archived");
   const projectName = filterProjectId ? projects.get(filterProjectId)?.name : null;
 
   // Fetch graph actions when selecting a session that has a graph
@@ -73,7 +76,6 @@ export function Sessions() {
   }, [selected?.graph_id, graphStatuses]);
 
   async function performGraphAction(graphId: string, action: string, graphName: string) {
-    if (action === "delete" && !confirm(`Delete graph ${graphName}? This cannot be undone.`)) return;
     if (action === "stop" && !confirm(`Stop graph ${graphName}? It will become unavailable until restarted.`)) return;
     try {
       await graphActions.perform(graphId, action);
@@ -83,11 +85,22 @@ export function Sessions() {
     }
   }
 
-  async function deleteSession(sessionId: string, name: string) {
-    if (!confirm(`Delete session "${name}"? This will also delete the associated graph.`)) return;
+  async function archiveSession(sessionId: string, name: string) {
+    if (!confirm(`Delete graph for "${name}"? The session config will be preserved.`)) return;
+    try {
+      await projection.deleteGraph(sessionId);
+      load();
+      window.dispatchEvent(new Event("projects-changed"));
+    } catch (e: any) {
+      setAlerts(prev => [...prev, { graphId: sessionId, graphName: name, message: e.message || "Failed to delete graph" }]);
+    }
+  }
+
+  async function purgeSession(sessionId: string, name: string) {
+    if (!confirm(`Permanently delete projection job "${name}"? This cannot be undone.`)) return;
     try {
       await projection.delete(sessionId);
-      setSelected(null);
+      if (selected?.id === sessionId) setSelected(null);
       load();
       window.dispatchEvent(new Event("projects-changed"));
     } catch (e: any) {
@@ -110,6 +123,26 @@ export function Sessions() {
     const interval = setInterval(() => load(), 30000);
     return () => clearInterval(interval);
   }, [hasTransient]);
+
+  const statusStyle = (status: string) => {
+    switch (status) {
+      case "complete": return "bg-green-100 text-green-700";
+      case "failed": return "bg-red-100 text-red-700";
+      case "executing": case "deleting": return "bg-blue-100 text-blue-700";
+      case "archived": return "bg-gray-100 text-gray-600";
+      default: return "bg-gray-100 text-gray-700";
+    }
+  };
+
+  const graphStatusStyle = (status: string) => {
+    switch (status) {
+      case "AVAILABLE": return "bg-green-100 text-green-700";
+      case "STOPPED": return "bg-yellow-100 text-yellow-700";
+      case "STOPPING": case "DELETING": return "bg-red-100 text-red-700";
+      case "CREATING": case "STARTING": return "bg-blue-100 text-blue-700";
+      default: return "bg-gray-100 text-gray-700";
+    }
+  };
 
   return (
     <div className="flex gap-4">
@@ -139,6 +172,7 @@ export function Sessions() {
         </div>
       ))}
 
+        {/* Active Sessions */}
         <Card className="overflow-hidden p-0">
           <table className="w-full text-left text-sm">
             <thead className="border-b bg-gray-50">
@@ -150,108 +184,158 @@ export function Sessions() {
                 <th className="px-4 py-3 font-medium">Created</th>
                 <th className="px-4 py-3 font-medium">Graph Status</th>
                 <th className="px-4 py-3 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {active.length === 0 ? (
+                <tr><td colSpan={7} className="px-4 py-6 text-center text-sm text-gray-500">No active sessions</td></tr>
+              ) : active.map((s) => {
+                const graphStatus = s.graph_id ? graphStatuses.get(s.graph_id) : undefined;
+                const state = s.graph_id ? actionStates[s.graph_id] : undefined;
+                const actions = state?.actions || [];
+                const isTransient = graphStatus ? ["STOPPING", "STARTING", "DELETING", "CREATING"].includes(graphStatus) : false;
+
+                return (
+                <tr
+                  key={s.id}
+                  className={`cursor-pointer border-b last:border-0 hover:bg-gray-50 ${selected?.id === s.id ? "bg-blue-50" : ""}`}
+                  onClick={() => setSelected(s)}
+                  onDoubleClick={() => navigate(`/import?session=${s.id}`)}
+                >
+                  <td className="px-4 py-3 font-medium">{s.graph_name || s.id.slice(0, 8)}</td>
+                  <td className="px-4 py-3 text-gray-600">{s.project_id ? projects.get(s.project_id)?.name || "—" : "—"}</td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusStyle(s.status)}`}>{s.status}</span>
+                  </td>
+                  <td className="px-4 py-3">{Math.round(s.progress)}%</td>
+                  <td className="px-4 py-3 text-gray-500">{new Date(s.created_at).toLocaleString()}</td>
+                  <td className="px-4 py-3">
+                    {graphStatus ? (
+                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${graphStatusStyle(graphStatus)}`}>{graphStatus}</span>
+                    ) : <span className="text-gray-400">—</span>}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-1">
+                      {/* Graph Explorer */}
+                      <button
+                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-blue-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                        disabled={!s.graph_id || graphStatus !== "AVAILABLE"}
+                        title="Open in Graph Explorer"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          const graphDbUrl = `https://${s.graph_id}.${region}.neptune-graph.amazonaws.com`;
+                          const params = new URLSearchParams({
+                            graphDbUrl,
+                            queryEngine: "openCypher",
+                            awsRegion: region,
+                            serviceType: "neptune-graph",
+                            name: s.graph_name || s.graph_id || "",
+                          });
+                          const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
+                          window.open(`${geBase}/#/connect?${params}`, "_blank");
+                        }}
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </button>
+
+                      {/* Stop */}
+                      <button
+                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-amber-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                        disabled={!actions.includes("stop") || isTransient}
+                        title="Stop graph"
+                        onClick={(e) => { e.stopPropagation(); performGraphAction(s.graph_id!, "stop", s.graph_name || s.graph_id!); }}
+                      >
+                        <Square className="h-4 w-4" />
+                      </button>
+
+                      {/* Start */}
+                      <button
+                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-green-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                        disabled={!actions.includes("start") || isTransient}
+                        title="Start graph"
+                        onClick={(e) => { e.stopPropagation(); performGraphAction(s.graph_id!, "start", s.graph_name || s.graph_id!); }}
+                      >
+                        <Play className="h-4 w-4" />
+                      </button>
+
+                      {/* Archive (delete graph, keep session) */}
+                      <button
+                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                        disabled={!s.graph_id || isTransient}
+                        title="Delete graph (archive session)"
+                        onClick={(e) => { e.stopPropagation(); archiveSession(s.id, s.graph_name || s.id.slice(0, 8)); }}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {filtered.map((s) => {
-                  const graphStatus = s.graph_id ? graphStatuses.get(s.graph_id) : undefined;
-                  const state = s.graph_id ? actionStates[s.graph_id] : undefined;
-                  const actions = state?.actions || [];
-                  const isTransient = graphStatus ? ["STOPPING", "STARTING", "DELETING", "CREATING"].includes(graphStatus) : false;
+                );
+              })}
+            </tbody>
+          </table>
+        </Card>
 
-                  return (
-                  <tr
-                    key={s.id}
-                    className={`cursor-pointer border-b last:border-0 hover:bg-gray-50 ${selected?.id === s.id ? "bg-blue-50" : ""}`}
-                    onClick={() => setSelected(s)}
-                    onDoubleClick={() => navigate(`/import?session=${s.id}`)}
-                  >
-                    <td className="px-4 py-3 font-medium">{s.graph_name || s.id.slice(0, 8)}</td>
-                    <td className="px-4 py-3 text-gray-600">{s.project_id ? projects.get(s.project_id)?.name || "—" : "—"}</td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
-                        s.status === "complete" ? "bg-green-100 text-green-700" :
-                        s.status === "failed" ? "bg-red-100 text-red-700" :
-                        s.status === "executing" ? "bg-blue-100 text-blue-700" :
-                        "bg-gray-100 text-gray-700"
-                      }`}>{s.status}</span>
-                    </td>
-                    <td className="px-4 py-3">{Math.round(s.progress)}%</td>
-                    <td className="px-4 py-3 text-gray-500">{new Date(s.created_at).toLocaleString()}</td>
-                    <td className="px-4 py-3">
-                      {graphStatus ? (
-                        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
-                          graphStatus === "AVAILABLE" ? "bg-green-100 text-green-700" :
-                          graphStatus === "STOPPED" ? "bg-yellow-100 text-yellow-700" :
-                          ["STOPPING", "DELETING"].includes(graphStatus) ? "bg-red-100 text-red-700" :
-                          ["CREATING", "STARTING"].includes(graphStatus) ? "bg-blue-100 text-blue-700" :
-                          "bg-gray-100 text-gray-700"
-                        }`}>{graphStatus}</span>
-                      ) : <span className="text-gray-400">—</span>}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex gap-1">
-                        {/* Graph Explorer */}
-                        <button
-                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-blue-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={!s.graph_id || graphStatus !== "AVAILABLE"}
-                          title="Open in Graph Explorer"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            const graphDbUrl = `https://${s.graph_id}.${region}.neptune-graph.amazonaws.com`;
-                            const params = new URLSearchParams({
-                              graphDbUrl,
-                              queryEngine: "openCypher",
-                              awsRegion: region,
-                              serviceType: "neptune-graph",
-                              name: s.graph_name || s.graph_id || "",
-                            });
-                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
-                            window.open(`${geBase}/#/connect?${params}`, "_blank");
-                          }}
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                        </button>
+        {/* Archived Sessions (collapsible) */}
+        {archived.length > 0 && (
+          <div>
+            <button
+              className="flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900"
+              onClick={() => setArchivedOpen(!archivedOpen)}
+            >
+              {archivedOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+              Archived ({archived.length})
+            </button>
 
-                        {/* Stop */}
-                        <button
-                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-amber-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={!actions.includes("stop") || isTransient}
-                          title="Stop graph"
-                          onClick={(e) => { e.stopPropagation(); performGraphAction(s.graph_id!, "stop", s.graph_name || s.graph_id!); }}
-                        >
-                          <Square className="h-4 w-4" />
-                        </button>
-
-                        {/* Start */}
-                        <button
-                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-green-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={!actions.includes("start") || isTransient}
-                          title="Start graph"
-                          onClick={(e) => { e.stopPropagation(); performGraphAction(s.graph_id!, "start", s.graph_name || s.graph_id!); }}
-                        >
-                          <Play className="h-4 w-4" />
-                        </button>
-
-                        {/* Delete session + graph */}
-                        <button
-                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={isTransient}
-                          title="Delete session and graph"
-                          onClick={(e) => { e.stopPropagation(); deleteSession(s.id, s.graph_name || s.id.slice(0, 8)); }}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </Card>
+            {archivedOpen && (
+              <Card className="mt-2 overflow-hidden p-0">
+                <table className="w-full text-left text-sm">
+                  <thead className="border-b bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-3 font-medium">Name</th>
+                      <th className="px-4 py-3 font-medium">Project</th>
+                      <th className="px-4 py-3 font-medium">Import Status</th>
+                      <th className="px-4 py-3 font-medium">Progress</th>
+                      <th className="px-4 py-3 font-medium">Created</th>
+                      <th className="px-4 py-3 font-medium">Graph Status</th>
+                      <th className="px-4 py-3 font-medium">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {archived.map((s) => (
+                      <tr
+                        key={s.id}
+                        className={`cursor-pointer border-b last:border-0 hover:bg-gray-50 ${selected?.id === s.id ? "bg-blue-50" : ""}`}
+                        onClick={() => setSelected(s)}
+                        onDoubleClick={() => navigate(`/import?session=${s.id}`)}
+                      >
+                        <td className="px-4 py-3 font-medium text-gray-500">{s.graph_name || s.id.slice(0, 8)}</td>
+                        <td className="px-4 py-3 text-gray-500">{s.project_id ? projects.get(s.project_id)?.name || "—" : "—"}</td>
+                        <td className="px-4 py-3">
+                          <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">archived</span>
+                        </td>
+                        <td className="px-4 py-3 text-gray-400">—</td>
+                        <td className="px-4 py-3 text-gray-500">{new Date(s.created_at).toLocaleString()}</td>
+                        <td className="px-4 py-3"><span className="text-gray-400">—</span></td>
+                        <td className="px-4 py-3">
+                          <button
+                            className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
+                            onClick={(e) => { e.stopPropagation(); purgeSession(s.id, s.graph_name || s.id.slice(0, 8)); }}
+                          >
+                            Delete projection job
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </Card>
+            )}
+          </div>
+        )}
       </div>
 
+      {/* Detail Panel */}
       {selected && (
         <Card className="w-80 shrink-0 space-y-3 self-start">
           <div className="flex items-center justify-between">
@@ -274,11 +358,9 @@ export function Sessions() {
             <div><span className="text-gray-500">Graph ID:</span> {selected.graph_id || "—"}</div>
             {selected.graph_id && graphStatuses.get(selected.graph_id) && (
               <div><span className="text-gray-500">Graph Status:</span>{" "}
-                <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
-                  graphStatuses.get(selected.graph_id) === "AVAILABLE" ? "bg-green-100 text-green-700" :
-                  graphStatuses.get(selected.graph_id) === "DELETING" ? "bg-red-100 text-red-700" :
-                  "bg-blue-100 text-blue-700"
-                }`}>{graphStatuses.get(selected.graph_id)}</span>
+                <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${graphStatusStyle(graphStatuses.get(selected.graph_id)!)}`}>
+                  {graphStatuses.get(selected.graph_id)}
+                </span>
               </div>
             )}
             {summaries.get(selected.id) && (
@@ -297,48 +379,57 @@ export function Sessions() {
           <Button variant="secondary" className="w-full" onClick={() => navigate(`/import?session=${selected.id}`)}>
             Open in Import
           </Button>
-          {selected.graph_id && selected.status === "complete" && (
-            <Button variant="ghost" className="w-full" onClick={() => {
-              const graphDbUrl = `https://${selected.graph_id}.${region}.neptune-graph.amazonaws.com`;
-              const params = new URLSearchParams({
-                graphDbUrl,
-                queryEngine: "openCypher",
-                awsRegion: region,
-                serviceType: "neptune-graph",
-                name: selected.graph_name || selected.graph_id || "",
-              } as Record<string, string>);
-              const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
-              window.open(`${geBase}/#/connect?${params}`, "_blank");
-            }}>
-              <ExternalLink className="h-3 w-3" /> Open in Graph Explorer
-            </Button>
+          {selected.graph_id && selected.status !== "archived" && (
+            <>
+              <Button variant="ghost" className="w-full" onClick={() => {
+                const graphDbUrl = `https://${selected.graph_id}.${region}.neptune-graph.amazonaws.com`;
+                const params = new URLSearchParams({
+                  graphDbUrl,
+                  queryEngine: "openCypher",
+                  awsRegion: region,
+                  serviceType: "neptune-graph",
+                  name: selected.graph_name || selected.graph_id || "",
+                } as Record<string, string>);
+                const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
+                window.open(`${geBase}/#/connect?${params}`, "_blank");
+              }}>
+                <ExternalLink className="h-3 w-3" /> Open in Graph Explorer
+              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  disabled={!actionStates[selected.graph_id]?.actions.includes("stop")}
+                  onClick={() => performGraphAction(selected.graph_id!, "stop", selected.graph_name || selected.graph_id!)}
+                >
+                  <Square className="h-3 w-3" /> Stop
+                </Button>
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  disabled={!actionStates[selected.graph_id]?.actions.includes("start")}
+                  onClick={() => performGraphAction(selected.graph_id!, "start", selected.graph_name || selected.graph_id!)}
+                >
+                  <Play className="h-3 w-3" /> Start
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="flex-1 text-red-600 hover:text-red-700"
+                  onClick={() => archiveSession(selected.id, selected.graph_name || selected.id.slice(0, 8))}
+                >
+                  <Trash2 className="h-3 w-3" /> Delete
+                </Button>
+              </div>
+            </>
           )}
-          {selected.graph_id && (
-            <div className="flex gap-2">
-              <Button
-                variant="secondary"
-                className="flex-1"
-                disabled={!actionStates[selected.graph_id]?.actions.includes("stop")}
-                onClick={() => performGraphAction(selected.graph_id!, "stop", selected.graph_name || selected.graph_id!)}
-              >
-                <Square className="h-3 w-3" /> Stop
-              </Button>
-              <Button
-                variant="secondary"
-                className="flex-1"
-                disabled={!actionStates[selected.graph_id]?.actions.includes("start")}
-                onClick={() => performGraphAction(selected.graph_id!, "start", selected.graph_name || selected.graph_id!)}
-              >
-                <Play className="h-3 w-3" /> Start
-              </Button>
-              <Button
-                variant="ghost"
-                className="flex-1 text-red-600 hover:text-red-700"
-                onClick={() => deleteSession(selected.id, selected.graph_name || selected.id.slice(0, 8))}
-              >
-                <Trash2 className="h-3 w-3" /> Delete
-              </Button>
-            </div>
+          {selected.status === "archived" && (
+            <Button
+              variant="ghost"
+              className="w-full text-red-600 hover:text-red-700"
+              onClick={() => purgeSession(selected.id, selected.graph_name || selected.id.slice(0, 8))}
+            >
+              Delete projection job
+            </Button>
           )}
           {selected.graph_id && actionStates[selected.graph_id]?.inflight?.error && (
             <div className="flex items-start gap-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">

--- a/proxy/ui-src/src/pages/Sessions.tsx
+++ b/proxy/ui-src/src/pages/Sessions.tsx
@@ -83,18 +83,6 @@ export function Sessions() {
     }
   }
 
-  async function deleteSession(sessionId: string, name: string) {
-    if (!confirm(`Delete session "${name}"? This will also delete the associated graph.`)) return;
-    try {
-      await projection.delete(sessionId);
-      setSelected(null);
-      load();
-      window.dispatchEvent(new Event("projects-changed"));
-    } catch (e: any) {
-      setAlerts(prev => [...prev, { graphId: sessionId, graphName: name, message: e.message || "Failed to delete" }]);
-    }
-  }
-
   function dismissAlert(graphId: string) {
     setAlerts(prev => prev.filter(a => a.graphId !== graphId));
     graphActions.dismissInflight(graphId).catch(() => {});
@@ -206,7 +194,7 @@ export function Sessions() {
                               serviceType: "neptune-graph",
                               name: s.graph_name || s.graph_id || "",
                             });
-                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost/explorer";
+                            const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
                             window.open(`${geBase}/#/connect?${params}`, "_blank");
                           }}
                         >
@@ -233,12 +221,12 @@ export function Sessions() {
                           <Play className="h-4 w-4" />
                         </button>
 
-                        {/* Delete session + graph */}
+                        {/* Delete */}
                         <button
                           className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={isTransient}
-                          title="Delete session and graph"
-                          onClick={(e) => { e.stopPropagation(); deleteSession(s.id, s.graph_name || s.id.slice(0, 8)); }}
+                          disabled={!actions.includes("delete") || isTransient}
+                          title="Delete graph"
+                          onClick={(e) => { e.stopPropagation(); performGraphAction(s.graph_id!, "delete", s.graph_name || s.graph_id!); }}
                         >
                           <Trash2 className="h-4 w-4" />
                         </button>
@@ -307,7 +295,7 @@ export function Sessions() {
                 serviceType: "neptune-graph",
                 name: selected.graph_name || selected.graph_id || "",
               } as Record<string, string>);
-              const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "https://localhost/explorer";
+              const geBase = (import.meta as any).env?.VITE_GRAPH_EXPLORER_URL || "http://localhost/explorer";
               window.open(`${geBase}/#/connect?${params}`, "_blank");
             }}>
               <ExternalLink className="h-3 w-3" /> Open in Graph Explorer
@@ -334,7 +322,8 @@ export function Sessions() {
               <Button
                 variant="ghost"
                 className="flex-1 text-red-600 hover:text-red-700"
-                onClick={() => deleteSession(selected.id, selected.graph_name || selected.id.slice(0, 8))}
+                disabled={!actionStates[selected.graph_id]?.actions.includes("delete")}
+                onClick={() => performGraphAction(selected.graph_id!, "delete", selected.graph_name || selected.graph_id!)}
               >
                 <Trash2 className="h-3 w-3" /> Delete
               </Button>


### PR DESCRIPTION
## Summary

When a user deletes a graph from a session, the session record is now preserved as "archived" instead of being purged. This allows users to revisit the config (queries, catalog, graph name, memory) and re-execute from it later.

## Changes

### Backend (`projection.py`)

- **`POST /projection/{id}/delete-graph`** (new) — Deletes the Neptune graph in background, then sets session status to `"archived"` and clears `graph_id`/`graph_endpoint`. Config is preserved.
- **`DELETE /projection/{id}`** (simplified) — Now always hard-deletes the record from DB. No longer handles graph deletion.

### Frontend

**Sessions page — active/archived split:**
- Active sessions (top table): all sessions except `status === "archived"`
- Archived sessions (collapsible section, always visible): shows "▶ Archived (N)" header, expands to show archived sessions
- Empty states for both tables

**Delete semantics:**
- Trash icon on active session → calls `POST /delete-graph` → archives the session (graph destroyed, config preserved)
- "Delete projection job" button on archived session → calls `DELETE /projection/{id}` → permanently removes the record

**API (`index.ts`):**
- Added `projection.deleteGraph(id)` method

## Files changed

| File | Change |
|------|--------|
| `proxy/src/nx_neptune_proxy/routers/projection.py` | New `delete-graph` endpoint, simplified `DELETE` to hard-delete only |
| `proxy/ui-src/src/api/index.ts` | Added `deleteGraph` API method |
| `proxy/ui-src/src/pages/Sessions.tsx` | Active/archived split, collapsible section, proper delete semantics |

## Testing

- 53 backend tests pass
- `npm run build` passes
- Manual verification against running proxy

<img width="1461" height="421" alt="Screenshot 2026-07-06 at 4 11 14 PM" src="https://github.com/user-attachments/assets/7e7625f5-1adf-4b29-bdff-521f9871ac8e" />
<img width="1466" height="429" alt="Screenshot 2026-07-06 at 4 11 43 PM" src="https://github.com/user-attachments/assets/66242ad6-a8e9-422c-bab5-75f008de37be" />
<img width="1481" height="399" alt="image" src="https://github.com/user-attachments/assets/6b992119-f5cf-440a-9a7f-5b9344ca8ba3" />

