### PR TITLE
Fix: Pass explicit limit=10 to preview endpoint

### DIFF
--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -157,7 +157,7 @@ export function Import() {
     setLoading("preview");
     try {
       const id = await ensureProjection();
-      const res = await projection.preview(id);
+      const res = await projection.preview(id, 10);
       if (res.error) setError(res.error);
       else setPreview(res.results);
     } catch (e: any) { setError(e.message); } finally { setLoading(null); }


### PR DESCRIPTION
**Description:**

The UI was relying on the server default for preview row count.
Make it explicit so the intent is clear and the behavior doesn't silently change if the server default is modified.
