### PR TITLE
Fix: Add CSRF protection via X-Requested-With header

### DIFF
--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -16,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from nx_neptune_proxy.config import Settings
 from nx_neptune_proxy.routers.graph import router as graph_router
 from nx_neptune_proxy.routers.metadata import router as metadata_router
+from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
 from nx_neptune_proxy.routers.projection import router as projection_router
 from nx_neptune_proxy.routers.project import router as project_router
@@ -107,7 +108,7 @@ async def aws_exception_handler(request: Request, exc: ClientError):
     logger.warning(f"AWS {code} on {request.method} {request.url.path}: {message}")
     return JSONResponse(
         status_code=status,
-        content={"error": code, "message": message},
+        content={"error": code, "message": sanitize_error_message(message)},
     )
 
 

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -46,8 +46,29 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.allowed_origins,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
-    allow_headers=["Content-Type", "Authorization"],
+    allow_headers=["Content-Type", "Authorization", "X-Requested-With"],
 )
+
+
+# --- CSRF protection middleware ---
+
+_CSRF_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+
+@app.middleware("http")
+async def csrf_protection(request: Request, call_next):
+    """Require X-Requested-With header on state-changing requests.
+
+    This forces browsers to send a CORS preflight, which blocks cross-origin
+    requests from malicious tabs that don't pass the Origin check.
+    """
+    if request.method not in _CSRF_SAFE_METHODS:
+        if not request.headers.get("x-requested-with"):
+            return JSONResponse(
+                status_code=403,
+                content={"error": "csrf_rejected", "message": "Missing required X-Requested-With header"},
+            )
+    return await call_next(request)
 
 
 # --- Request logging middleware ---

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -13,6 +13,8 @@ from nx_neptune.clients.response_utils import get_query_failure_reason, get_quer
 from nx_neptune.instance_management import _execute_athena_query, get_athena_query_results
 from nx_neptune.utils.task_future import TaskType, wait_until_all_complete
 from nx_neptune.validators import check_athena_query, validate_resources, wrap_with_limit
+from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 from nx_neptune_proxy.routers.schemas import (
     PreviewResponse,
     ProjectionCreate,
@@ -173,7 +175,7 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
             client.delete_graph(graphIdentifier=p.graph_id, skipSnapshot=True)
         except ClientError as e:
             if e.response["Error"]["Code"] != "ResourceNotFoundException":
-                store.update(projection_id, status="failed", error=str(e))
+                store.update(projection_id, status="failed", error=sanitize_error_message(str(e)))
                 return
         # Poll until gone
         for _ in range(60):

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -5,6 +5,7 @@ import logging
 
 from nx_neptune_proxy.config import Settings
 from nx_neptune_proxy.services.projection_store import Projection, store
+from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,9 @@ async def run_pipeline(projection: Projection) -> None:
             error_msg = f"{err.get('Code', 'Error')}: {err.get('Message', str(e))}"
         else:
             error_msg = str(e)
-        store.update(projection.id, status="failed", error=error_msg)
+
+        # Sanitize before persisting — strip ARNs, account IDs
+        store.update(projection.id, status="failed", error=sanitize_error_message(error_msg))
 
 
 def _update(projection_id: str, step: str, label: str, progress: float) -> None:

--- a/proxy/src/nx_neptune_proxy/utils/__init__.py
+++ b/proxy/src/nx_neptune_proxy/utils/__init__.py
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .aws_helper import paginate_aws, unpack_query_results
+from .sanitize import sanitize_error_message
 
-__all__ = ["paginate_aws", "unpack_query_results"]
+__all__ = ["paginate_aws", "unpack_query_results", "sanitize_error_message"]

--- a/proxy/src/nx_neptune_proxy/utils/sanitize.py
+++ b/proxy/src/nx_neptune_proxy/utils/sanitize.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for sanitizing sensitive data from user-facing messages."""
+
+import re
+
+# Patterns that leak account info — strip from user-facing messages
+_SENSITIVE_PATTERNS = [
+    (re.compile(r"arn:aws[^:\s]*:[^:\s]*:[^:\s]*:\d{12}:[^\s,\"']+"), "[ARN]"),
+    (re.compile(r"(AKIA|ASIA|AROA|AIDA)[0-9A-Z]{16}"), "[AWS_ID]"),
+]
+
+
+def sanitize_error_message(message: str) -> str:
+    """Remove AWS account IDs, ARNs, and credentials from error messages."""
+    for pattern, replacement in _SENSITIVE_PATTERNS:
+        message = pattern.sub(replacement, message)
+    return message

--- a/proxy/tests/conftest.py
+++ b/proxy/tests/conftest.py
@@ -11,6 +11,17 @@ from nx_neptune_proxy.services.db import get_connection
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
+
+
+@pytest.fixture
+def bare_client():
+    """Client without X-Requested-With header — for CSRF rejection tests."""
+    transport = ASGITransport(app=app)
     return AsyncClient(transport=transport, base_url="http://test")
 
 

--- a/proxy/tests/test_app.py
+++ b/proxy/tests/test_app.py
@@ -10,7 +10,7 @@ from nx_neptune_proxy.app import app
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test")
+    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
 
 
 @pytest.mark.asyncio

--- a/proxy/tests/test_csrf.py
+++ b/proxy/tests/test_csrf.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CSRF protection via X-Requested-With header requirement."""
+
+import pytest
+
+
+class TestCsrfProtection:
+    """State-changing requests must include X-Requested-With header."""
+
+    # --- Blocked without header ---
+
+    @pytest.mark.asyncio
+    async def test_post_without_header_rejected(self, bare_client):
+        """POST without X-Requested-With must be rejected."""
+        resp = await bare_client.post("/api/v0/projection", json={"database": "test", "graph_name": "g"})
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "csrf_rejected"
+
+    @pytest.mark.asyncio
+    async def test_put_without_header_rejected(self, bare_client):
+        """PUT without X-Requested-With must be rejected."""
+        resp = await bare_client.put("/api/v0/projection/fake-id", json={"status": "done"})
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "csrf_rejected"
+
+    @pytest.mark.asyncio
+    async def test_delete_without_header_rejected(self, bare_client):
+        """DELETE without X-Requested-With must be rejected."""
+        resp = await bare_client.delete("/api/v0/projection/fake-id")
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "csrf_rejected"
+
+    # --- Allowed with header ---
+
+    @pytest.mark.asyncio
+    async def test_post_with_header_allowed(self, client):
+        """POST with X-Requested-With must pass CSRF check."""
+        resp = await client.post(
+            "/api/v0/projection",
+            json={"database": "test", "graph_name": "g"},
+        )
+        # Should pass CSRF check (may get 422/400 from validation, but not 403 csrf)
+        assert resp.status_code != 403 or resp.json().get("error") != "csrf_rejected"
+
+    @pytest.mark.asyncio
+    async def test_delete_with_header_allowed(self, client):
+        """DELETE with X-Requested-With must pass CSRF check."""
+        resp = await client.delete("/api/v0/projection/fake-id")
+        # Should pass CSRF check (may get 404, but not 403 csrf)
+        assert resp.status_code != 403 or resp.json().get("error") != "csrf_rejected"
+
+    # --- Safe methods unaffected ---
+
+    @pytest.mark.asyncio
+    async def test_get_without_header_allowed(self, bare_client):
+        """GET must work without X-Requested-With."""
+        resp = await bare_client.get("/health")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_options_without_header_allowed(self, bare_client):
+        """OPTIONS (preflight) must work without X-Requested-With."""
+        resp = await bare_client.options("/api/v0/projection")
+        assert resp.status_code != 403

--- a/proxy/tests/test_error_sanitization.py
+++ b/proxy/tests/test_error_sanitization.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AWS error message sanitization — no ARNs, account IDs, or keys in responses."""
+
+from nx_neptune_proxy.utils.sanitize import sanitize_error_message
+
+
+class TestErrorSanitization:
+    """Sensitive AWS identifiers must be stripped from user-facing errors."""
+
+    def test_arn_stripped(self):
+        msg = "User arn:aws:iam::123456789012:user/dev is not authorized"
+        result = sanitize_error_message(msg)
+        assert "123456789012" not in result
+        assert "arn:aws" not in result
+        assert "[ARN]" in result
+
+    def test_sts_assumed_role_stripped(self):
+        msg = "User arn:aws:sts::987654321098:assumed-role/MyRole/session is not authorized"
+        result = sanitize_error_message(msg)
+        assert "987654321098" not in result
+        assert "MyRole" not in result
+        assert "[ARN]" in result
+
+    def test_account_id_in_arn_stripped(self):
+        msg = "Resource arn:aws:neptune-graph:us-east-1:123456789012:graph/g-123 not found"
+        result = sanitize_error_message(msg)
+        assert "123456789012" not in result
+        assert "arn:aws" not in result
+
+    def test_access_key_stripped(self):
+        msg = "The security token for AKIA1234567890ABCDEF is invalid"
+        result = sanitize_error_message(msg)
+        assert "AKIA1234567890ABCDEF" not in result
+        assert "[AWS_ID]" in result
+
+    def test_session_key_stripped(self):
+        msg = "Token for ASIA1234567890ABCDEF expired"
+        result = sanitize_error_message(msg)
+        assert "ASIA1234567890ABCDEF" not in result
+        assert "[AWS_ID]" in result
+
+    def test_multiple_arns_stripped(self):
+        msg = "arn:aws:iam::111111111111:role/A cannot assume arn:aws:iam::222222222222:role/B"
+        result = sanitize_error_message(msg)
+        assert "111111111111" not in result
+        assert "222222222222" not in result
+
+    def test_normal_message_unchanged(self):
+        msg = "Graph not found"
+        result = sanitize_error_message(msg)
+        assert result == "Graph not found"
+
+    def test_error_code_preserved(self):
+        msg = "AccessDeniedException: User arn:aws:iam::123456789012:user/x cannot perform action"
+        result = sanitize_error_message(msg)
+        assert "AccessDeniedException" in result
+        assert "cannot perform action" in result

--- a/proxy/tests/test_graph.py
+++ b/proxy/tests/test_graph.py
@@ -14,7 +14,7 @@ from nx_neptune_proxy.services import graph_state_machine
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test")
+    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
 
 
 @pytest.fixture(autouse=True)

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -13,7 +13,7 @@ from nx_neptune_proxy.app import app
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test")
+    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
 
 
 # --- Athena databases ---

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -14,7 +14,7 @@ from nx_neptune_proxy.services.db import get_connection
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test")
+    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
 
 
 @pytest.fixture(autouse=True)

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -1,7 +1,9 @@
 const BASE = "/api/v0";
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, init);
+  const headers = new Headers(init?.headers);
+  headers.set("X-Requested-With", "nx-neptune");
+  const res = await fetch(`${BASE}${path}`, { ...init, headers });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.message || `Request failed: ${res.status}`);


### PR DESCRIPTION
Summary

Require X-Requested-With header on all state-changing requests (POST/PUT/DELETE). This forces browser preflight on cross-origin requests, preventing drive-by CSRF from malicious tabs. 
Frontend updated to send the header on all API calls.

Changes

- proxy/src/nx_neptune_proxy/app.py — CSRF middleware + X-Requested-With in CORS allow_headers
- proxy/ui-src/src/api/index.ts — send header on all fetch calls
- proxy/tests/conftest.py — client fixture sends header; new bare_client without it
- proxy/tests/test_csrf.py — 7 tests covering blocked/allowed/safe-method cases
- proxy/tests/test_app.py, test_graph.py, test_metadata.py, test_projection.py — fixtures
updated

Testing

75 passed, 7 skipped (UI not built)