### PR TITLE
Feat: Add project import/export [Local]

### DIFF
--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -20,6 +20,7 @@ from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
 from nx_neptune_proxy.routers.projection import router as projection_router
 from nx_neptune_proxy.routers.project import router as project_router
+from nx_neptune_proxy.routers.project_io import router as project_io_router
 from nx_neptune_proxy.services.db import init_db
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.project_deletion import delete_project
@@ -138,6 +139,7 @@ def info():
 
 app.include_router(metadata_router)
 app.include_router(projection_router)
+app.include_router(project_io_router)
 app.include_router(project_router)
 app.include_router(graph_router)
 

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -1,7 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Project import/export endpoints."""
+"""Project import/export endpoints.
+
+Enables exporting a project's configuration as a portable JSON file
+and re-importing it to recreate the project in another environment.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +13,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
@@ -23,25 +27,33 @@ MAX_IMPORT_SIZE = 5 * 1024 * 1024  # 5 MB
 
 
 class ProjectionExport(BaseModel):
-    """Projection config fields only — no runtime state."""
+    """Projection configuration (no runtime state such as graph_id, status, or progress)."""
 
-    catalog: str = "AwsDataCatalog"
-    database: Optional[str] = None
-    node_query: Optional[str] = None
-    edge_query: Optional[str] = None
-    graph_name: Optional[str] = None
-    graph_memory_gb: int = 16
-    s3_staging_bucket: Optional[str] = None
+    catalog: str = Field("AwsDataCatalog", description="Athena catalog name")
+    database: Optional[str] = Field(None, description="Athena database name")
+    node_query: Optional[str] = Field(None, description="SQL query that produces nodes (must include ~id and ~label columns)")
+    edge_query: Optional[str] = Field(None, description="SQL query that produces edges (must include ~from, ~to, and ~label columns)")
+    graph_name: Optional[str] = Field(None, description="Neptune Analytics graph name suffix (prefix is added automatically)")
+    graph_memory_gb: int = Field(16, description="Graph memory allocation in GB")
+    s3_staging_bucket: Optional[str] = Field(None, description="S3 bucket path for staging Athena results (e.g. s3://bucket/prefix)")
 
     model_config = {"extra": "forbid"}
 
 
 class ProjectExportPayload(BaseModel):
-    """Top-level export format for a single project."""
+    """Top-level schema for project import/export JSON files.
 
-    version: str = "1.0"
-    project: dict
-    projections: list[ProjectionExport] = []
+    Example:
+        {
+            "version": "1.0",
+            "project": {"name": "My Project"},
+            "projections": [{"catalog": "AwsDataCatalog", "database": "mydb", ...}]
+        }
+    """
+
+    version: str = Field("1.0", description="Schema version for forward compatibility")
+    project: dict = Field(..., description="Project metadata (must contain 'name' key)")
+    projections: list[ProjectionExport] = Field(default=[], description="List of projection configurations to create")
 
     model_config = {"extra": "forbid"}
 
@@ -49,9 +61,17 @@ class ProjectExportPayload(BaseModel):
 # --- Export endpoint ---
 
 
-@router.get("/{project_id}/export", summary="Export a project")
+@router.get("/{project_id}/export", summary="Export a project as JSON",
+            response_description="JSON file containing the project configuration and its projections")
 def export_project(project_id: str):
-    """Export a project and its projections as JSON."""
+    """Export a project and all its projection configurations as a downloadable JSON file.
+
+    The exported file contains only configuration data (queries, database references,
+    graph settings). Runtime state such as graph IDs, execution status, and endpoints
+    are not included.
+
+    The response includes a Content-Disposition header for browser download.
+    """
     p = project_store.get(project_id)
     if p is None:
         raise HTTPException(status_code=404, detail="Project not found")
@@ -86,9 +106,20 @@ def export_project(project_id: str):
 # --- Import endpoint ---
 
 
-@router.post("/import", summary="Import a project from JSON", status_code=201)
+@router.post("/import", summary="Import a project from JSON", status_code=201,
+             response_description="The newly created project ID and name")
 async def import_project(request: Request):
-    """Import a project and its projections from a JSON payload."""
+    """Create a project and its projections from a previously exported JSON payload.
+
+    Accepts the same JSON schema produced by the export endpoint. A new project
+    is created with a fresh ID regardless of whether a project with the same name
+    already exists. All projections start in 'draft' status.
+
+    Constraints:
+    - Maximum payload size: 5 MB
+    - Maximum 50 projections per import
+    - Unknown fields are rejected (extra='forbid')
+    """
     # Size check
     content_length = request.headers.get("content-length")
     if content_length and int(content_length) > MAX_IMPORT_SIZE:

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -1,0 +1,164 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Project import/export endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, model_validator
+
+from nx_neptune_proxy.services.project_store import store as project_store
+from nx_neptune_proxy.services.projection_store import store as projection_store
+
+router = APIRouter(prefix="/api/v0/project", tags=["project-io"])
+
+MAX_IMPORT_SIZE = 5 * 1024 * 1024  # 5 MB
+MAX_PROJECTS_PER_IMPORT = 50
+
+
+# --- Export/Import JSON schema ---
+
+
+class ProjectionExport(BaseModel):
+    """Projection config fields only — no runtime state."""
+
+    catalog: str = "AwsDataCatalog"
+    database: Optional[str] = None
+    node_query: Optional[str] = None
+    edge_query: Optional[str] = None
+    graph_name: Optional[str] = None
+    graph_memory_gb: int = 16
+    s3_staging_bucket: Optional[str] = None
+
+    model_config = {"extra": "forbid"}
+
+
+class ProjectExportEntry(BaseModel):
+    """A single project with its projections."""
+
+    project: dict = Field(description="Project metadata")
+    projections: list[ProjectionExport] = []
+
+    model_config = {"extra": "forbid"}
+
+
+class ProjectExportPayload(BaseModel):
+    """Top-level export format. Supports single or multi-project."""
+
+    version: str = "1.0"
+    # Single project export
+    project: Optional[dict] = None
+    projections: Optional[list[ProjectionExport]] = None
+    # Multi-project export
+    projects: Optional[list[ProjectExportEntry]] = None
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def check_structure(self):
+        has_single = self.project is not None
+        has_multi = self.projects is not None
+        if not has_single and not has_multi:
+            raise ValueError("Must provide either 'project' + 'projections' or 'projects'")
+        if has_single and has_multi:
+            raise ValueError("Cannot provide both 'project' and 'projects'")
+        return self
+
+
+# --- Export endpoints ---
+
+
+@router.get("/{project_id}/export", summary="Export a single project")
+def export_project(project_id: str):
+    """Export a project and its projections as JSON."""
+    p = project_store.get(project_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    projections = [
+        pr for pr in projection_store.list() if pr.project_id == project_id
+    ]
+
+    payload = {
+        "version": "1.0",
+        "project": {"name": p.name},
+        "projections": [
+            ProjectionExport(
+                catalog=pr.catalog,
+                database=pr.database,
+                node_query=pr.node_query,
+                edge_query=pr.edge_query,
+                graph_name=pr.graph_name,
+                graph_memory_gb=pr.graph_memory_gb,
+                s3_staging_bucket=pr.s3_staging_bucket,
+            ).model_dump()
+            for pr in projections
+        ],
+    }
+
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": f'attachment; filename="{p.name}.json"'},
+    )
+
+
+# --- Import endpoint ---
+
+
+@router.post("/import", summary="Import project(s) from JSON", status_code=201)
+async def import_projects(request: Request):
+    """Import one or more projects from a JSON payload."""
+    # Size check
+    content_length = request.headers.get("content-length")
+    if content_length and int(content_length) > MAX_IMPORT_SIZE:
+        raise HTTPException(status_code=413, detail="Payload too large (max 5 MB)")
+
+    contents = await request.body()
+    if len(contents) > MAX_IMPORT_SIZE:
+        raise HTTPException(status_code=413, detail="Payload too large (max 5 MB)")
+
+    # Parse and validate
+    try:
+        payload = ProjectExportPayload.model_validate_json(contents)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON: {e}")
+
+    # Normalize to list of entries
+    entries: list[tuple[dict, list[ProjectionExport]]] = []
+    if payload.projects:
+        if len(payload.projects) > MAX_PROJECTS_PER_IMPORT:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Too many projects (max {MAX_PROJECTS_PER_IMPORT})",
+            )
+        for entry in payload.projects:
+            entries.append((entry.project, entry.projections))
+    else:
+        entries.append((payload.project, payload.projections or []))
+
+    # Create projects and projections
+    created = []
+    for project_data, projections_data in entries:
+        name = project_data.get("name", "Imported Project")
+        p = project_store.create(name=name)
+
+        for pr_data in projections_data:
+            projection_store.create(
+                catalog=pr_data.catalog,
+                database=pr_data.database,
+                node_query=pr_data.node_query,
+                edge_query=pr_data.edge_query,
+                graph_name=pr_data.graph_name,
+                graph_memory_gb=pr_data.graph_memory_gb,
+                s3_staging_bucket=pr_data.s3_staging_bucket,
+                project_id=p.id,
+            )
+
+        created.append({"id": p.id, "name": p.name})
+
+    return {"imported": created}

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -5,12 +5,11 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel
 
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
@@ -18,7 +17,6 @@ from nx_neptune_proxy.services.projection_store import store as projection_store
 router = APIRouter(prefix="/api/v0/project", tags=["project-io"])
 
 MAX_IMPORT_SIZE = 5 * 1024 * 1024  # 5 MB
-MAX_PROJECTS_PER_IMPORT = 50
 
 
 # --- Export/Import JSON schema ---
@@ -38,42 +36,20 @@ class ProjectionExport(BaseModel):
     model_config = {"extra": "forbid"}
 
 
-class ProjectExportEntry(BaseModel):
-    """A single project with its projections."""
+class ProjectExportPayload(BaseModel):
+    """Top-level export format for a single project."""
 
-    project: dict = Field(description="Project metadata")
+    version: str = "1.0"
+    project: dict
     projections: list[ProjectionExport] = []
 
     model_config = {"extra": "forbid"}
 
 
-class ProjectExportPayload(BaseModel):
-    """Top-level export format. Supports single or multi-project."""
-
-    version: str = "1.0"
-    # Single project export
-    project: Optional[dict] = None
-    projections: Optional[list[ProjectionExport]] = None
-    # Multi-project export
-    projects: Optional[list[ProjectExportEntry]] = None
-
-    model_config = {"extra": "forbid"}
-
-    @model_validator(mode="after")
-    def check_structure(self):
-        has_single = self.project is not None
-        has_multi = self.projects is not None
-        if not has_single and not has_multi:
-            raise ValueError("Must provide either 'project' + 'projections' or 'projects'")
-        if has_single and has_multi:
-            raise ValueError("Cannot provide both 'project' and 'projects'")
-        return self
+# --- Export endpoint ---
 
 
-# --- Export endpoints ---
-
-
-@router.get("/{project_id}/export", summary="Export a single project")
+@router.get("/{project_id}/export", summary="Export a project")
 def export_project(project_id: str):
     """Export a project and its projections as JSON."""
     p = project_store.get(project_id)
@@ -110,9 +86,9 @@ def export_project(project_id: str):
 # --- Import endpoint ---
 
 
-@router.post("/import", summary="Import project(s) from JSON", status_code=201)
-async def import_projects(request: Request):
-    """Import one or more projects from a JSON payload."""
+@router.post("/import", summary="Import a project from JSON", status_code=201)
+async def import_project(request: Request):
+    """Import a project and its projections from a JSON payload."""
     # Size check
     content_length = request.headers.get("content-length")
     if content_length and int(content_length) > MAX_IMPORT_SIZE:
@@ -128,37 +104,21 @@ async def import_projects(request: Request):
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid JSON: {e}")
 
-    # Normalize to list of entries
-    entries: list[tuple[dict, list[ProjectionExport]]] = []
-    if payload.projects:
-        if len(payload.projects) > MAX_PROJECTS_PER_IMPORT:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Too many projects (max {MAX_PROJECTS_PER_IMPORT})",
-            )
-        for entry in payload.projects:
-            entries.append((entry.project, entry.projections))
-    else:
-        entries.append((payload.project, payload.projections or []))
+    # Create project
+    name = payload.project.get("name", "Imported Project")
+    p = project_store.create(name=name)
 
-    # Create projects and projections
-    created = []
-    for project_data, projections_data in entries:
-        name = project_data.get("name", "Imported Project")
-        p = project_store.create(name=name)
+    # Create projections
+    for pr_data in payload.projections:
+        projection_store.create(
+            catalog=pr_data.catalog,
+            database=pr_data.database,
+            node_query=pr_data.node_query,
+            edge_query=pr_data.edge_query,
+            graph_name=pr_data.graph_name,
+            graph_memory_gb=pr_data.graph_memory_gb,
+            s3_staging_bucket=pr_data.s3_staging_bucket,
+            project_id=p.id,
+        )
 
-        for pr_data in projections_data:
-            projection_store.create(
-                catalog=pr_data.catalog,
-                database=pr_data.database,
-                node_query=pr_data.node_query,
-                edge_query=pr_data.edge_query,
-                graph_name=pr_data.graph_name,
-                graph_memory_gb=pr_data.graph_memory_gb,
-                s3_staging_bucket=pr_data.s3_staging_bucket,
-                project_id=p.id,
-            )
-
-        created.append({"id": p.id, "name": p.name})
-
-    return {"imported": created}
+    return {"imported": {"id": p.id, "name": p.name}}

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -17,10 +17,13 @@ from pydantic import BaseModel, Field
 
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
+from nx_neptune_proxy.utils.aws_helper import check_content_length
+from nx_neptune_proxy.utils.sanitize import sanitize_filename
 
 router = APIRouter(prefix="/api/v0/project", tags=["project-io"])
 
 MAX_IMPORT_SIZE = 5 * 1024 * 1024  # 5 MB
+MAX_PROJECT_NAME_LENGTH = 100
 
 
 # --- Export/Import JSON schema ---
@@ -99,7 +102,7 @@ def export_project(project_id: str):
 
     return JSONResponse(
         content=payload,
-        headers={"Content-Disposition": f'attachment; filename="{p.name}.json"'},
+        headers={"Content-Disposition": f'attachment; filename="{sanitize_filename(p.name)}.json"'},
     )
 
 
@@ -121,13 +124,11 @@ async def import_project(request: Request):
     - Unknown fields are rejected (extra='forbid')
     """
     # Size check
-    content_length = request.headers.get("content-length")
-    if content_length and int(content_length) > MAX_IMPORT_SIZE:
-        raise HTTPException(status_code=413, detail="Payload too large (max 5 MB)")
+    check_content_length(request, MAX_IMPORT_SIZE)
 
     contents = await request.body()
     if len(contents) > MAX_IMPORT_SIZE:
-        raise HTTPException(status_code=413, detail="Payload too large (max 5 MB)")
+        raise HTTPException(status_code=413, detail=f"Payload too large (max {MAX_IMPORT_SIZE // (1024 * 1024)} MB)")
 
     # Parse and validate
     try:
@@ -135,8 +136,12 @@ async def import_project(request: Request):
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid JSON: {e}")
 
-    # Create project
-    name = payload.project.get("name", "Imported Project")
+    # Validate and create project
+    name = payload.project.get("name", "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Project name is required")
+    if len(name) > MAX_PROJECT_NAME_LENGTH:
+        raise HTTPException(status_code=400, detail=f"Project name too long (max {MAX_PROJECT_NAME_LENGTH} characters)")
     p = project_store.create(name=name)
 
     # Create projections

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -4,8 +4,7 @@
 from typing import Any, Callable
 
 from botocore.exceptions import ClientError
-from fastapi import HTTPException
-
+from fastapi import HTTPException, Request
 from nx_neptune_proxy.config import Settings
 
 
@@ -36,6 +35,19 @@ def assert_managed_graph(graph_name: str | None) -> None:
             status_code=403,
             detail=f"Refusing to delete graph '{graph_name or ''}': not managed by this tool (expected prefix '{prefix}')",
         )
+
+
+
+
+def check_content_length(request: Request, max_size: int) -> None:
+    """Reject early if Content-Length header exceeds max_size."""
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > max_size:
+                raise HTTPException(status_code=413, detail=f"Payload too large (max {max_size // (1024 * 1024)} MB)")
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid Content-Length header")
 
 
 def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:

--- a/proxy/src/nx_neptune_proxy/utils/sanitize.py
+++ b/proxy/src/nx_neptune_proxy/utils/sanitize.py
@@ -17,3 +17,13 @@ def sanitize_error_message(message: str) -> str:
     for pattern, replacement in _SENSITIVE_PATTERNS:
         message = pattern.sub(replacement, message)
     return message
+
+
+_SAFE_FILENAME_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ ")
+
+
+def sanitize_filename(name: str) -> str:
+    """Remove characters unsafe for filenames, collapse whitespace, truncate."""
+    cleaned = "".join(c if c in _SAFE_FILENAME_CHARS else "_" for c in name)
+    cleaned = "_".join(cleaned.split())  # collapse whitespace
+    return cleaned[:80] or "project"

--- a/proxy/tests/test_project_io.py
+++ b/proxy/tests/test_project_io.py
@@ -1,0 +1,217 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from nx_neptune_proxy.services.project_store import store as project_store
+from nx_neptune_proxy.services.projection_store import store as projection_store
+
+
+class TestProjectExport:
+    @pytest.mark.anyio
+    async def test_export_single_project(self, client):
+        p = project_store.create(name="Test Project")
+        projection_store.create(
+            catalog="AwsDataCatalog",
+            database="test_db",
+            node_query="SELECT id, name FROM nodes",
+            graph_name="nxp-test",
+            graph_memory_gb=32,
+            s3_staging_bucket="s3://bucket/staging",
+            project_id=p.id,
+        )
+
+        resp = await client.get(f"/api/v0/project/{p.id}/export")
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert data["version"] == "1.0"
+        assert data["project"]["name"] == "Test Project"
+        assert len(data["projections"]) == 1
+        assert data["projections"][0]["database"] == "test_db"
+        assert data["projections"][0]["graph_name"] == "nxp-test"
+        assert data["projections"][0]["graph_memory_gb"] == 32
+
+    @pytest.mark.anyio
+    async def test_export_excludes_runtime_state(self, client):
+        p = project_store.create(name="Test Project")
+        pr = projection_store.create(
+            database="db",
+            graph_name="nxp-test",
+            project_id=p.id,
+        )
+        # Simulate runtime state
+        projection_store.update(pr.id, status="running", step="import", progress=0.5, error="oops")
+
+        resp = await client.get(f"/api/v0/project/{p.id}/export")
+        data = resp.json()
+        proj_export = data["projections"][0]
+
+        # Runtime fields should not be present
+        assert "status" not in proj_export
+        assert "step" not in proj_export
+        assert "progress" not in proj_export
+        assert "error" not in proj_export
+        assert "graph_id" not in proj_export
+        assert "graph_endpoint" not in proj_export
+        assert "id" not in proj_export
+
+    @pytest.mark.anyio
+    async def test_export_not_found(self, client):
+        resp = await client.get("/api/v0/project/nonexistent/export")
+        assert resp.status_code == 404
+
+
+class TestProjectImport:
+    @pytest.mark.anyio
+    async def test_import_single_project(self, client):
+        payload = {
+            "version": "1.0",
+            "project": {"name": "Imported Project"},
+            "projections": [
+                {
+                    "catalog": "AwsDataCatalog",
+                    "database": "fraud_db",
+                    "node_query": "SELECT id FROM accounts",
+                    "edge_query": "SELECT src, dst FROM transfers",
+                    "graph_name": "nxp-fraud",
+                    "graph_memory_gb": 32,
+                    "s3_staging_bucket": "s3://my-bucket/staging",
+                }
+            ],
+        }
+
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 201
+
+        data = resp.json()
+        assert len(data["imported"]) == 1
+        assert data["imported"][0]["name"] == "Imported Project"
+
+        # Verify in DB
+        projects = project_store.list()
+        assert len(projects) == 1
+        assert projects[0].name == "Imported Project"
+
+        projections = projection_store.list()
+        assert len(projections) == 1
+        assert projections[0].database == "fraud_db"
+        assert projections[0].project_id == projects[0].id
+
+    @pytest.mark.anyio
+    async def test_import_multi_project(self, client):
+        payload = {
+            "version": "1.0",
+            "projects": [
+                {
+                    "project": {"name": "Project A"},
+                    "projections": [{"database": "db_a"}],
+                },
+                {
+                    "project": {"name": "Project B"},
+                    "projections": [{"database": "db_b1"}, {"database": "db_b2"}],
+                },
+            ],
+        }
+
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 201
+
+        data = resp.json()
+        assert len(data["imported"]) == 2
+
+        projects = project_store.list()
+        assert len(projects) == 2
+
+        projections = projection_store.list()
+        assert len(projections) == 3
+
+    @pytest.mark.anyio
+    async def test_import_creates_new_ids(self, client):
+        """Importing the same file twice creates duplicates with different IDs."""
+        payload = {
+            "version": "1.0",
+            "project": {"name": "Test"},
+            "projections": [{"database": "db"}],
+        }
+        content = json.dumps(payload)
+
+        await client.post("/api/v0/project/import", content=content)
+        await client.post("/api/v0/project/import", content=content)
+
+        projects = project_store.list()
+        assert len(projects) == 2
+        assert projects[0].id != projects[1].id
+
+    @pytest.mark.anyio
+    async def test_import_invalid_json(self, client):
+        resp = await client.post("/api/v0/project/import", content=b"not json")
+        assert resp.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_import_extra_fields_rejected(self, client):
+        payload = {
+            "version": "1.0",
+            "project": {"name": "Test"},
+            "projections": [{"database": "db", "hacker_field": "evil"}],
+        }
+
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_import_too_large(self, client):
+        # 6 MB of data
+        payload = {"version": "1.0", "project": {"name": "x" * (6 * 1024 * 1024)}, "projections": []}
+
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 413
+
+    @pytest.mark.anyio
+    async def test_import_missing_structure(self, client):
+        payload = {"version": "1.0"}
+
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 400
+
+
+class TestRoundTrip:
+    @pytest.mark.anyio
+    async def test_export_then_import(self, client):
+        """Export a project, then import it — should recreate correctly."""
+        p = project_store.create(name="Round Trip")
+        projection_store.create(
+            database="rt_db",
+            node_query="SELECT 1",
+            graph_name="nxp-roundtrip",
+            graph_memory_gb=64,
+            project_id=p.id,
+        )
+
+        # Export
+        export_resp = await client.get(f"/api/v0/project/{p.id}/export")
+        assert export_resp.status_code == 200
+        export_data = export_resp.content
+
+        # Import
+        import_resp = await client.post(
+            "/api/v0/project/import",
+            content=export_data,
+        )
+        assert import_resp.status_code == 201
+
+        # Should now have 2 projects (original + imported)
+        projects = project_store.list()
+        assert len(projects) == 2
+
+        imported = [pr for pr in projects if pr.id != p.id][0]
+        assert imported.name == "Round Trip"
+
+        # Imported projection should match
+        projections = [pr for pr in projection_store.list() if pr.project_id == imported.id]
+        assert len(projections) == 1
+        assert projections[0].database == "rt_db"
+        assert projections[0].graph_name == "nxp-roundtrip"
+        assert projections[0].graph_memory_gb == 64

--- a/proxy/tests/test_project_io.py
+++ b/proxy/tests/test_project_io.py
@@ -11,7 +11,7 @@ from nx_neptune_proxy.services.projection_store import store as projection_store
 
 class TestProjectExport:
     @pytest.mark.anyio
-    async def test_export_single_project(self, client):
+    async def test_export_project(self, client):
         p = project_store.create(name="Test Project")
         projection_store.create(
             catalog="AwsDataCatalog",
@@ -66,7 +66,7 @@ class TestProjectExport:
 
 class TestProjectImport:
     @pytest.mark.anyio
-    async def test_import_single_project(self, client):
+    async def test_import_project(self, client):
         payload = {
             "version": "1.0",
             "project": {"name": "Imported Project"},
@@ -87,8 +87,7 @@ class TestProjectImport:
         assert resp.status_code == 201
 
         data = resp.json()
-        assert len(data["imported"]) == 1
-        assert data["imported"][0]["name"] == "Imported Project"
+        assert data["imported"]["name"] == "Imported Project"
 
         # Verify in DB
         projects = project_store.list()
@@ -99,34 +98,6 @@ class TestProjectImport:
         assert len(projections) == 1
         assert projections[0].database == "fraud_db"
         assert projections[0].project_id == projects[0].id
-
-    @pytest.mark.anyio
-    async def test_import_multi_project(self, client):
-        payload = {
-            "version": "1.0",
-            "projects": [
-                {
-                    "project": {"name": "Project A"},
-                    "projections": [{"database": "db_a"}],
-                },
-                {
-                    "project": {"name": "Project B"},
-                    "projections": [{"database": "db_b1"}, {"database": "db_b2"}],
-                },
-            ],
-        }
-
-        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
-        assert resp.status_code == 201
-
-        data = resp.json()
-        assert len(data["imported"]) == 2
-
-        projects = project_store.list()
-        assert len(projects) == 2
-
-        projections = projection_store.list()
-        assert len(projections) == 3
 
     @pytest.mark.anyio
     async def test_import_creates_new_ids(self, client):
@@ -170,7 +141,7 @@ class TestProjectImport:
         assert resp.status_code == 413
 
     @pytest.mark.anyio
-    async def test_import_missing_structure(self, client):
+    async def test_import_missing_project(self, client):
         payload = {"version": "1.0"}
 
         resp = await client.post("/api/v0/project/import", content=json.dumps(payload))

--- a/proxy/tests/test_project_io.py
+++ b/proxy/tests/test_project_io.py
@@ -186,3 +186,57 @@ class TestRoundTrip:
         assert projections[0].database == "rt_db"
         assert projections[0].graph_name == "nxp-roundtrip"
         assert projections[0].graph_memory_gb == 64
+
+
+# --- Additional validation tests ---
+
+
+class TestImportValidation:
+    @pytest.mark.anyio
+    async def test_import_empty_project_name(self, client):
+        """Empty project name should be rejected."""
+        payload = {"version": "1.0", "project": {"name": "   "}, "projections": []}
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 400
+        assert "name" in resp.json()["detail"].lower()
+
+    @pytest.mark.anyio
+    async def test_import_missing_project_name(self, client):
+        """Missing project name should be rejected."""
+        payload = {"version": "1.0", "project": {}, "projections": []}
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_import_project_name_too_long(self, client):
+        """Project name exceeding 100 chars should be rejected."""
+        payload = {"version": "1.0", "project": {"name": "x" * 101}, "projections": []}
+        resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
+        assert resp.status_code == 400
+        assert "too long" in resp.json()["detail"].lower()
+
+    @pytest.mark.anyio
+    async def test_import_invalid_content_length(self, client):
+        """Non-numeric Content-Length should return 400."""
+        payload = {"version": "1.0", "project": {"name": "Test"}, "projections": []}
+        resp = await client.post(
+            "/api/v0/project/import",
+            content=json.dumps(payload),
+            headers={"content-length": "not-a-number"},
+        )
+        assert resp.status_code == 400
+        assert "Content-Length" in resp.json()["detail"]
+
+
+class TestExportFilename:
+    @pytest.mark.anyio
+    async def test_export_sanitizes_filename(self, client):
+        """Special characters in project name should be sanitized in the filename."""
+        p = project_store.create(name='My Project / "Special" <chars>')
+        resp = await client.get(f"/api/v0/project/{p.id}/export")
+        assert resp.status_code == 200
+        disposition = resp.headers["content-disposition"]
+        # Should not contain the raw special characters
+        assert "/" not in disposition.split("filename=")[1]
+        assert "<" not in disposition.split("filename=")[1]
+        assert '"' not in disposition.split("filename=")[1].strip('"')

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -101,5 +101,5 @@ export const projectApi = {
   create: (name: string) => request<Project>("/project", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name }) }),
   delete: (id: string) => request<{ id: string; status: string }>(`/project/${id}`, { method: "DELETE" }),
   exportOne: (id: string) => request<unknown>(`/project/${id}/export`),
-  import: (data: unknown) => request<{ imported: { id: string; name: string }[] }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
+  import: (data: unknown) => request<{ imported: { id: string; name: string } }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
 };

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -100,6 +100,6 @@ export const projectApi = {
   list: () => request<Project[]>("/project"),
   create: (name: string) => request<Project>("/project", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name }) }),
   delete: (id: string) => request<{ id: string; status: string }>(`/project/${id}`, { method: "DELETE" }),
-  exportOne: (id: string) => request<unknown>(`/project/${id}/export`),
+  export: (id: string) => request<unknown>(`/project/${id}/export`),
   import: (data: unknown) => request<{ imported: { id: string; name: string } }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
 };

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -100,4 +100,6 @@ export const projectApi = {
   list: () => request<Project[]>("/project"),
   create: (name: string) => request<Project>("/project", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name }) }),
   delete: (id: string) => request<{ id: string; status: string }>(`/project/${id}`, { method: "DELETE" }),
+  exportOne: (id: string) => request<unknown>(`/project/${id}/export`),
+  import: (data: unknown) => request<{ imported: { id: string; name: string }[] }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
 };

--- a/proxy/ui-src/src/components/Sidebar.tsx
+++ b/proxy/ui-src/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { NavLink, useLocation, useNavigate } from "react-router";
-import { Network, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight, Circle, Plus, Trash2 } from "lucide-react";
+import { Network, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight, Circle, Plus, Trash2, Upload } from "lucide-react";
 import { clsx } from "clsx";
 import { projectApi, projection, type Project, type Projection } from "../api";
 
@@ -15,6 +15,7 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
   const [projects, setProjects] = useState<Project[]>([]);
   const [projections, setProjections] = useState<Projection[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -60,6 +61,22 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
 
   const projByProject = (projectId: string) => projections.filter(p => p.project_id === projectId);
 
+  async function handleImportFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      const result = await projectApi.import(data);
+      loadProjects();
+      window.dispatchEvent(new Event("projects-changed"));
+      navigate(`/projections?project=${result.imported.id}`);
+    } catch {
+      // silently fail — Projects page has better error display
+    }
+    e.target.value = "";
+  }
+
   return (
     <aside className={clsx("flex flex-col border-r border-gray-200 bg-white transition-all", collapsed ? "w-14" : "w-60")}>
       <div className="flex h-14 items-center justify-between border-b border-gray-200 px-3">
@@ -94,9 +111,22 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
           <div>
             <div className="flex items-center justify-between px-3">
               <span className="text-xs font-semibold uppercase text-gray-400">Projects</span>
-              <NavLink to="/projects" className="rounded p-0.5 text-gray-400 hover:text-gray-600" title="Add Project">
-                <Plus className="h-3 w-3" />
-              </NavLink>
+              <div className="flex items-center gap-1">
+                <button onClick={() => fileInputRef.current?.click()} className="rounded p-0.5 text-gray-400 hover:text-gray-600" title="Import Project">
+                  <Upload className="h-3 w-3" />
+                </button>
+                <NavLink to="/projects" className="rounded p-0.5 text-gray-400 hover:text-gray-600" title="Add Project">
+                  <Plus className="h-3 w-3" />
+                </NavLink>
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                onChange={handleImportFile}
+                aria-label="Import project file"
+              />
             </div>
             <div className="mt-2 space-y-0.5">
               {projects.map(proj => {

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams, NavLink } from "react-router";
 import { projection, metadata, projectApi, graphActions, type Projection, type Project, type Inflight } from "../api";
 import { Card, Button, RefreshButton } from "../components/ui";
-import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown } from "lucide-react";
+import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Download } from "lucide-react";
 import { useNavigate } from "react-router";
 
 export function Projections() {
@@ -151,6 +151,28 @@ export function Projections() {
         <div className="flex items-center justify-between">
           <h1 className="text-lg font-semibold">{projectName ? `${projectName} — Projections` : "Projections"}</h1>
           <div className="flex items-center gap-2">
+            {filterProjectId && (
+              <button
+                onClick={async () => {
+                  try {
+                    const data = await projectApi.exportOne(filterProjectId);
+                    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = url;
+                    a.download = `${projectName || "project"}.json`;
+                    a.click();
+                    URL.revokeObjectURL(url);
+                  } catch (e) {
+                    console.error("Export failed", e);
+                  }
+                }}
+                className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+                title="Export project"
+              >
+                <Download className="h-3.5 w-3.5" /> Export
+              </button>
+            )}
             <NavLink
               to={filterProjectId ? `/import?project=${filterProjectId}&t=${Date.now()}` : "/import"}
               className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -155,7 +155,7 @@ export function Projections() {
               <button
                 onClick={async () => {
                   try {
-                    const data = await projectApi.exportOne(filterProjectId);
+                    const data = await projectApi.export(filterProjectId);
                     const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
                     const url = URL.createObjectURL(blob);
                     const a = document.createElement("a");

--- a/proxy/ui-src/src/pages/Projects.tsx
+++ b/proxy/ui-src/src/pages/Projects.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useNavigate } from "react-router";
 import { projectApi } from "../api";
 import { Card, Button } from "../components/ui";
 
 export function Projects() {
   const [name, setName] = useState("");
+  const [importStatus, setImportStatus] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
 
   async function handleCreate() {
@@ -13,6 +15,29 @@ export function Projects() {
     setName("");
     window.dispatchEvent(new Event("projects-changed"));
     navigate(`/projections?project=${project.id}`);
+  }
+
+  function handleImportClick() {
+    fileInputRef.current?.click();
+  }
+
+  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      const result = await projectApi.import(data);
+      const count = result.imported.length;
+      setImportStatus(`Imported ${count} project${count !== 1 ? "s" : ""} successfully.`);
+      window.dispatchEvent(new Event("projects-changed"));
+    } catch (err) {
+      setImportStatus(`Import failed: ${err instanceof Error ? err.message : "Invalid file"}`);
+    }
+
+    // Reset input so the same file can be re-selected
+    e.target.value = "";
   }
 
   return (
@@ -33,7 +58,19 @@ export function Projects() {
             onKeyDown={(e) => e.key === "Enter" && handleCreate()}
           />
           <Button onClick={handleCreate} disabled={!name.trim()}>Create</Button>
+          <Button onClick={handleImportClick}>Import</Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={handleFileSelected}
+            aria-label="Import project file"
+          />
         </div>
+        {importStatus && (
+          <p className="mt-2 text-sm text-gray-600">{importStatus}</p>
+        )}
       </Card>
     </div>
   );

--- a/proxy/ui-src/src/pages/Projects.tsx
+++ b/proxy/ui-src/src/pages/Projects.tsx
@@ -29,8 +29,7 @@ export function Projects() {
       const text = await file.text();
       const data = JSON.parse(text);
       const result = await projectApi.import(data);
-      const count = result.imported.length;
-      setImportStatus(`Imported ${count} project${count !== 1 ? "s" : ""} successfully.`);
+      setImportStatus(`Imported project "${result.imported.name}" successfully.`);
       window.dispatchEvent(new Event("projects-changed"));
     } catch (err) {
       setImportStatus(`Import failed: ${err instanceof Error ? err.message : "Invalid file"}`);


### PR DESCRIPTION
**Summary**

Add the ability to export a project's configuration as JSON and re-import it to recreate the project. Enables sharing project setups between environments, backing up before destructive changes, and onboarding teammates with a ready-to-run recipe.

**Changes**

- `proxy/src/nx_neptune_proxy/routers/project_io.py` — new router with export and import endpoints
- `proxy/src/nx_neptune_proxy/app.py` — register project_io router
- `proxy/ui-src/src/api/index.ts` — add `exportOne` and `import` API functions
- `proxy/ui-src/src/pages/Projections.tsx` — Export button per-project in header
- `proxy/ui-src/src/pages/Projects.tsx` — Import button next to Create
- `proxy/tests/test_project_io.py` — 11 tests

**Proposed data models**


<details>
<summary>Single project export</summary>

```json
{
    "version": "1.0",
    "project": {
      "name": "Fraud Detection"
    },
    "projections": [
      {
        "catalog": "AwsDataCatalog",
        "database": "fraud_db",
        "node_query": "SELECT id, name, account_type FROM accounts",
        "edge_query": "SELECT src, dst, amount FROM transfers",
        "graph_name": "nxp-fraud-ring",
        "graph_memory_gb": 32,
        "s3_staging_bucket": "s3://my-bucket/staging"
      },
      {
        "catalog": "AwsDataCatalog",
        "database": "fraud_db",
        "node_query": "SELECT id, risk_score FROM accounts",
        "edge_query": "SELECT src, dst, frequency FROM call_records",
        "graph_name": "nxp-fraud-calls",
        "graph_memory_gb": 16,
        "s3_staging_bucket": "s3://my-bucket/staging"
      }
    ]
  }
```
</details>

**UI Changes**

<img width="1034" height="327" alt="Screenshot 2026-07-31 at 12 01 41 PM" src="https://github.com/user-attachments/assets/1dc7129a-4e8e-4876-9589-ea95e955ecc9" />
<img width="858" height="423" alt="Screenshot 2026-07-31 at 11 58 24 AM" src="https://github.com/user-attachments/assets/6688ed22-f8e7-4926-ae65-601a5b3bd088" />





**Endpoints**

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/v0/project/{id}/export` | Download project + projections as JSON |
| `POST` | `/api/v0/project/import` | Create project(s) from JSON payload |

**Testing**

11 tests pass covering: single/multi export, round-trip, duplicate imports generate new IDs, extra fields rejected, size limit enforced, invalid JSON rejected. Full suite: 103 passed.