### PR TITLE
Feat: Allow deleting draft projections from the projections list

### DIFF
--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -270,7 +270,7 @@ export function Projections() {
                       ) : (
                         <button
                           className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={!s.graph_id || isTransient}
+                          disabled={!s.graph_id || isTransient || s.status === "importing" || s.status === "executing"}
                           title="Delete graph (archive projection)"
                           onClick={(e) => { e.stopPropagation(); archiveProjection(s.id, s.graph_name || s.id.slice(0, 8)); }}
                         >

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -259,22 +259,22 @@ export function Projections() {
                       </button>
 
                       {/* Delete: X to discard draft, Trash2 to delete graph */}
-                      {s.graph_id ? (
-                        <button
-                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                          disabled={isTransient}
-                          title="Delete graph (archive projection)"
-                          onClick={(e) => { e.stopPropagation(); archiveProjection(s.id, s.graph_name || s.id.slice(0, 8)); }}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      ) : (
+                      {s.status === "draft" ? (
                         <button
                           className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600"
                           title="Discard draft"
                           onClick={(e) => { e.stopPropagation(); purgeProjection(s.id, s.graph_name || s.id.slice(0, 8)); }}
                         >
                           <X className="h-4 w-4" />
+                        </button>
+                      ) : (
+                        <button
+                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                          disabled={!s.graph_id || isTransient}
+                          title="Delete graph (archive projection)"
+                          onClick={(e) => { e.stopPropagation(); archiveProjection(s.id, s.graph_name || s.id.slice(0, 8)); }}
+                        >
+                          <Trash2 className="h-4 w-4" />
                         </button>
                       )}
                     </div>

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -97,7 +97,7 @@ export function Projections() {
   }
 
   async function purgeProjection(sessionId: string, name: string) {
-    if (!confirm(`Permanently delete projection job "${name}"? This cannot be undone.`)) return;
+    if (!confirm(`Delete projection "${name}"? This cannot be undone.`)) return;
     try {
       await projection.delete(sessionId);
       if (selected?.id === sessionId) setSelected(null);
@@ -258,15 +258,25 @@ export function Projections() {
                         <Play className="h-4 w-4" />
                       </button>
 
-                      {/* Archive (delete graph, keep projection) */}
-                      <button
-                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
-                        disabled={!s.graph_id || isTransient}
-                        title="Delete graph (archive projection)"
-                        onClick={(e) => { e.stopPropagation(); archiveProjection(s.id, s.graph_name || s.id.slice(0, 8)); }}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
+                      {/* Delete: X to discard draft, Trash2 to delete graph */}
+                      {s.graph_id ? (
+                        <button
+                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                          disabled={isTransient}
+                          title="Delete graph (archive projection)"
+                          onClick={(e) => { e.stopPropagation(); archiveProjection(s.id, s.graph_name || s.id.slice(0, 8)); }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      ) : (
+                        <button
+                          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-red-600"
+                          title="Discard draft"
+                          onClick={(e) => { e.stopPropagation(); purgeProjection(s.id, s.graph_name || s.id.slice(0, 8)); }}
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      )}
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary


Adds the ability to discard draft projections from the Projections page and prevents accidental graph deletion during active imports.

<img width="803" height="339" alt="image" src="https://github.com/user-attachments/assets/ea708d70-0a95-444d-aabf-a583646a0335" />


## Changes

- Updated the confirmation message for purging to be more concise
- Conditional delete icon in the Actions column based on projection status:

| Projection Status | Icon | Enabled | Action |
|---|---|---|---|
| `draft` | ✕ (X) | ✔ | Permanently delete the projection record |
| `importing` / `executing` | 🗑 (Trash2) | ✗ (greyed out) | — |
| `complete` (with graph) | 🗑 (Trash2) | ✔ | Delete Neptune graph, archive projection |
| `failed` (with graph) | 🗑 (Trash2) | ✔ | Delete Neptune graph, archive projection |
| No `graph_id` + non-draft | 🗑 (Trash2) | ✗ (greyed out) | — |


## What was tested

- `npm run build` passes (TypeScript type-check + Vite production build)
- No new dependencies or backend changes required — reuses the existing `DELETE /api/v0/projection/{id}` endpoint



