### PR TITLE
Fix: Scope "Copy config from" dropdown to current project

### DIFF
--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -253,7 +253,7 @@ export function Import() {
                 }}
               >
                 <option value="">Select a projection...</option>
-                {projectionsList.map((s) => (
+                {(projectId ? projectionsList.filter(s => s.project_id === projectId) : projectionsList).map((s) => (
                   <option key={s.id} value={s.id}>{s.graph_name || s.id.slice(0, 8)}</option>
                 ))}
               </Select>


### PR DESCRIPTION
**Description:**

The "Copy config from" dropdown on the import page now only shows projections belonging to the current project. If no project is selected, all projections are shown.

Client-side filter on the existing `projectionsList` state — no backend changes needed.