### PR TITLE
Misc: Make graph name prefix configurable via env var

### DIFF
--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -13,6 +13,7 @@ class Settings:
     allowed_origins: list[str] = None  # type: ignore[assignment]
     port: int = 8080
     region: str = ""
+    graph_prefix: str = "nxp-"
 
     def __post_init__(self) -> None:
         if self.allowed_origins is None:
@@ -27,4 +28,5 @@ class Settings:
             allowed_origins=origins,
             port=int(os.environ.get("PORT", "8080")),
             region=os.environ.get("AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")),
+            graph_prefix=os.environ.get("GRAPH_PREFIX", "nxp-"),
         )

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -21,7 +21,8 @@ router = APIRouter(prefix="/api/v0/metadata", tags=["metadata"])
 @router.get("/config", summary="Get server configuration")
 def get_config():
     """Get server-side configuration"""
-    return {"region": Settings.from_env().region or ""}
+    settings = Settings.from_env()
+    return {"region": settings.region or "", "graph_prefix": settings.graph_prefix}
 
 
 @router.get("/athena/catalogs", summary="List Athena data catalogs", response_model=CatalogsResponse)
@@ -75,15 +76,13 @@ def list_s3_buckets():
     return {"buckets": buckets}
 
 
-GRAPH_PREFIX = "nxp-"
-
-
 @router.get("/neptune/graph-analytics", summary="List Neptune Analytics graphs", response_model=NeptuneAnalyticsGraphsResponse)
 def list_neptune_graphs():
     """List Neptune Analytics graphs managed by nx-neptune"""
     client = ClientFactory().neptune()
     items = paginate_aws(client.list_graphs, "graphs")
-    filtered = [g for g in items if g.get("name", "").startswith(GRAPH_PREFIX)]
+    prefix = Settings.from_env().graph_prefix
+    filtered = [g for g in items if g.get("name", "").startswith(prefix)]
     return {"graphs": [{"id": g["id"], "name": g["name"], "status": g["status"]} for g in filtered]}
 
 

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -3,7 +3,8 @@
 
 import logging
 
-from nx_neptune_proxy.services.projection_store import GRAPH_PREFIX, Projection, store
+from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.services.projection_store import Projection, store
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ async def run_pipeline(projection: Projection) -> None:
     """Execute the full pipeline: create graph → Athena → import."""
     from nx_neptune.session_manager import SessionManager
 
-    graph_name = f"{GRAPH_PREFIX}{projection.graph_name}"
+    graph_name = f"{Settings.from_env().graph_prefix}{projection.graph_name}"
     s3_location = projection.s3_staging_bucket.rstrip("/") + f"/{projection.id}/"
 
     try:

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -8,8 +8,6 @@ from typing import Optional
 
 from .db import get_connection
 
-GRAPH_PREFIX = "nxp-"
-
 _FIELDS = [
     "id", "status", "catalog", "database", "sql_query", "node_query", "edge_query",
     "graph_name", "graph_memory_gb", "s3_staging_bucket", "graph_id", "graph_endpoint",

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -13,7 +13,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 // --- Metadata ---
 
 export const metadata = {
-  config: () => request<{ region: string }>("/metadata/config"),
+  config: () => request<{ region: string; graph_prefix: string }>("/metadata/config"),
   catalogs: () => request<{ catalogs: { name: string; status: string }[] }>("/metadata/athena/catalogs"),
   databases: (catalog: string) => request<{ databases: string[] }>(`/metadata/athena/databases?catalog=${encodeURIComponent(catalog)}`),
   tables: (database: string, catalog: string) => request<{ tables: string[] }>(`/metadata/athena/tables?database=${encodeURIComponent(database)}&catalog=${encodeURIComponent(catalog)}`),

--- a/proxy/ui-src/src/pages/Graphs.tsx
+++ b/proxy/ui-src/src/pages/Graphs.tsx
@@ -26,6 +26,7 @@ export function Graphs() {
   const [loading, setLoading] = useState(true);
   const [summaries, setSummaries] = useState<Record<string, Summary>>({});
   const [region, setRegion] = useState("");
+  const [graphPrefix, setGraphPrefix] = useState("nxp-");
   const [actionStates, setActionStates] = useState<Record<string, GraphActionState>>({});
   const [alerts, setAlerts] = useState<{ graphId: string; graphName: string; message: string }[]>([]);
 
@@ -64,7 +65,7 @@ export function Graphs() {
   }, [loadActions]);
 
   useEffect(() => {
-    metadata.config().then(c => setRegion(c.region));
+    metadata.config().then(c => { setRegion(c.region); setGraphPrefix(c.graph_prefix); });
     load({ withActions: true, withSummaries: true });
   }, [load]);
 
@@ -113,7 +114,7 @@ export function Graphs() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-lg font-semibold">Neptune Analytics Graphs</h1>
-          <p className="text-sm text-gray-500">Showing graphs with <code className="rounded bg-gray-100 px-1">nxp-</code> prefix</p>
+          <p className="text-sm text-gray-500">Showing graphs with <code className="rounded bg-gray-100 px-1">{graphPrefix}</code> prefix</p>
         </div>
         <RefreshButton onClick={() => load({ withActions: true, withSummaries: true })} />
       </div>


### PR DESCRIPTION
## Summary

The `nxp-` prefix used for Neptune graph names is now configurable via the `GRAPH_PREFIX` environment variable, defaulting to `"nxp-"`.

## Changes

- Added `graph_prefix` to server settings, loaded from `GRAPH_PREFIX` env var
- Removed all hardcoded `"nxp-"` references — pipeline, graph filtering, and UI now read from config
- Exposed `graph_prefix` in the `/api/v0/metadata/config` endpoint so the UI can display it dynamically

## Usage

```bash
export GRAPH_PREFIX="myteam-"
```

Defaults to `"nxp-"` if not set.

## What was tested

- All 53 backend tests pass
- UI TypeScript type-check + Vite production build passes