### PR TITLE
Feat: Add Jaccard Coefficient Algorithm

### DIFF
--- a/algorithms.md
+++ b/algorithms.md
@@ -100,6 +100,40 @@ Parameters:
 Yields:
 - List of nodes at the same distance from `sources`.
 
+## Link Prediction Algorithms
+
+### jaccard_coefficient
+
+Compute the Jaccard coefficient of all node pairs in ebunch. The Jaccard coefficient measures the similarity between two sets of neighbors: |Γ(u) ∩ Γ(v)| / |Γ(u) ∪ Γ(v)|.  
+Link: https://docs.aws.amazon.com/neptune-analytics/latest/userguide/jaccard-similarity.html
+
+Source: [nx_neptune/algorithms/link_prediction/jaccard.py](nx_neptune/algorithms/link_prediction/jaccard.py)
+
+```python
+@configure_if_nx_active()
+def jaccard_coefficient(
+    neptune_graph: NeptuneGraph,
+    ebunch=None,
+    edge_labels: Optional[List] = None,
+    vertex_label: Optional[str] = None,
+    traversal_direction: Optional[str] = None,
+):
+```
+
+Parameters:
+- `neptune_graph : NeptuneGraph` - A NeptuneGraph instance
+- `ebunch : iterable of node pairs, optional (default = None)` - Jaccard coefficient will be computed for each pair of nodes given in the iterable. The pairs must be given as 2-tuples (u, v) where u and v are nodes in the graph. If ebunch is None then all nonexistent edges in the graph will be used.
+
+Note: When `ebunch=None`, the non-existent edges are computed locally from the NetworkX graph object before being sent to Neptune Analytics. Neptune always receives an explicit list of node pairs — it does not compute non-edges on its own. For large graphs, this can produce a very large number of pairs; prefer passing an explicit `ebunch` in production.
+- `edge_labels : list, optional` - To filter on one or more edge labels, provide a list of the ones to filter on. If no edgeLabels field is provided then all edge labels are processed during traversal.
+- `vertex_label : str, optional` - A vertex label for vertex filtering. If a vertex label is provided, only nodes matching the label are considered neighbors.
+- `traversal_direction : str, optional` - The direction of edge to follow. Must be one of: "inbound", "outbound", or "both". Default: "outbound".
+
+Returns:
+- An iterator of 3-tuples in the form (u, v, p) where (u, v) is a pair of nodes and p is their Jaccard coefficient.
+
+Note: Neptune Analytics does not support a mutate variant for Jaccard similarity.
+
 ## Link Analysis Algorithms
 
 ### pagerank

--- a/docs-site/src/content/docs/networkx-backend/algorithms.mdx
+++ b/docs-site/src/content/docs/networkx-backend/algorithms.mdx
@@ -103,6 +103,47 @@ def bfs_layers(
 
 ---
 
+## Link Prediction Algorithms
+
+---
+
+### jaccard_coefficient
+
+Compute the Jaccard coefficient of all node pairs in ebunch, measuring the similarity between two sets of neighbors.
+
+- **Neptune Analytics docs:** [Jaccard Similarity](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/jaccard-similarity.html)
+- **Source:** [`nx_neptune/algorithms/link_prediction/jaccard.py`](https://github.com/awslabs/nx-neptune/blob/main/nx_neptune/algorithms/link_prediction/jaccard.py)
+
+```python
+@configure_if_nx_active()
+def jaccard_coefficient(
+    neptune_graph: NeptuneGraph,
+    ebunch=None,
+    edge_labels: Optional[List] = None,
+    vertex_label: Optional[str] = None,
+    traversal_direction: Optional[str] = None,
+):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ebunch` | iterable of node pairs | Node pairs to compute Jaccard coefficient for. If None, all non-edges are used. |
+| `edge_labels` | list | Edge label filter |
+| `vertex_label` | str | Vertex label filter (only matching nodes are considered neighbors) |
+| `traversal_direction` | str | `"inbound"`, `"outbound"`, or `"both"` |
+
+**Returns:** An iterator of 3-tuples `(u, v, p)` where `(u, v)` is a pair of nodes and `p` is their Jaccard coefficient.
+
+<Aside type="caution">
+  When `ebunch=None`, the non-existent edges are computed **locally** from the NetworkX graph object before being sent to Neptune Analytics. Neptune always receives an explicit list of node pairs — it does not compute non-edges on its own. For large graphs this can produce a very large number of pairs; prefer passing an explicit `ebunch` in production.
+</Aside>
+
+<Aside type="note">
+  Neptune Analytics does not support a mutate variant for Jaccard similarity.
+</Aside>
+
+---
+
 ## Link Analysis Algorithms
 
 ### pagerank

--- a/docs/algorithm-docs-guide.md
+++ b/docs/algorithm-docs-guide.md
@@ -221,6 +221,23 @@ Must be included in the `.ipynb` JSON:
 - Always include: basic execution, one variant (e.g. with filtering), and mutation
 - The notebook filename must match: `{algorithm_name}_demo.ipynb` (e.g., `wcc_demo.ipynb`)
 
+### Important: Edge and node labels in Neptune Analytics
+
+When nx-neptune syncs a plain NetworkX graph to Neptune Analytics:
+- **All edges** get the default label `"RELATES_TO"` (defined as `DEFAULT_EDGE_RELATIONSHIP` in `nx_neptune/clients/na_models.py`)
+- **All nodes** get the default label `"Node"` (defined as `DEFAULT_NODE_LABEL_TYPE`)
+
+This means:
+- The **only valid `edge_labels` value** for the air-routes dataset is `["RELATES_TO"]`
+- The **only valid `vertex_label` value** is `"Node"`
+- Do NOT use domain-specific labels like `["route"]`, `["airport"]`, etc. — they don't exist on the Neptune graph
+
+When writing filtering examples in notebooks or integ tests, always use:
+```python
+edge_labels=["RELATES_TO"]
+vertex_label="Node"
+```
+
 ---
 
 ## Updating the Plugin Info (`nx_plugin/__init__.py`)

--- a/integ_test/graph_operations/test_algo_jaccard.py
+++ b/integ_test/graph_operations/test_algo_jaccard.py
@@ -1,0 +1,107 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+import networkx as nx
+from utils.test_utils import BACKEND, neptune_graph, air_route_graph
+
+
+@pytest.fixture
+def graph():
+    """Create a new undirected graph"""
+    return nx.Graph()
+
+
+class TestJaccardCoefficient:
+
+    def test_jaccard_coefficient_basic(self, air_route_graph):
+        """Test basic jaccard coefficient on airline routes data"""
+        pairs = [("JFK", "LAX"), ("SFO", "ORD")]
+        result = nx.jaccard_coefficient(air_route_graph, ebunch=pairs, backend=BACKEND)
+
+        result_list = list(result)
+        assert len(result_list) == 2
+
+        for u, v, score in result_list:
+            assert isinstance(score, float)
+            assert 0 <= score <= 1
+
+    def test_jaccard_coefficient_with_edge_labels(self, air_route_graph):
+        """Test jaccard coefficient with edge label filtering"""
+        pairs = [("JFK", "LAX")]
+        result = nx.jaccard_coefficient(
+            air_route_graph,
+            ebunch=pairs,
+            backend=BACKEND,
+            edge_labels=["RELATES_TO"],
+        )
+
+        result_list = list(result)
+        assert len(result_list) == 1
+
+        u, v, score = result_list[0]
+        assert u == "JFK"
+        assert v == "LAX"
+        assert isinstance(score, float)
+        assert 0 <= score <= 1
+
+    def test_jaccard_coefficient_with_vertex_label(self, air_route_graph):
+        """Test jaccard coefficient with vertex label filtering"""
+        pairs = [("JFK", "LAX")]
+        result = nx.jaccard_coefficient(
+            air_route_graph,
+            ebunch=pairs,
+            backend=BACKEND,
+            vertex_label="Node",
+        )
+
+        result_list = list(result)
+        assert len(result_list) == 1
+        assert isinstance(result_list[0][2], float)
+
+    def test_jaccard_coefficient_with_traversal_direction(self, air_route_graph):
+        """Test jaccard coefficient with traversal direction"""
+        pairs = [("JFK", "LAX")]
+        result = nx.jaccard_coefficient(
+            air_route_graph,
+            ebunch=pairs,
+            backend=BACKEND,
+            traversal_direction="both",
+        )
+
+        result_list = list(result)
+        assert len(result_list) == 1
+        assert isinstance(result_list[0][2], float)
+        assert 0 <= result_list[0][2] <= 1
+
+    def test_jaccard_coefficient_empty_graph(self, graph):
+        """Test jaccard coefficient on empty graph"""
+        result = nx.jaccard_coefficient(graph, ebunch=[], backend=BACKEND)
+
+        result_list = list(result)
+        assert len(result_list) == 0
+
+    def test_jaccard_coefficient_single_pair(self, graph):
+        """Test jaccard coefficient with a simple graph"""
+        # Create a graph with shared neighbors
+        graph.add_edges_from([("A", "C"), ("A", "D"), ("B", "C"), ("B", "D"), ("B", "E")])
+        result = nx.jaccard_coefficient(graph, ebunch=[("A", "B")], backend=BACKEND)
+
+        result_list = list(result)
+        assert len(result_list) == 1
+        u, v, score = result_list[0]
+        assert u == "A"
+        assert v == "B"
+        assert isinstance(score, float)
+        assert 0 <= score <= 1

--- a/notebooks/jaccard_coefficient_demo.ipynb
+++ b/notebooks/jaccard_coefficient_demo.ipynb
@@ -176,7 +176,7 @@
         "    air_route_graph,\n",
         "    ebunch=pairs,\n",
         "    backend=\"neptune\",\n",
-        "    edge_labels=[\"route\"]\n",
+        "    edge_labels=[\"RELATES_TO\"]\n",
         ")\n",
         "\n",
         "for u, v, score in result:\n",

--- a/notebooks/jaccard_coefficient_demo.ipynb
+++ b/notebooks/jaccard_coefficient_demo.ipynb
@@ -1,0 +1,234 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# Jaccard Coefficient with Neptune Analytics\n",
+        "\n",
+        "This notebook demonstrates using the Jaccard coefficient algorithm via the nx-neptune backend.\n",
+        "The Jaccard coefficient measures the similarity between two nodes by computing the ratio of\n",
+        "shared neighbors to total unique neighbors: |Γ(u) ∩ Γ(v)| / |Γ(u) ∪ Γ(v)|.\n",
+        "It is useful in link prediction — predicting which edges are likely to form in a network."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "setup-header",
+      "metadata": {},
+      "source": [
+        "## Setup and Imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "imports",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Check the Python version:\n",
+        "from sys import version_info\n",
+        "assert version_info >= (3, 11), \"Python 3.11 or higher is required\"\n",
+        "\n",
+        "import os\n",
+        "import requests\n",
+        "import pandas as pd\n",
+        "\n",
+        "import networkx as nx\n",
+        "from nx_neptune import NeptuneGraph\n",
+        "from nx_neptune.clients import Node\n",
+        "from nx_neptune.utils.utils import get_stdout_logger"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "logger",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "logger = get_stdout_logger(__name__,[\n",
+        "                    'nx_neptune.algorithms.link_prediction.jaccard',\n",
+        "                    'nx_neptune.na_graph', 'nx_neptune.utils.decorators',\n",
+        "                    'nx_neptune.instance_management',__name__])\n",
+        "\n",
+        "# Ignore cache warnings\n",
+        "nx.config.warnings_to_ignore.add(\"cache\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "graph-id-header",
+      "metadata": {},
+      "source": [
+        "## Check for Neptune Analytics Graph ID"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "graph-id",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Read and load graphId from environment variable\n",
+        "graph_id = os.getenv('NETWORKX_GRAPH_ID')\n",
+        "\n",
+        "# If not set, you can set it here\n",
+        "if not graph_id:\n",
+        "    # Uncomment and set your Graph ID\n",
+        "    # %env NETWORKX_GRAPH_ID=your-neptune-analytics-graph-id\n",
+        "    # graph_id = os.getenv('NETWORKX_GRAPH_ID')\n",
+        "    print(\"Warning: Environment Variable NETWORKX_GRAPH_ID is not defined\")\n",
+        "    print(\"You can set it using: %env NETWORKX_GRAPH_ID=your-neptune-analytics-graph-id\")\n",
+        "else:\n",
+        "    print(f\"Using Neptune Analytics Graph ID: {graph_id}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "dataset-header",
+      "metadata": {},
+      "source": [
+        "## Download and configure Air route dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "dataset",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Download routes data\n",
+        "routes_url = \"https://raw.githubusercontent.com/jpatokal/openflights/master/data/routes.dat\"\n",
+        "routes_file = \"resources/notebook_test_data_routes.dat\"\n",
+        "\n",
+        "# Ensure the directory exists\n",
+        "os.makedirs(os.path.dirname(routes_file), exist_ok=True)\n",
+        "\n",
+        "# Download only if file doesn't exist\n",
+        "if not os.path.isfile(routes_file):\n",
+        "    with open(routes_file, \"wb\") as f:\n",
+        "        f.write(requests.get(routes_url).content)\n",
+        "\n",
+        "cols = [\n",
+        "    \"airline\", \"airline_id\", \"source_airport\", \"source_airport_id\",\n",
+        "    \"dest_airport\", \"dest_airport_id\", \"codeshare\", \"stops\", \"equipment\",\n",
+        "]\n",
+        "routes = pd.read_csv(routes_file, names=cols)\n",
+        "routes = routes[[\"source_airport\", \"dest_airport\"]].dropna()\n",
+        "\n",
+        "air_route_graph = nx.from_pandas_edgelist(\n",
+        "    routes, source=\"source_airport\", target=\"dest_airport\",\n",
+        "    create_using=nx.Graph()\n",
+        ")\n",
+        "print(f\"Graph loaded: {air_route_graph.number_of_nodes()} nodes, {air_route_graph.number_of_edges()} edges\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "example1-header",
+      "metadata": {},
+      "source": [
+        "## Example 1: Basic Jaccard Coefficient\n",
+        "\n",
+        "Compute the Jaccard coefficient for a specific pair of airports to determine how similar their route networks are."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "example1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Compute Jaccard coefficient for specific pairs\n",
+        "pairs = [(\"JFK\", \"LAX\"), (\"SFO\", \"ORD\"), (\"ATL\", \"DFW\")]\n",
+        "result = nx.jaccard_coefficient(air_route_graph, ebunch=pairs, backend=\"neptune\")\n",
+        "\n",
+        "for u, v, score in result:\n",
+        "    print(f\"({u}, {v}) -> {score:.6f}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "example2-header",
+      "metadata": {},
+      "source": [
+        "## Example 2: Jaccard Coefficient with Edge Label Filtering\n",
+        "\n",
+        "Filter the computation to only consider specific edge types when determining neighbor sets."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "example2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Compute with edge label filtering\n",
+        "pairs = [(\"JFK\", \"LAX\"), (\"SFO\", \"ORD\")]\n",
+        "result = nx.jaccard_coefficient(\n",
+        "    air_route_graph,\n",
+        "    ebunch=pairs,\n",
+        "    backend=\"neptune\",\n",
+        "    edge_labels=[\"route\"]\n",
+        ")\n",
+        "\n",
+        "for u, v, score in result:\n",
+        "    print(f\"({u}, {v}) -> {score:.6f}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "example3-header",
+      "metadata": {},
+      "source": [
+        "## Example 3: Jaccard Coefficient with Traversal Direction\n",
+        "\n",
+        "Control which direction of edges are considered when computing neighbor sets."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "example3",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Compute with both inbound and outbound edges\n",
+        "pairs = [(\"JFK\", \"LAX\"), (\"ATL\", \"ORD\")]\n",
+        "result = nx.jaccard_coefficient(\n",
+        "    air_route_graph,\n",
+        "    ebunch=pairs,\n",
+        "    backend=\"neptune\",\n",
+        "    traversal_direction=\"both\"\n",
+        ")\n",
+        "\n",
+        "for u, v, score in result:\n",
+        "    print(f\"({u}, {v}) -> {score:.6f}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {"name": "ipython", "version": 3},
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.5"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/nx_neptune/__init__.py
+++ b/nx_neptune/__init__.py
@@ -24,6 +24,7 @@ from .algorithms.communities.label_propagation import (
 )
 from .algorithms.communities.wcc import weakly_connected_components
 from .algorithms.link_analysis.pagerank import pagerank
+from .algorithms.link_prediction.jaccard import jaccard_coefficient
 from .algorithms.traversal.bfs import bfs_edges, bfs_layers, descendants_at_distance
 from .clients import Edge, Node
 from .instance_management import (
@@ -76,6 +77,7 @@ __all__ = [
     "fast_label_propagation_communities",
     "louvain_communities",
     "weakly_connected_components",
+    "jaccard_coefficient",
     # graphs
     "Node",
     "Edge",

--- a/nx_neptune/algorithms/__init__.py
+++ b/nx_neptune/algorithms/__init__.py
@@ -25,6 +25,7 @@ from .communities import (
     weakly_connected_components,
 )
 from .link_analysis.pagerank import pagerank
+from .link_prediction.jaccard import jaccard_coefficient
 from .traversal.bfs import bfs_edges, bfs_layers, descendants_at_distance
 
 # import modules

--- a/nx_neptune/algorithms/link_prediction/__init__.py
+++ b/nx_neptune/algorithms/link_prediction/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from .jaccard import jaccard_coefficient
+
+__all__ = ["jaccard_coefficient"]

--- a/nx_neptune/algorithms/link_prediction/jaccard.py
+++ b/nx_neptune/algorithms/link_prediction/jaccard.py
@@ -1,0 +1,113 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+from typing import Any, List, Optional
+
+from nx_neptune.clients.neptune_constants import (
+    PARAM_EDGE_LABELS,
+    PARAM_TRAVERSAL_DIRECTION,
+    PARAM_VERTEX_LABEL,
+)
+from nx_neptune.clients.opencypher_builder import jaccard_coefficient_query
+from nx_neptune.na_graph import NeptuneGraph
+from nx_neptune.utils.decorators import configure_if_nx_active
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["jaccard_coefficient"]
+
+
+@configure_if_nx_active()
+def jaccard_coefficient(
+    neptune_graph: NeptuneGraph,
+    ebunch=None,
+    edge_labels: Optional[List] = None,
+    vertex_label: Optional[str] = None,
+    traversal_direction: Optional[str] = None,
+):
+    """
+    Compute the Jaccard coefficient of all node pairs in ebunch.
+    Link: https://docs.aws.amazon.com/neptune-analytics/latest/userguide/jaccard-similarity.html
+
+    The Jaccard coefficient measures the similarity between two sets of neighbors.
+    It is defined as |Γ(u) ∩ Γ(v)| / |Γ(u) ∪ Γ(v)| where Γ(u) denotes the set
+    of neighbors of u.
+
+    :param neptune_graph: A NeptuneGraph instance
+    :param ebunch: An iterable of node pairs (u, v). Jaccard coefficient will be
+        computed for each pair. The pairs must be given as 2-tuples (u, v) where
+        u and v are nodes in the graph. If ebunch is None then all nonexistent
+        edges in the graph will be used. Note: when ebunch is None, the non-edges
+        are computed locally from the NetworkX graph object before being sent to
+        Neptune Analytics. For large graphs, prefer passing an explicit ebunch.
+    :param edge_labels: To filter on one or more edge labels, provide a list of the
+        ones to filter on. If no edgeLabels field is provided then all edge labels
+        are processed during traversal.
+    :param vertex_label: A vertex label for vertex filtering. If a vertex label is
+        provided, only nodes matching the label are considered neighbors.
+    :param traversal_direction: The direction of edge to follow. Must be one of:
+        "inbound", "outbound", or "both". Default: "outbound".
+
+    :return: An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
+        pair of nodes and p is their Jaccard coefficient.
+    """
+
+    parameters: dict[str, Any] = {}
+
+    if edge_labels:
+        parameters[PARAM_EDGE_LABELS] = edge_labels
+
+    if vertex_label:
+        parameters[PARAM_VERTEX_LABEL] = vertex_label
+
+    if traversal_direction:
+        parameters[PARAM_TRAVERSAL_DIRECTION] = traversal_direction
+
+    if ebunch is None:
+        # When ebunch is None, compute for all non-existent edges in the graph
+        ebunch = _generate_non_edges(neptune_graph)
+
+    # Collect pairs into lists for batched execution
+    pairs = list(ebunch)
+    if not pairs:
+        return iter([])
+
+    first_nodes = [str(u) for u, v in pairs]
+    second_nodes = [str(v) for u, v in pairs]
+
+    query_str, para_map = jaccard_coefficient_query(first_nodes, second_nodes, parameters)
+    json_result = neptune_graph.execute_call(query_str, para_map)
+
+    # Map results back to original pairs
+    results = []
+    for i, (u, v) in enumerate(pairs):
+        if json_result and i < len(json_result):
+            score = json_result[i].get("score", 0.0)
+        else:
+            score = 0.0
+        results.append((u, v, score))
+
+    return iter(results)
+
+
+def _generate_non_edges(neptune_graph: NeptuneGraph):
+    """
+    Generate all non-existent edges for the graph.
+    This retrieves all nodes and yields pairs that are not connected.
+    """
+    graph = neptune_graph.graph
+    if graph is not None:
+        import networkx as nx
+
+        return nx.non_edges(graph)
+    return iter([])

--- a/nx_neptune/algorithms/link_prediction/jaccard.py
+++ b/nx_neptune/algorithms/link_prediction/jaccard.py
@@ -77,24 +77,19 @@ def jaccard_coefficient(
         # When ebunch is None, compute for all non-existent edges in the graph
         ebunch = _generate_non_edges(neptune_graph)
 
-    # Collect pairs into lists for batched execution
-    pairs = list(ebunch)
-    if not pairs:
-        return iter([])
-
-    first_nodes = [str(u) for u, v in pairs]
-    second_nodes = [str(v) for u, v in pairs]
-
-    query_str, para_map = jaccard_coefficient_query(first_nodes, second_nodes, parameters)
-    json_result = neptune_graph.execute_call(query_str, para_map)
-
-    # Map results back to original pairs
+    # Process one pair at a time — Neptune requires Node references from MATCH,
+    # and using MATCH ... IN with multiple nodes produces a cross join, not
+    # positional pairing. Each pair must be a separate query.
     results = []
-    for i, (u, v) in enumerate(pairs):
-        if json_result and i < len(json_result):
-            score = json_result[i].get("score", 0.0)
+    for u, v in ebunch:
+        query_str, para_map = jaccard_coefficient_query(str(u), str(v), parameters)
+        json_result = neptune_graph.execute_call(query_str, para_map)
+
+        if json_result and len(json_result) > 0:
+            score = json_result[0].get("score", 0.0)
         else:
             score = 0.0
+
         results.append((u, v, score))
 
     return iter(results)

--- a/nx_neptune/clients/opencypher_builder.py
+++ b/nx_neptune/clients/opencypher_builder.py
@@ -1115,28 +1115,31 @@ def _get_nodes_in_list(source_nodes: list[str]):
 
 
 def jaccard_coefficient_query(
-    first_nodes: List[str],
-    second_nodes: List[str],
+    first_node: str,
+    second_node: str,
     parameters: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, Dict[str, Any]]:
     """
-    Create a query to execute the Jaccard Similarity algorithm on Neptune Analytics.
+    Create a query to execute the Jaccard Similarity algorithm on Neptune Analytics
+    for a single pair of nodes.
 
-    :param first_nodes: List of IDs for the first nodes
-    :param second_nodes: List of IDs for the second nodes (must be same length as first_nodes)
+    Neptune requires Node references from MATCH clauses, and using MATCH ... IN
+    with multiple nodes produces a cross join. Each pair must be queried separately.
+
+    :param first_node: The ID of the first node
+    :param second_node: The ID of the second node
     :param parameters: Optional dictionary of algorithm parameters (edgeLabels, vertexLabel, traversalDirection)
     :return: Tuple of (OpenCypher query string, parameter map) for Jaccard Similarity algorithm execution
 
     Example:
-        >>> jaccard_coefficient_query(["Alice", "Charlie"], ["Bob", "Dave"])
-        ("MATCH (n1) WHERE id(n1) IN $0 MATCH (n2) WHERE id(n2) IN $1
-        CALL neptune.algo.jaccardSimilarity(collect(n1), collect(n2)) YIELD score RETURN score",
-        {'0': ['Alice', 'Charlie'], '1': ['Bob', 'Dave']})
+        >>> jaccard_coefficient_query("Alice", "Bob")
+        ('MATCH (n1) WHERE id(n1) = $0 MATCH (n2) WHERE id(n2) = $1
+        CALL neptune.algo.jaccardSimilarity(n1, n2) YIELD score RETURN score', {'0': 'Alice', '1': 'Bob'})
     """
     param_builder = ParameterMapBuilder()
 
-    masked_first = param_builder.read_map({"id(n1)": first_nodes})
-    masked_second = param_builder.read_map({"id(n2)": second_nodes})
+    masked_first = param_builder.read_map({"id(n1)": first_node})
+    masked_second = param_builder.read_map({"id(n2)": second_node})
 
     jaccard_params = "n1, n2"
     if parameters:
@@ -1147,10 +1150,10 @@ def jaccard_coefficient_query(
         QueryBuilder()
         .match()
         .node(ref_name="n1")
-        .where_multiple(masked_first, comparison_operator="IN", escape=False)
+        .where_multiple(masked_first, escape=False)
         .match()
         .node(ref_name="n2")
-        .where_multiple(masked_second, comparison_operator="IN", escape=False)
+        .where_multiple(masked_second, escape=False)
         .call()
         .procedure(f"{_JACCARD_ALG}({jaccard_params})")
         .yield_((_SCORE_REF, _SCORE_REF))

--- a/nx_neptune/clients/opencypher_builder.py
+++ b/nx_neptune/clients/opencypher_builder.py
@@ -47,6 +47,7 @@ _LOUVAIN_ALG = "neptune.algo.louvain"
 _LOUVAIN_MUTATE_ALG = "neptune.algo.louvain.mutate"
 _WCC_ALG = "neptune.algo.wcc"
 _WCC_MUTATE_ALG = "neptune.algo.wcc.mutate"
+_JACCARD_ALG = "neptune.algo.jaccardSimilarity"
 _RANK_REF = "rank"
 _DEGREE_REF = "degree"
 _COMMUNITY_REF = "community"
@@ -1111,3 +1112,49 @@ def _get_nodes_in_list(source_nodes: list[str]):
         if not _NODE_ID_RE.match(str(node_id)):
             raise ValueError(f"Invalid node ID: {node_id!r}")
     return "[" + ",".join(f"'{s}'" for s in nodes) + "]"
+
+
+def jaccard_coefficient_query(
+    first_nodes: List[str],
+    second_nodes: List[str],
+    parameters: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, Dict[str, Any]]:
+    """
+    Create a query to execute the Jaccard Similarity algorithm on Neptune Analytics.
+
+    :param first_nodes: List of IDs for the first nodes
+    :param second_nodes: List of IDs for the second nodes (must be same length as first_nodes)
+    :param parameters: Optional dictionary of algorithm parameters (edgeLabels, vertexLabel, traversalDirection)
+    :return: Tuple of (OpenCypher query string, parameter map) for Jaccard Similarity algorithm execution
+
+    Example:
+        >>> jaccard_coefficient_query(["Alice", "Charlie"], ["Bob", "Dave"])
+        ("MATCH (n1) WHERE id(n1) IN $0 MATCH (n2) WHERE id(n2) IN $1
+        CALL neptune.algo.jaccardSimilarity(collect(n1), collect(n2)) YIELD score RETURN score",
+        {'0': ['Alice', 'Charlie'], '1': ['Bob', 'Dave']})
+    """
+    param_builder = ParameterMapBuilder()
+
+    masked_first = param_builder.read_map({"id(n1)": first_nodes})
+    masked_second = param_builder.read_map({"id(n2)": second_nodes})
+
+    jaccard_params = "n1, n2"
+    if parameters:
+        parameters_list_str = _to_parameter_list(parameters)
+        jaccard_params = f"{jaccard_params}, {{{parameters_list_str}}}"
+
+    query_str = (
+        QueryBuilder()
+        .match()
+        .node(ref_name="n1")
+        .where_multiple(masked_first, comparison_operator="IN", escape=False)
+        .match()
+        .node(ref_name="n2")
+        .where_multiple(masked_second, comparison_operator="IN", escape=False)
+        .call()
+        .procedure(f"{_JACCARD_ALG}({jaccard_params})")
+        .yield_((_SCORE_REF, _SCORE_REF))
+        .return_literal(_SCORE_REF)
+        .query
+    )
+    return query_str, param_builder.get_param_values()

--- a/nx_neptune/interface.py
+++ b/nx_neptune/interface.py
@@ -56,6 +56,7 @@ ALGORITHMS = [
     "fast_label_propagation_communities",
     "louvain_communities",
     "weakly_connected_components",
+    "jaccard_coefficient",
 ]
 
 

--- a/nx_plugin/__init__.py
+++ b/nx_plugin/__init__.py
@@ -37,6 +37,7 @@ _info = {
         "asyn_lpa_communities",
         "louvain_communities",
         "weakly_connected_components",
+        "jaccard_coefficient",
     },
     "additional_docs": {
         "bfs_edges": f"For additional details, see {algorithms_url}#bfs_edges",
@@ -64,6 +65,11 @@ strategy. Variant-specific control over the update method (e.g., synchronous vs.
 moment.
 - For additional parameters, see {algorithms_url}#louvain_communities""",
         "weakly_connected_components": f"For additional details, see {algorithms_url}#weakly_connected_components",
+        "jaccard_coefficient": f"""- The `ebunch` parameter must be provided as an iterable of node pairs (u, v).
+- When `ebunch=None`, non-edges are computed locally from the NetworkX graph before being sent to Neptune. \
+For large graphs, prefer passing an explicit `ebunch`.
+- Neptune Analytics does not support a mutate variant for Jaccard similarity.
+- For additional parameters, see {algorithms_url}#jaccard_coefficient""",
     },
     "additional_parameters": {},
 }

--- a/tests/algorithms/link_prediction/test_jaccard_coefficient.py
+++ b/tests/algorithms/link_prediction/test_jaccard_coefficient.py
@@ -47,7 +47,7 @@ class TestJaccardCoefficient:
             result = jaccard_coefficient(mock_graph, ebunch=[("A", "B")])
 
             # Verify the correct query was built and executed
-            expected_query, param_values = jaccard_coefficient_query(["A"], ["B"])
+            expected_query, param_values = jaccard_coefficient_query("A", "B")
             mock_graph.execute_call.assert_called_once_with(
                 expected_query, param_values
             )
@@ -59,12 +59,8 @@ class TestJaccardCoefficient:
             assert result_list[0] == ("A", "B", 0.6)
 
     def test_jaccard_coefficient_multiple_pairs(self, mock_graph):
-        """Test jaccard coefficient with multiple node pairs (batched)."""
-        mock_graph.execute_call.return_value = [
-            {"score": 0.6},
-            {"score": 0.4},
-            {"score": 0.8},
-        ]
+        """Test jaccard coefficient with multiple node pairs (one query per pair)."""
+        mock_graph.execute_call.return_value = [{"score": 0.6}]
 
         with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
             result = jaccard_coefficient(
@@ -73,12 +69,12 @@ class TestJaccardCoefficient:
 
             result_list = list(result)
             assert len(result_list) == 3
-            # Batched: only one call to Neptune
-            mock_graph.execute_call.assert_called_once()
+            # One query per pair
+            assert mock_graph.execute_call.call_count == 3
 
-            assert result_list[0] == ("A", "B", 0.6)
-            assert result_list[1] == ("C", "D", 0.4)
-            assert result_list[2] == ("E", "F", 0.8)
+            # All results should have score 0.6 (mocked)
+            for u, v, p in result_list:
+                assert p == 0.6
 
     def test_jaccard_coefficient_with_edge_labels(self, mock_graph):
         """Test jaccard coefficient with edge label filtering."""
@@ -90,7 +86,7 @@ class TestJaccardCoefficient:
             )
 
             expected_query, param_values = jaccard_coefficient_query(
-                ["A"], ["B"], {PARAM_EDGE_LABELS: ["route", "knows"]}
+                "A", "B", {PARAM_EDGE_LABELS: ["route", "knows"]}
             )
             mock_graph.execute_call.assert_called_once_with(
                 expected_query, param_values
@@ -110,7 +106,7 @@ class TestJaccardCoefficient:
             )
 
             expected_query, param_values = jaccard_coefficient_query(
-                ["A"], ["B"], {PARAM_VERTEX_LABEL: "airport"}
+                "A", "B", {PARAM_VERTEX_LABEL: "airport"}
             )
             mock_graph.execute_call.assert_called_once_with(
                 expected_query, param_values
@@ -130,7 +126,7 @@ class TestJaccardCoefficient:
             )
 
             expected_query, param_values = jaccard_coefficient_query(
-                ["A"], ["B"], {PARAM_TRAVERSAL_DIRECTION: "both"}
+                "A", "B", {PARAM_TRAVERSAL_DIRECTION: "both"}
             )
             mock_graph.execute_call.assert_called_once_with(
                 expected_query, param_values
@@ -152,8 +148,8 @@ class TestJaccardCoefficient:
             )
 
             expected_query, param_values = jaccard_coefficient_query(
-                ["A"],
-                ["B"],
+                "A",
+                "B",
                 {
                     PARAM_EDGE_LABELS: ["route"],
                     PARAM_VERTEX_LABEL: "airport",

--- a/tests/algorithms/link_prediction/test_jaccard_coefficient.py
+++ b/tests/algorithms/link_prediction/test_jaccard_coefficient.py
@@ -1,0 +1,190 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from networkx.classes import Graph
+
+from nx_neptune import jaccard_coefficient
+from nx_neptune.clients.neptune_constants import (
+    PARAM_EDGE_LABELS,
+    PARAM_TRAVERSAL_DIRECTION,
+    PARAM_VERTEX_LABEL,
+)
+from nx_neptune.clients.opencypher_builder import jaccard_coefficient_query
+from nx_neptune.na_graph import NeptuneGraph
+
+
+class TestJaccardCoefficient:
+    """Test suite for jaccard_coefficient function in nx_neptune."""
+
+    @pytest.fixture
+    def mock_graph(self):
+        """Create a mock NeptuneGraph for testing."""
+        graph_nx = MagicMock(spec=NeptuneGraph)
+        # Mock the execute_call method to return a predefined result
+        graph_nx.execute_call.return_value = [{"score": 0.6}]
+
+        graph = MagicMock(spec=Graph)
+        graph.number_of_nodes.return_value = 5
+        graph_nx.graph = graph
+        return graph_nx
+
+    def test_jaccard_coefficient_basic(self, mock_graph):
+        """Test basic functionality of jaccard coefficient with ebunch."""
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(mock_graph, ebunch=[("A", "B")])
+
+            # Verify the correct query was built and executed
+            expected_query, param_values = jaccard_coefficient_query(["A"], ["B"])
+            mock_graph.execute_call.assert_called_once_with(
+                expected_query, param_values
+            )
+            assert "neptune.algo.jaccardSimilarity" in expected_query
+
+            # Verify the result format (iterator of (u, v, p) tuples)
+            result_list = list(result)
+            assert len(result_list) == 1
+            assert result_list[0] == ("A", "B", 0.6)
+
+    def test_jaccard_coefficient_multiple_pairs(self, mock_graph):
+        """Test jaccard coefficient with multiple node pairs (batched)."""
+        mock_graph.execute_call.return_value = [
+            {"score": 0.6},
+            {"score": 0.4},
+            {"score": 0.8},
+        ]
+
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(
+                mock_graph, ebunch=[("A", "B"), ("C", "D"), ("E", "F")]
+            )
+
+            result_list = list(result)
+            assert len(result_list) == 3
+            # Batched: only one call to Neptune
+            mock_graph.execute_call.assert_called_once()
+
+            assert result_list[0] == ("A", "B", 0.6)
+            assert result_list[1] == ("C", "D", 0.4)
+            assert result_list[2] == ("E", "F", 0.8)
+
+    def test_jaccard_coefficient_with_edge_labels(self, mock_graph):
+        """Test jaccard coefficient with edge label filtering."""
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(
+                mock_graph,
+                ebunch=[("A", "B")],
+                edge_labels=["route", "knows"],
+            )
+
+            expected_query, param_values = jaccard_coefficient_query(
+                ["A"], ["B"], {PARAM_EDGE_LABELS: ["route", "knows"]}
+            )
+            mock_graph.execute_call.assert_called_once_with(
+                expected_query, param_values
+            )
+
+            result_list = list(result)
+            assert len(result_list) == 1
+            assert result_list[0] == ("A", "B", 0.6)
+
+    def test_jaccard_coefficient_with_vertex_label(self, mock_graph):
+        """Test jaccard coefficient with vertex label filtering."""
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(
+                mock_graph,
+                ebunch=[("A", "B")],
+                vertex_label="airport",
+            )
+
+            expected_query, param_values = jaccard_coefficient_query(
+                ["A"], ["B"], {PARAM_VERTEX_LABEL: "airport"}
+            )
+            mock_graph.execute_call.assert_called_once_with(
+                expected_query, param_values
+            )
+
+            result_list = list(result)
+            assert len(result_list) == 1
+            assert result_list[0] == ("A", "B", 0.6)
+
+    def test_jaccard_coefficient_with_traversal_direction(self, mock_graph):
+        """Test jaccard coefficient with traversal direction."""
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(
+                mock_graph,
+                ebunch=[("A", "B")],
+                traversal_direction="both",
+            )
+
+            expected_query, param_values = jaccard_coefficient_query(
+                ["A"], ["B"], {PARAM_TRAVERSAL_DIRECTION: "both"}
+            )
+            mock_graph.execute_call.assert_called_once_with(
+                expected_query, param_values
+            )
+
+            result_list = list(result)
+            assert len(result_list) == 1
+            assert result_list[0] == ("A", "B", 0.6)
+
+    def test_jaccard_coefficient_all_parameters(self, mock_graph):
+        """Test jaccard coefficient with all Neptune Analytics parameters."""
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(
+                mock_graph,
+                ebunch=[("A", "B")],
+                edge_labels=["route"],
+                vertex_label="airport",
+                traversal_direction="outbound",
+            )
+
+            expected_query, param_values = jaccard_coefficient_query(
+                ["A"],
+                ["B"],
+                {
+                    PARAM_EDGE_LABELS: ["route"],
+                    PARAM_VERTEX_LABEL: "airport",
+                    PARAM_TRAVERSAL_DIRECTION: "outbound",
+                },
+            )
+            mock_graph.execute_call.assert_called_once_with(
+                expected_query, param_values
+            )
+
+            result_list = list(result)
+            assert len(result_list) == 1
+            assert result_list[0] == ("A", "B", 0.6)
+
+    def test_jaccard_coefficient_empty_result(self, mock_graph):
+        """Test jaccard coefficient when Neptune returns empty result."""
+        mock_graph.execute_call.return_value = []
+
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(mock_graph, ebunch=[("A", "B")])
+
+            result_list = list(result)
+            assert len(result_list) == 1
+            # Should default to 0.0 when no result
+            assert result_list[0] == ("A", "B", 0.0)
+
+    def test_jaccard_coefficient_empty_ebunch(self, mock_graph):
+        """Test jaccard coefficient with empty ebunch."""
+        with patch.dict(os.environ, {"NX_ALGORITHM_TEST": "test_case"}):
+            result = jaccard_coefficient(mock_graph, ebunch=[])
+
+            result_list = list(result)
+            assert len(result_list) == 0
+            mock_graph.execute_call.assert_not_called()


### PR DESCRIPTION
### Summary

Implements `jaccard_coefficient` mapping NetworkX's `nx.jaccard_coefficient()` to Neptune Analytics' `neptune.algo.jaccardSimilarity`. New link prediction category.

### Design

- One query per pair: `MATCH (n1) WHERE id(n1) = $0 MATCH (n2) WHERE id(n2) = $1 CALL neptune.algo.jaccardSimilarity(n1, n2)`
- Batching not possible — Neptune produces a cross join when MATCH returns multiple nodes
- When `ebunch=None`, non-edges computed locally before querying
- Supports `edge_labels`, `vertex_label`, `traversal_direction`
- No mutate variant


### Testing

- Unit + integ tests pass
- Verified correct behavior via direct openCypher queries against live Neptune instance