### PR TITLE
Misc: Parallelize graph deletion on project delete

### DIFF
--- a/proxy/src/nx_neptune_proxy/services/project_deletion.py
+++ b/proxy/src/nx_neptune_proxy/services/project_deletion.py
@@ -23,16 +23,27 @@ async def delete_project(project_id: str) -> None:
     projections = [p for p in projection_store.list() if p.project_id == project_id]
 
     # Delete all graphs in parallel
+    graphs_to_delete = [p for p in projections if p.graph_id]
     results = await asyncio.gather(
-        *[_delete_graph(p.graph_id) for p in projections if p.graph_id],
+        *[_delete_graph(p.graph_id) for p in graphs_to_delete],
         return_exceptions=True,
     )
-    for r in results:
-        if isinstance(r, Exception):
-            logger.warning(f"Failed to delete graph: {r}")
+
+    # Only delete projection records where graph deletion succeeded
+    failed_ids = set()
+    for p, result in zip(graphs_to_delete, results):
+        if isinstance(result, Exception):
+            logger.warning(f"Failed to delete graph {p.graph_id} for projection {p.id}: {result}")
+            failed_ids.add(p.id)
 
     for p in projections:
-        projection_store.delete(p.id)
+        if p.id not in failed_ids:
+            projection_store.delete(p.id)
+
+    # Only delete the project if all graphs were cleaned up
+    if failed_ids:
+        logger.warning(f"Project {project_id} has {len(failed_ids)} projection(s) with failed graph deletion, keeping project in deleting state")
+        return
 
     project_store.delete(project_id)
     logger.info(f"Project {project_id} fully deleted")

--- a/proxy/src/nx_neptune_proxy/services/project_deletion.py
+++ b/proxy/src/nx_neptune_proxy/services/project_deletion.py
@@ -22,12 +22,16 @@ async def delete_project(project_id: str) -> None:
     """Delete all graphs for a project's projections, then remove records."""
     projections = [p for p in projection_store.list() if p.project_id == project_id]
 
+    # Delete all graphs in parallel
+    results = await asyncio.gather(
+        *[_delete_graph(p.graph_id) for p in projections if p.graph_id],
+        return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            logger.warning(f"Failed to delete graph: {r}")
+
     for p in projections:
-        if p.graph_id:
-            try:
-                await _delete_graph(p.graph_id)
-            except Exception as e:
-                logger.warning(f"Failed to delete graph {p.graph_id} for projection {p.id}: {e}")
         projection_store.delete(p.id)
 
     project_store.delete(project_id)


### PR DESCRIPTION
**Description:**

Graph deletions during project delete now run in parallel via `asyncio.gather` instead of sequentially.
Each deletion polls until the graph is gone (~10s intervals), so parallelizing avoids waiting N × timeout for N graphs.
Failures are logged without blocking other deletions.