### PR TITLE
Fix: Bind Docker published ports to 127.0.0.1

### DIFF
--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ..
       dockerfile: proxy/Dockerfile
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
@@ -21,8 +21,8 @@ services:
   graph-explorer:
     image: ${GRAPH_EXPLORER_IMAGE:-public.ecr.aws/neptune/graph-explorer:latest}
     ports:
-      - "443:443"
-      - "80:80"
+      - "127.0.0.1:443:443"
+      - "127.0.0.1:80:80"
     environment:
       - HOST=localhost
       - AWS_REGION=${AWS_DEFAULT_REGION:-us-west-2}


### PR DESCRIPTION

 Summary
  
Bind all published ports in docker-compose.yml to 127.0.0.1, preventing remote access to development containers.
Matches the standalone deployment security posture.
  
  Changes
  
  - proxy/docker-compose.yml — 8080:8080 → 127.0.0.1:8080:8080, same for ports 443 and 80
  