### PR TITLE
[FEATURE] Display 'running times' in the UI during graph execution

### DIFF
--- a/nx_neptune/session_manager.py
+++ b/nx_neptune/session_manager.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import logging
+import time
 from enum import Enum
 from typing import Callable, Optional, Union
 
@@ -351,6 +352,7 @@ class SessionManager:
         catalog=None,
         database=None,
         remove_buckets=True,
+        on_phase_complete: Optional[Callable[[str, float], None]] = None,
     ) -> str:
         """Import data from Athena table query results into a Neptune Analytics graph.
 
@@ -362,6 +364,10 @@ class SessionManager:
             catalog (str, optional): Athena catalog name. Defaults to None.
             database (str, optional): Athena database name. Defaults to None.
             remove_buckets (bool): After a successful import, delete the S3 bucket contents if True.
+            on_phase_complete (Callable[[str, float], None], optional): Invoked after each
+                internal phase with the phase name ("athena_export", "graph_import") and its
+                elapsed wall-clock time in seconds. Exceptions raised by the callback are
+                suppressed so timing never breaks the import.
 
         Returns:
             str: Graph ID of the target graph.
@@ -374,7 +380,16 @@ class SessionManager:
         if sql_parameters is None:
             sql_parameters = []
 
+        def _report(phase: str, elapsed: float) -> None:
+            if on_phase_complete is None:
+                return
+            try:
+                on_phase_complete(phase, elapsed)
+            except Exception:  # never let timing break the import
+                logger.warning(f"on_phase_complete callback failed for phase {phase}", exc_info=True)
+
         # export the datalake table to S3 as CSV projection data
+        _athena_start = time.monotonic()
         query_execution_ids = await instance_management.export_athena_table_to_s3(
             sql_queries,
             sql_parameters,
@@ -386,12 +401,14 @@ class SessionManager:
             iam_client=self._iam_client,
             sts_client=self._sts_client,
         )
+        _report("athena_export", time.monotonic() - _athena_start)
         if not query_execution_ids:
             raise Exception("Projections not created.")
 
         logger.info(f"Created projection data in {s3_location}")
 
         # import the S3 CSV files to Neptune
+        _import_start = time.monotonic()
         task_id = await instance_management.import_csv_from_s3(
             NeptuneGraph(
                 graph,
@@ -402,6 +419,7 @@ class SessionManager:
             reset_graph_ahead,
             skip_snapshot,
         )
+        _report("graph_import", time.monotonic() - _import_start)
 
         if remove_buckets:
             for query_execution_id in query_execution_ids:

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -163,11 +163,14 @@ def run_post_import_query(projection_id: str):
         raise HTTPException(status_code=409, detail="No graph associated with this projection")
     if not p.post_import_query:
         raise HTTPException(status_code=400, detail="No post-import query configured")
+    _t = time.monotonic()
     try:
         results = execute_opencypher_query(p.graph_id, p.post_import_query)
+        store.append_timing(projection_id, "post_import_query", time.monotonic() - _t)
         store.update(projection_id, post_import_error=None)
         return {"success": True, "row_count": len(results), "results": results}
     except Exception as e:
+        store.append_timing(projection_id, "post_import_query", time.monotonic() - _t)
         error_msg = str(e)
         store.update(projection_id, post_import_error=error_msg)
         return {"success": False, "error": error_msg}

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -129,6 +129,7 @@ class ProjectionResponse(BaseModel):
     error: Optional[str] = None
     post_import_query: Optional[str] = None
     post_import_error: Optional[str] = None
+    timings: list[dict] = []
     created_at: datetime
 
 

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -47,14 +47,15 @@ def init_db() -> None:
             error TEXT,
             post_import_query TEXT,
             post_import_error TEXT,
+            timings TEXT,
             created_at TEXT NOT NULL,
             FOREIGN KEY (project_id) REFERENCES projects(id)
         );
     """)
-    # Migration: add post_import columns if missing (for existing databases)
+    # Migration: add columns if missing (for existing databases)
     cursor = conn.execute("PRAGMA table_info(projections)")
     existing_columns = {row[1] for row in cursor.fetchall()}
-    for col in ["post_import_query", "post_import_error"]:
+    for col in ["post_import_query", "post_import_error", "timings"]:
         if col not in existing_columns:
             conn.execute(f"ALTER TABLE projections ADD COLUMN {col} TEXT")
     conn.commit()

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import time
 
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune_proxy.services.projection_store import GRAPH_PREFIX, Projection, store
@@ -22,19 +23,23 @@ async def run_pipeline(projection: Projection) -> None:
         # Step 1: Create graph
         _update(projection.id, step="graph_creation", label="Creating Neptune Analytics graph", progress=5)
         sm = SessionManager(session_name=graph_name)
+        _t = time.monotonic()
         graph = await sm.get_or_create_graph(
             config={"provisionedMemory": projection.graph_memory_gb}
         )
+        store.append_timing(projection.id, "graph_creation", time.monotonic() - _t)
         store.update(projection.id, graph_id=graph.graph_id,
                      graph_endpoint=f"https://{graph.graph_id}.neptune-graph.amazonaws.com")
         _update(projection.id, step="graph_creation", label="Graph available", progress=20)
 
         # Step 1b: Reset graph to ensure it's empty
         _update(projection.id, step="graph_reset", label="Resetting graph data", progress=25)
+        _t = time.monotonic()
         await sm.reset_graph(graph.name)
+        store.append_timing(projection.id, "graph_reset", time.monotonic() - _t)
         _update(projection.id, step="graph_reset", label="Graph ready for import", progress=40)
 
-        # Step 2: Athena query + CSV import
+        # Step 2: Athena query + CSV import (timed as two separate phases)
         _update(projection.id, step="athena_import", label="Running Athena query and importing data", progress=45)
         sql_queries = [q for q in [projection.node_query, projection.edge_query] if q]
         await sm.import_from_table(
@@ -44,17 +49,21 @@ async def run_pipeline(projection: Projection) -> None:
             catalog=projection.catalog,
             database=projection.database,
             remove_buckets=True,
+            on_phase_complete=lambda phase, seconds: store.append_timing(projection.id, phase, seconds),
         )
         _update(projection.id, step="athena_import", label="Import complete", progress=90)
 
         # Step 3: Run post-import query (optional)
         if projection.post_import_query:
             _update(projection.id, step="post_import_query", label="Running post-import query", progress=92)
+            _t = time.monotonic()
             try:
                 result = execute_opencypher_query(graph.graph_id, projection.post_import_query)
+                store.append_timing(projection.id, "post_import_query", time.monotonic() - _t)
                 store.update(projection.id, post_import_error=None)
                 logger.info(f"Post-import query returned {len(result)} results")
             except Exception as e:
+                store.append_timing(projection.id, "post_import_query", time.monotonic() - _t)
                 error_msg = str(e)
                 logger.warning(f"Post-import query failed (non-fatal): {error_msg}")
                 store.update(projection.id, post_import_error=error_msg)

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -14,7 +15,7 @@ _FIELDS = [
     "id", "status", "catalog", "database", "sql_query", "node_query", "edge_query",
     "graph_name", "graph_memory_gb", "s3_staging_bucket", "graph_id", "graph_endpoint",
     "project_id", "step", "step_label", "progress", "error",
-    "post_import_query", "post_import_error", "created_at",
+    "post_import_query", "post_import_error", "timings", "created_at",
 ]
 
 
@@ -41,6 +42,7 @@ class Projection:
     error: Optional[str] = None
     post_import_query: Optional[str] = None
     post_import_error: Optional[str] = None
+    timings: list = field(default_factory=list)
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
@@ -67,11 +69,19 @@ class ProjectionStore:
         conn = get_connection()
         conn.execute(
             f"INSERT INTO projections ({', '.join(_FIELDS)}) VALUES ({', '.join('?' for _ in _FIELDS)})",
-            [getattr(p, f) if f != "created_at" else p.created_at.isoformat() for f in _FIELDS],
+            [self._serialize_field(f, getattr(p, f)) for f in _FIELDS],
         )
         conn.commit()
         conn.close()
         return p
+
+    @staticmethod
+    def _serialize_field(field_name: str, value):
+        if field_name == "created_at":
+            return value.isoformat()
+        if field_name == "timings":
+            return json.dumps(value or [])
+        return value
 
     def get(self, projection_id: str) -> Optional[Projection]:
         conn = get_connection()
@@ -97,6 +107,8 @@ class ProjectionStore:
         invalid = set(kwargs.keys()) - self._ALLOWED_UPDATE_COLUMNS
         if invalid:
             raise ValueError(f"Invalid column(s): {invalid}")
+        if "timings" in kwargs:
+            kwargs["timings"] = json.dumps(kwargs["timings"] or [])
         sets = ", ".join(f"{k} = ?" for k in kwargs)
         vals = list(kwargs.values()) + [projection_id]
         conn = get_connection()
@@ -104,6 +116,19 @@ class ProjectionStore:
         conn.commit()
         conn.close()
         return self.get(projection_id)
+
+    def append_timing(self, projection_id: str, phase: str, seconds: float) -> Optional[Projection]:
+        """Append a single phase-timing record, preserving prior records (sequential log)."""
+        p = self.get(projection_id)
+        if not p:
+            return None
+        timings = list(p.timings)
+        timings.append({
+            "phase": phase,
+            "seconds": round(seconds, 3),
+            "at": datetime.now(timezone.utc).isoformat(),
+        })
+        return self.update(projection_id, timings=timings)
 
     def delete(self, projection_id: str) -> bool:
         conn = get_connection()
@@ -134,6 +159,7 @@ class ProjectionStore:
             error=row["error"],
             post_import_query=row["post_import_query"],
             post_import_error=row["post_import_error"],
+            timings=json.loads(row["timings"]) if row["timings"] else [],
             created_at=datetime.fromisoformat(row["created_at"]),
         )
 

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -335,3 +335,55 @@ async def test_run_query_failure(client):
     # Verify post_import_error was stored
     proj = store.get(pid)
     assert "Syntax error" in proj.post_import_error
+
+
+# --- Timings ---
+
+
+@pytest.mark.asyncio
+async def test_append_timing_accumulates_sequentially(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+
+    # Fresh projection starts with no timings
+    assert store.get(pid).timings == []
+
+    store.append_timing(pid, "graph_creation", 1.234)
+    store.append_timing(pid, "athena_export", 5.5)
+    store.append_timing(pid, "graph_import", 10.0)
+
+    proj = store.get(pid)
+    assert [t["phase"] for t in proj.timings] == ["graph_creation", "athena_export", "graph_import"]
+    assert proj.timings[0]["seconds"] == 1.234
+    assert all("at" in t for t in proj.timings)
+
+
+@pytest.mark.asyncio
+async def test_run_query_records_timing(client):
+    body = {**SAMPLE_BODY, "post_import_query": "MATCH (n) RETURN count(n)"}
+    create_resp = await client.post("/api/v0/projection", json=body)
+    pid = create_resp.json()["id"]
+    store.update(pid, graph_id="g-123")
+
+    with patch("nx_neptune_proxy.routers.projection.execute_opencypher_query", return_value=[{"count(n)": 1}]):
+        await client.post(f"/api/v0/projection/{pid}/run-query")
+        await client.post(f"/api/v0/projection/{pid}/run-query")
+
+    # Each re-run appends a new sequential post_import_query record
+    proj = store.get(pid)
+    phases = [t["phase"] for t in proj.timings]
+    assert phases == ["post_import_query", "post_import_query"]
+
+
+@pytest.mark.asyncio
+async def test_timings_exposed_in_response(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    pid = create_resp.json()["id"]
+    store.append_timing(pid, "graph_creation", 2.0)
+
+    resp = await client.get(f"/api/v0/projection/{pid}")
+    assert resp.status_code == 200
+    timings = resp.json()["timings"]
+    assert len(timings) == 1
+    assert timings[0]["phase"] == "graph_creation"
+    assert timings[0]["seconds"] == 2.0

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -60,7 +60,14 @@ export interface Projection {
   error?: string;
   post_import_query?: string;
   post_import_error?: string;
+  timings?: TimingRecord[];
   created_at: string;
+}
+
+export interface TimingRecord {
+  phase: string;
+  seconds: number;
+  at: string;
 }
 
 export interface QueryResult {

--- a/proxy/ui-src/src/pages/Sessions.tsx
+++ b/proxy/ui-src/src/pages/Sessions.tsx
@@ -1,9 +1,63 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, NavLink } from "react-router";
-import { projection, metadata, projectApi, graphActions, type Projection, type Project, type Inflight } from "../api";
+import { projection, metadata, projectApi, graphActions, type Projection, type Project, type Inflight, type TimingRecord } from "../api";
 import { Card, Button, RefreshButton } from "../components/ui";
-import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown } from "lucide-react";
+import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Clock } from "lucide-react";
 import { useNavigate } from "react-router";
+
+const PHASE_LABELS: Record<string, string> = {
+  graph_creation: "Create graph",
+  graph_reset: "Reset graph",
+  athena_export: "Execute Athena statements",
+  graph_import: "Import graph data",
+  post_import_query: "Post-import query",
+};
+
+function formatDuration(seconds: number): string {
+  if (seconds < 1) return `${Math.round(seconds * 1000)} ms`;
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 2 : 1)} s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return `${m}m ${s}s`;
+}
+
+function TimingsList({ timings }: { timings: TimingRecord[] }) {
+  const total = timings.reduce((sum, t) => sum + t.seconds, 0);
+  return (
+    <>
+      <ul className="space-y-1">
+        {timings.map((t, i) => (
+          <li key={i} className="flex items-baseline justify-between gap-3 text-xs">
+            <span className="text-gray-600">
+              {i + 1}. {PHASE_LABELS[t.phase] || t.phase}
+            </span>
+            <span className="whitespace-nowrap font-mono text-gray-800">{formatDuration(t.seconds)}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 flex items-baseline justify-between gap-3 border-t border-gray-100 pt-1 text-xs font-medium">
+        <span className="text-gray-700">Total</span>
+        <span className="whitespace-nowrap font-mono text-gray-900">{formatDuration(total)}</span>
+      </div>
+    </>
+  );
+}
+
+function TimingsPopover({ timings, anchor }: { timings: TimingRecord[]; anchor: DOMRect }) {
+  // Rendered with position: fixed so an ancestor's overflow-hidden (the table
+  // Card) can't clip it. Anchored just below the status badge.
+  return (
+    <div
+      className="pointer-events-none fixed z-50 w-72 rounded-md border border-gray-200 bg-white p-3 text-left shadow-lg"
+      style={{ top: anchor.bottom + 4, left: anchor.left }}
+    >
+      <p className="mb-2 flex items-center gap-1 text-xs font-semibold text-gray-700">
+        <Clock className="h-3 w-3" /> Timing breakdown
+      </p>
+      <TimingsList timings={timings} />
+    </div>
+  );
+}
 
 export function Sessions() {
   const [searchParams] = useSearchParams();
@@ -16,6 +70,7 @@ export function Sessions() {
   const [actionStates, setActionStates] = useState<Record<string, { actions: string[]; inflight: Inflight | null }>>({});
   const [alerts, setAlerts] = useState<{ graphId: string; graphName: string; message: string }[]>([]);
   const [archivedOpen, setArchivedOpen] = useState(false);
+  const [timingHover, setTimingHover] = useState<{ id: string; anchor: DOMRect } | null>(null);
   const navigate = useNavigate();
   const filterProjectId = searchParams.get("project");
 
@@ -210,9 +265,21 @@ export function Sessions() {
                   <td className="px-4 py-3">{Math.round(s.progress)}%</td>
                   <td className="px-4 py-3 text-gray-500">{new Date(s.created_at).toLocaleString()}</td>
                   <td className="px-4 py-3">
-                    {graphStatus ? (
-                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${graphStatusStyle(graphStatus)}`}>{graphStatus}</span>
-                    ) : <span className="text-gray-400">—</span>}
+                    <div className="inline-block">
+                      {graphStatus ? (
+                        <span
+                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${graphStatusStyle(graphStatus)}`}
+                          onMouseEnter={(e) => {
+                            if (s.timings && s.timings.length > 0)
+                              setTimingHover({ id: s.id, anchor: e.currentTarget.getBoundingClientRect() });
+                          }}
+                          onMouseLeave={() => setTimingHover((h) => (h?.id === s.id ? null : h))}
+                        >
+                          {graphStatus}
+                          {s.timings && s.timings.length > 0 && <Clock className="h-3 w-3 opacity-60" />}
+                        </span>
+                      ) : <span className="text-gray-400">—</span>}
+                    </div>
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex gap-1">
@@ -369,6 +436,14 @@ export function Sessions() {
                 <div><span className="text-gray-500">Edges:</span> {summaries.get(selected.id)!.numEdges.toLocaleString()}</div>
               </>
             )}
+            {selected.timings && selected.timings.length > 0 && (
+              <div>
+                <span className="flex items-center gap-1 text-gray-500"><Clock className="h-3 w-3" /> Timing breakdown</span>
+                <div className="mt-1 rounded bg-gray-50 p-2">
+                  <TimingsList timings={selected.timings} />
+                </div>
+              </div>
+            )}
             {selected.error && (
               <div>
                 <span className="text-gray-500">Error:</span>
@@ -439,6 +514,14 @@ export function Sessions() {
           )}
         </Card>
       )}
+
+      {/* Hover popover for timing breakdown, rendered at root so the table's
+          overflow-hidden cannot clip it. */}
+      {timingHover && (() => {
+        const s = sessions.find((x) => x.id === timingHover.id);
+        if (!s?.timings || s.timings.length === 0) return null;
+        return <TimingsPopover timings={s.timings} anchor={timingHover.anchor} />;
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
### Summary :memo:

Related PR: #333 

  This adds step-by-step timings to the graph import process, so users can see how long each phase of an import took. Every status change is timed and surfaced in the Sessions UI.

  Timed phases
  - Create graph — provisioning the Neptune Analytics graph
  - Reset graph — clearing existing data
  - Execute Athena statements — running the node/edge SQL and exporting CSV to S3
  - Import graph data — loading the CSV into Neptune
  - Post-import query — running the optional OpenCypher query

  Backend
  - nx_neptune/session_manager.py: import_from_table gains an optional on_phase_complete(phase, seconds) callback that times the Athena export and the Neptune CSV import as two separate phases. Backward-compatible (callback is optional)
  and callback errors are swallowed so timing can never break an import.
  - services/pipeline.py: times each pipeline phase (graph_creation, graph_reset, athena_export, graph_import, post_import_query) and records them.
  - services/projection_store.py + db.py: new timings JSON column (with migration for existing DBs) and an append_timing(id, phase, seconds) helper that appends records sequentially — so repeated runs (e.g. re-running the post-import
  query) accumulate rather than overwrite.
  - routers/projection.py: the run-query endpoint records a post_import_query timing on each invocation.
  - routers/schemas.py: timings exposed on the projection response.

  Frontend (ui-src/)
  - Sessions page: hovering the Graph Status badge shows a "Timing breakdown" popover listing each phase in order with durations and a total; the same breakdown appears in the session detail panel. A clock icon marks rows that have
  timings.
  - The popover uses fixed positioning so it isn't clipped by the table container's overflow-hidden.
  - Durations format adaptively (ms / seconds / m s). API client adds the TimingRecord type and timings on Projection.


### Test plan:

  Automated
  - cd proxy && pytest tests/test_projection.py — new tests: test_append_timing_accumulates_sequentially (records append in order across calls), test_run_query_records_timing (each re-run appends a post_import_query entry),
  test_timings_exposed_in_response (timings surfaced via the API).
  - pytest tests/ (repo root) — confirms the session_manager timing callback doesn't regress existing import tests.
  - cd proxy/ui-src && npx tsc --noEmit && npm run build — frontend typecheck + build.

  Manual (against a real Neptune Analytics + Athena environment)
  1. Run a full import; open the Sessions page and hover the Graph Status badge — confirm all five phases appear in order with plausible durations and a correct total.
  2. Open the session detail panel and confirm the same breakdown renders there.
  3. Re-run the post-import query from the Import page; confirm a new post_import_query timing is appended (existing entries preserved), not overwritten.
  4. Confirm the popover renders fully and isn't clipped by the table edge.


### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
