### PR TITLE
Fix: Add prefix-scoped delete guard

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
-
+from nx_neptune_proxy.config import Settings
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune_proxy.services.graph_state_machine import (
     InvalidTransitionError,
@@ -52,6 +52,16 @@ def perform_action(graph_id: str, action: str, background_tasks: BackgroundTasks
     if not current_status:
         logger.warning(f"Graph {graph_id} returned empty status: {resp}")
         raise HTTPException(status_code=502, detail="Graph returned no status")
+
+    # Prefix guard: only allow destructive actions on graphs managed by this tool
+    if action == "delete":
+        prefix = Settings.from_env().graph_prefix
+        graph_name = resp.get("name", "")
+        if not graph_name.startswith(prefix):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Graph '{graph_name}' is not managed by this tool (missing '{prefix}' prefix)",
+            )
 
     try:
         # Validate early (execute_transition also validates, but fail fast for the user)

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune_proxy.config import Settings
@@ -90,6 +90,15 @@ def list_neptune_graphs():
 def delete_neptune_graph(graph_id: str):
     """Delete a Neptune Analytics graph"""
     client = ClientFactory().neptune()
+    # Verify graph belongs to this tool (prefix guard)
+    prefix = Settings.from_env().graph_prefix
+    resp = client.get_graph(graphIdentifier=graph_id)
+    graph_name = resp.get("name", "")
+    if not graph_name.startswith(prefix):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Graph '{graph_name}' is not managed by this tool (missing '{prefix}' prefix)",
+        )
     client.delete_graph(graphIdentifier=graph_id, skipSnapshot=True)
     return {"id": graph_id, "status": "DELETING"}
 

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -167,6 +167,15 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
         raise HTTPException(status_code=409, detail="No graph associated with this projection")
     if p.status == "deleting":
         raise HTTPException(status_code=409, detail="Already deleting")
+
+    # Prefix guard: only delete graphs managed by this tool
+    prefix = Settings.from_env().graph_prefix
+    if p.graph_name and not p.graph_name.startswith(prefix):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Graph '{p.graph_name}' is not managed by this tool (missing '{prefix}' prefix)",
+        )
+
     store.update(projection_id, status="deleting", step="graph_delete", step_label="Deleting graph")
 
     async def _delete_graph():

--- a/proxy/tests/test_graph.py
+++ b/proxy/tests/test_graph.py
@@ -166,7 +166,7 @@ async def test_perform_start_accepted(mock_cf, mock_exec, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_perform_delete_accepted(mock_cf, mock_exec, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test-graph"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/delete")


### PR DESCRIPTION
Summary

Graph delete operations now verify the target graph name starts with the configured prefix (nxp-). Prevents accidental or malicious deletion of graphs not created by this tool.

Changes

- proxy/src/nx_neptune_proxy/routers/graph.py — prefix check before delete action
- proxy/src/nx_neptune_proxy/routers/metadata.py — prefix check on delete_neptune_graph
- proxy/src/nx_neptune_proxy/routers/projection.py — prefix check on delete_projection_graph
- proxy/tests/test_graph.py — mock response includes name: "nxp-test-graph"
