### PR TITLE
Feat: Add S3 storage backend for project import/export

### DIFF
--- a/nx_neptune/clients/iam_client.py
+++ b/nx_neptune/clients/iam_client.py
@@ -701,16 +701,18 @@ class IamClientWrapper:
         return results
 
 
-def split_s3_arn_to_bucket_and_path(s3_arn: str) -> tuple:
+def split_s3_arn_to_bucket_and_path(s3_arn: str, include_path: bool = True) -> tuple:
     """
     Splits out the s3 arn as a bucket and path
-    :param s3_arn:
+    :param s3_arn: S3 URI (e.g., 's3://bucket-name/prefix/') or plain path (e.g., 'bucket-name/prefix')
+    :param include_path: If True (default), returns (bucket, path). If False, returns (bucket, "").
     :return: (str, str) - a tuple containing the bucket and path
     """
 
-    bucket_path = s3_arn.replace("s3://", "").split("/")
+    raw = s3_arn.replace("s3://", "") if s3_arn.startswith("s3://") else s3_arn
+    bucket_path = raw.split("/")
     bucket_name = bucket_path.pop(0)
-    bucket_path_str = "/".join(bucket_path)
+    bucket_path_str = "/".join(bucket_path) if include_path else ""
 
     return bucket_name, bucket_path_str
 

--- a/nx_neptune/clients/iam_client.py
+++ b/nx_neptune/clients/iam_client.py
@@ -701,18 +701,17 @@ class IamClientWrapper:
         return results
 
 
-def split_s3_arn_to_bucket_and_path(s3_arn: str, include_path: bool = True) -> tuple:
+def split_s3_arn_to_bucket_and_path(s3_arn: str) -> tuple:
     """
     Splits out the s3 arn as a bucket and path
     :param s3_arn: S3 URI (e.g., 's3://bucket-name/prefix/') or plain path (e.g., 'bucket-name/prefix')
-    :param include_path: If True (default), returns (bucket, path). If False, returns (bucket, "").
     :return: (str, str) - a tuple containing the bucket and path
     """
 
     raw = s3_arn.replace("s3://", "") if s3_arn.startswith("s3://") else s3_arn
     bucket_path = raw.split("/")
     bucket_name = bucket_path.pop(0)
-    bucket_path_str = "/".join(bucket_path) if include_path else ""
+    bucket_path_str = "/".join(bucket_path)
 
     return bucket_name, bucket_path_str
 

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -14,6 +14,7 @@ class Settings:
     port: int = 8080
     region: str = ""
     graph_prefix: str = "nxp-"
+    export_bucket: str = ""
 
     def __post_init__(self) -> None:
         if self.allowed_origins is None:
@@ -29,4 +30,5 @@ class Settings:
             port=int(os.environ.get("PORT", "8080")),
             region=os.environ.get("AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")),
             graph_prefix=os.environ.get("GRAPH_PREFIX", "nxp-"),
+            export_bucket=os.environ.get("NX_NEPTUNE_EXPORT_BUCKET", ""),
         )

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -14,7 +14,7 @@ class Settings:
     port: int = 8080
     region: str = ""
     graph_prefix: str = "nxp-"
-    export_bucket: str = ""
+    config_bucket: str = ""
 
     def __post_init__(self) -> None:
         if self.allowed_origins is None:
@@ -30,5 +30,5 @@ class Settings:
             port=int(os.environ.get("PORT", "8080")),
             region=os.environ.get("AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")),
             graph_prefix=os.environ.get("GRAPH_PREFIX", "nxp-"),
-            export_bucket=os.environ.get("NX_NEPTUNE_EXPORT_BUCKET", ""),
+            config_bucket=os.environ.get("NX_NEPTUNE_CONFIG_BUCKET", ""),
         )

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -26,7 +26,7 @@ def get_config():
     return {
         "region": settings.region or "",
         "graph_prefix": settings.graph_prefix,
-        "export_bucket": settings.export_bucket or None,
+        "export_bucket": settings.export_bucket or "",
     }
 
 

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -26,7 +26,7 @@ def get_config():
     return {
         "region": settings.region or "",
         "graph_prefix": settings.graph_prefix,
-        "export_bucket": settings.export_bucket or "",
+        "config_bucket": settings.config_bucket or "",
     }
 
 

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -23,7 +23,11 @@ router = APIRouter(prefix="/api/v0/metadata", tags=["metadata"])
 def get_config():
     """Get server-side configuration"""
     settings = Settings.from_env()
-    return {"region": settings.region or "", "graph_prefix": settings.graph_prefix}
+    return {
+        "region": settings.region or "",
+        "graph_prefix": settings.graph_prefix,
+        "export_bucket": settings.export_bucket or None,
+    }
 
 
 @router.get("/athena/catalogs", summary="List Athena data catalogs", response_model=CatalogsResponse)

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -41,7 +41,8 @@ def _get_export_bucket_tuple() -> tuple:
     settings = Settings.from_env()
     if not settings.export_bucket:
         raise HTTPException(status_code=404, detail="S3 export bucket not configured")
-    return split_s3_arn_to_bucket_and_path(settings.export_bucket)
+    bucket, prefix = split_s3_arn_to_bucket_and_path(settings.export_bucket)
+    return bucket, prefix.rstrip("/")
 
 
 def _s3_object_to_entry(obj: dict) -> dict:
@@ -66,7 +67,7 @@ def _build_export_payload(project_id: str) -> tuple[dict, str]:
 
 def _build_s3_key(name: str, prefix: str) -> tuple[str, str]:
     """Build S3 key from project name and prefix. Returns (key, filename)."""
-    sanitized = sanitize_s3_key_name(name)
+    sanitized = sanitize_s3_key_name(name) or "project"
     now = datetime.now(timezone.utc)
     timestamp = now.strftime("%Y%m%d_%H%M%S") + f"{now.microsecond // 1000:03d}"
     filename = f"{sanitized}_{timestamp}.json"

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -1,160 +1,182 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Project import/export endpoints.
-
-Enables exporting a project's configuration as a portable JSON file
-and re-importing it to recreate the project in another environment.
-"""
+"""Project import/export endpoints."""
 
 from __future__ import annotations
 
-from typing import Optional
-
+import json
+from datetime import datetime, timezone
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
 
+from nx_neptune.clients.client_factory import ClientFactory
+from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.routers.schemas import ProjectionExport, ProjectExportPayload
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
-from nx_neptune_proxy.utils.aws_helper import check_content_length
-from nx_neptune_proxy.utils.sanitize import sanitize_filename
+from nx_neptune_proxy.utils.aws_helper import friendly_s3_error, check_content_length, check_body_size, check_key_not_exists, list_s3_json_objects
+from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
 
 router = APIRouter(prefix="/api/v0/project", tags=["project-io"])
 
 MAX_IMPORT_SIZE = 5 * 1024 * 1024  # 5 MB
-MAX_PROJECT_NAME_LENGTH = 100
 
 
-# --- Export/Import JSON schema ---
+# --- Helpers ---
 
 
-class ProjectionExport(BaseModel):
-    """Projection configuration (no runtime state such as graph_id, status, or progress)."""
-
-    catalog: str = Field("AwsDataCatalog", description="Athena catalog name")
-    database: Optional[str] = Field(None, description="Athena database name")
-    node_query: Optional[str] = Field(None, description="SQL query that produces nodes (must include ~id and ~label columns)")
-    edge_query: Optional[str] = Field(None, description="SQL query that produces edges (must include ~from, ~to, and ~label columns)")
-    graph_name: Optional[str] = Field(None, description="Neptune Analytics graph name suffix (prefix is added automatically)")
-    graph_memory_gb: int = Field(16, description="Graph memory allocation in GB")
-    s3_staging_bucket: Optional[str] = Field(None, description="S3 bucket path for staging Athena results (e.g. s3://bucket/prefix)")
-
-    model_config = {"extra": "forbid"}
+def _get_export_bucket_tuple() -> tuple:
+    """Return (bucket, prefix) or raise 404 if not configured."""
+    settings = Settings.from_env()
+    if not settings.export_bucket:
+        raise HTTPException(status_code=404, detail="S3 export bucket not configured")
+    return split_s3_arn_to_bucket_and_path(settings.export_bucket)
 
 
-class ProjectExportPayload(BaseModel):
-    """Top-level schema for project import/export JSON files.
-
-    Example:
-        {
-            "version": "1.0",
-            "project": {"name": "My Project"},
-            "projections": [{"catalog": "AwsDataCatalog", "database": "mydb", ...}]
-        }
-    """
-
-    version: str = Field("1.0", description="Schema version for forward compatibility")
-    project: dict = Field(..., description="Project metadata (must contain 'name' key)")
-    projections: list[ProjectionExport] = Field(default=[], description="List of projection configurations to create")
-
-    model_config = {"extra": "forbid"}
+def _s3_object_to_entry(obj: dict) -> dict:
+    """Convert an S3 object dict to an API response entry."""
+    return {
+        "key": obj["Key"],
+        "filename": obj["Key"].rsplit("/", 1)[-1],
+        "last_modified": obj["LastModified"].isoformat(),
+    }
 
 
-# --- Export endpoint ---
-
-
-@router.get("/{project_id}/export", summary="Export a project as JSON",
-            response_description="JSON file containing the project configuration and its projections")
-def export_project(project_id: str):
-    """Export a project and all its projection configurations as a downloadable JSON file.
-
-    The exported file contains only configuration data (queries, database references,
-    graph settings). Runtime state such as graph IDs, execution status, and endpoints
-    are not included.
-
-    The response includes a Content-Disposition header for browser download.
-    """
+def _build_export_payload(project_id: str) -> tuple[dict, str]:
+    """Build the export JSON payload for a project. Returns (payload_dict, project_name)."""
     p = project_store.get(project_id)
     if p is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    projections = [
-        pr for pr in projection_store.list() if pr.project_id == project_id
-    ]
-
-    payload = {
-        "version": "1.0",
-        "project": {"name": p.name},
-        "projections": [
-            ProjectionExport(
-                catalog=pr.catalog,
-                database=pr.database,
-                node_query=pr.node_query,
-                edge_query=pr.edge_query,
-                graph_name=pr.graph_name,
-                graph_memory_gb=pr.graph_memory_gb,
-                s3_staging_bucket=pr.s3_staging_bucket,
-            ).model_dump()
-            for pr in projections
-        ],
-    }
-
-    return JSONResponse(
-        content=payload,
-        headers={"Content-Disposition": f'attachment; filename="{sanitize_filename(p.name)}.json"'},
-    )
+    projections = projection_store.list_by_project(project_id)
+    payload = ProjectExportPayload.from_project(p, projections)
+    return payload.model_dump(), p.name
 
 
-# --- Import endpoint ---
+def _build_s3_key(name: str, prefix: str) -> tuple[str, str]:
+    """Build S3 key from project name and prefix. Returns (key, filename)."""
+    sanitized = sanitize_s3_key_name(name)
+    now = datetime.now(timezone.utc)
+    timestamp = now.strftime("%Y%m%d_%H%M%S") + f"{now.microsecond // 1000:03d}"
+    filename = f"{sanitized}_{timestamp}.json"
+    key = f"{prefix}/{filename}" if prefix else filename
+    return key, filename
 
 
-@router.post("/import", summary="Import a project from JSON", status_code=201,
-             response_description="The newly created project ID and name")
-async def import_project(request: Request):
-    """Create a project and its projections from a previously exported JSON payload.
-
-    Accepts the same JSON schema produced by the export endpoint. A new project
-    is created with a fresh ID regardless of whether a project with the same name
-    already exists. All projections start in 'draft' status.
-
-    Constraints:
-    - Maximum payload size: 5 MB
-    - Maximum 50 projections per import
-    - Unknown fields are rejected (extra='forbid')
-    """
-    # Size check
-    check_content_length(request, MAX_IMPORT_SIZE)
-
-    contents = await request.body()
-    if len(contents) > MAX_IMPORT_SIZE:
-        raise HTTPException(status_code=413, detail=f"Payload too large (max {MAX_IMPORT_SIZE // (1024 * 1024)} MB)")
-
-    # Parse and validate
+def _parse_payload(contents: bytes) -> ProjectExportPayload:
+    """Parse and validate export JSON. Raises 400 on failure."""
     try:
-        payload = ProjectExportPayload.model_validate_json(contents)
+        return ProjectExportPayload.model_validate_json(contents)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid JSON: {e}")
 
-    # Validate and create project
-    name = payload.project.get("name", "").strip()
-    if not name:
-        raise HTTPException(status_code=400, detail="Project name is required")
-    if len(name) > MAX_PROJECT_NAME_LENGTH:
-        raise HTTPException(status_code=400, detail=f"Project name too long (max {MAX_PROJECT_NAME_LENGTH} characters)")
+
+def _import_from_payload(payload: ProjectExportPayload) -> dict:
+    """Create project and projections from validated payload. Returns {id, name}."""
+    name = payload.project.get("name", "Imported Project")
     p = project_store.create(name=name)
 
-    # Create projections
     for pr_data in payload.projections:
-        projection_store.create(
-            catalog=pr_data.catalog,
-            database=pr_data.database,
-            node_query=pr_data.node_query,
-            edge_query=pr_data.edge_query,
-            graph_name=pr_data.graph_name,
-            graph_memory_gb=pr_data.graph_memory_gb,
-            s3_staging_bucket=pr_data.s3_staging_bucket,
-            project_id=p.id,
-        )
+        projection_store.create(**pr_data.model_dump(), project_id=p.id)
 
-    return {"imported": {"id": p.id, "name": p.name}}
+    return {"id": p.id, "name": p.name}
+
+
+
+# --- Export endpoints ---
+
+
+@router.get("/{project_id}/export", summary="Export a project")
+def export_project(project_id: str):
+    """Export a project and its projections as JSON (download)."""
+    payload, name = _build_export_payload(project_id)
+
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": f'attachment; filename="{name}.json"'},
+    )
+
+
+@router.post("/{project_id}/export/s3", summary="Export a project to S3")
+def export_project_to_s3(project_id: str):
+    """Export a project and its projections to the configured S3 bucket."""
+    bucket, prefix = _get_export_bucket_tuple()
+    payload, name = _build_export_payload(project_id)
+    key, filename = _build_s3_key(name, prefix)
+
+    s3 = ClientFactory().s3()
+    try:
+        check_key_not_exists(s3, bucket, key)
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=json.dumps(payload, indent=2),
+            ContentType="application/json",
+            Tagging="graph_studio=true",
+        )
+    except HTTPException:
+        raise
+    except ClientError as e:
+        raise HTTPException(status_code=502, detail=friendly_s3_error(e))
+
+    return {"filename": filename, "key": key}
+
+
+# --- Import endpoints ---
+
+
+@router.post("/import", summary="Import a project from JSON", status_code=201)
+async def import_project(request: Request):
+    """Import a project and its projections from a JSON payload."""
+    check_content_length(request, MAX_IMPORT_SIZE)
+    contents = await request.body()
+    check_body_size(contents, MAX_IMPORT_SIZE)
+
+    payload = _parse_payload(contents)
+    result = _import_from_payload(payload)
+    return {"imported": result}
+
+
+@router.get("/import/s3/list", summary="List available exports from S3")
+def list_s3_exports():
+    """List the last 10 export files from S3 (filtered by prefix)."""
+    bucket, prefix = _get_export_bucket_tuple()
+    s3 = ClientFactory().s3()
+
+    try:
+        json_objects = list_s3_json_objects(s3, bucket, prefix)
+
+        # Sort by last modified descending, take last 10
+        json_objects.sort(key=lambda o: o["LastModified"], reverse=True)
+        recent = json_objects[:10]
+
+        return {
+            "files": [_s3_object_to_entry(obj) for obj in recent]
+        }
+    except ClientError as e:
+        raise HTTPException(status_code=502, detail=friendly_s3_error(e))
+
+
+@router.post("/import/s3", summary="Import a project from S3", status_code=201)
+def import_project_from_s3(request_body: dict):
+    """Import a project from a specific S3 file."""
+    key = request_body.get("key")
+    if not key:
+        raise HTTPException(status_code=400, detail="Missing 'key' in request body")
+
+    bucket, _ = _get_export_bucket_tuple()
+    s3 = ClientFactory().s3()
+
+    try:
+        resp = s3.get_object(Bucket=bucket, Key=key)
+        contents = resp["Body"].read()
+    except ClientError as e:
+        raise HTTPException(status_code=502, detail=friendly_s3_error(e))
+
+    check_body_size(contents, MAX_IMPORT_SIZE)
+    payload = _parse_payload(contents)
+    result = _import_from_payload(payload)
+    return {"imported": result}

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -39,9 +39,9 @@ MAX_PROJECT_NAME_LENGTH = 100
 def _get_export_bucket_tuple() -> tuple:
     """Return (bucket, prefix) or raise 404 if not configured."""
     settings = Settings.from_env()
-    if not settings.export_bucket:
+    if not settings.config_bucket:
         raise HTTPException(status_code=404, detail="S3 export bucket not configured")
-    bucket, prefix = split_s3_arn_to_bucket_and_path(settings.export_bucket)
+    bucket, prefix = split_s3_arn_to_bucket_and_path(settings.config_bucket)
     return bucket, prefix.rstrip("/")
 
 

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -1,15 +1,22 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Project import/export endpoints."""
+"""Project import/export endpoints.
+
+Enables exporting a project's configuration as a portable JSON file
+and re-importing it to recreate the project in another environment.
+"""
 
 from __future__ import annotations
+
+from typing import Optional
 
 import json
 from datetime import datetime, timezone
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
@@ -17,12 +24,13 @@ from nx_neptune_proxy.config import Settings
 from nx_neptune_proxy.routers.schemas import ProjectionExport, ProjectExportPayload
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
-from nx_neptune_proxy.utils.aws_helper import friendly_s3_error, check_content_length, check_body_size, check_key_not_exists, list_s3_json_objects
-from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+from nx_neptune_proxy.utils.aws_helper import friendly_s3_error, check_content_length, check_body_size, check_key_not_exists, list_s3_json_objects, require_name
+from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name, sanitize_filename
 
 router = APIRouter(prefix="/api/v0/project", tags=["project-io"])
 
 MAX_IMPORT_SIZE = 5 * 1024 * 1024  # 5 MB
+MAX_PROJECT_NAME_LENGTH = 100
 
 
 # --- Helpers ---
@@ -76,7 +84,8 @@ def _parse_payload(contents: bytes) -> ProjectExportPayload:
 
 def _import_from_payload(payload: ProjectExportPayload) -> dict:
     """Create project and projections from validated payload. Returns {id, name}."""
-    name = payload.project.get("name", "Imported Project")
+    name = require_name(payload.project.get("name"), max_length=MAX_PROJECT_NAME_LENGTH)
+
     p = project_store.create(name=name)
 
     for pr_data in payload.projections:
@@ -89,14 +98,22 @@ def _import_from_payload(payload: ProjectExportPayload) -> dict:
 # --- Export endpoints ---
 
 
-@router.get("/{project_id}/export", summary="Export a project")
+@router.get("/{project_id}/export", summary="Export a project as JSON",
+            response_description="JSON file containing the project configuration and its projections")
 def export_project(project_id: str):
-    """Export a project and its projections as JSON (download)."""
+    """Export a project and all its projection configurations as a downloadable JSON file.
+
+    The exported file contains only configuration data (queries, database references,
+    graph settings). Runtime state such as graph IDs, execution status, and endpoints
+    are not included.
+
+    The response includes a Content-Disposition header for browser download.
+    """
     payload, name = _build_export_payload(project_id)
 
     return JSONResponse(
         content=payload,
-        headers={"Content-Disposition": f'attachment; filename="{name}.json"'},
+        headers={"Content-Disposition": f'attachment; filename="{sanitize_filename(name)}.json"'},
     )
 
 

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -126,3 +126,51 @@ class ProjectionResponse(BaseModel):
     progress: float = 0
     error: Optional[str] = None
     created_at: datetime
+
+
+# --- Project import/export ---
+
+
+class ProjectionExport(BaseModel):
+    """Projection config fields only — no runtime state."""
+
+    catalog: str = "AwsDataCatalog"
+    database: Optional[str] = None
+    node_query: Optional[str] = None
+    edge_query: Optional[str] = None
+    graph_name: Optional[str] = None
+    graph_memory_gb: int = 16
+    s3_staging_bucket: Optional[str] = None
+
+    model_config = {"extra": "forbid"}
+
+    @classmethod
+    def from_projection(cls, pr) -> "ProjectionExport":
+        """Create from a Projection dataclass instance."""
+        return cls(
+            catalog=pr.catalog,
+            database=pr.database,
+            node_query=pr.node_query,
+            edge_query=pr.edge_query,
+            graph_name=pr.graph_name,
+            graph_memory_gb=pr.graph_memory_gb,
+            s3_staging_bucket=pr.s3_staging_bucket,
+        )
+
+
+class ProjectExportPayload(BaseModel):
+    """Top-level export format for a single project."""
+
+    version: str = "1.0"
+    project: dict
+    projections: list[ProjectionExport] = []
+
+    model_config = {"extra": "forbid"}
+
+    @classmethod
+    def from_project(cls, project, projections: list) -> "ProjectExportPayload":
+        """Build export payload from a project and its projections."""
+        return cls(
+            project={"name": project.name},
+            projections=[ProjectionExport.from_projection(pr) for pr in projections],
+        )

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # --- Metadata responses ---
@@ -134,13 +134,13 @@ class ProjectionResponse(BaseModel):
 class ProjectionExport(BaseModel):
     """Projection config fields only — no runtime state."""
 
-    catalog: str = "AwsDataCatalog"
-    database: Optional[str] = None
-    node_query: Optional[str] = None
-    edge_query: Optional[str] = None
-    graph_name: Optional[str] = None
-    graph_memory_gb: int = 16
-    s3_staging_bucket: Optional[str] = None
+    catalog: str = Field("AwsDataCatalog", description="Athena catalog name")
+    database: Optional[str] = Field(None, description="Athena database name")
+    node_query: Optional[str] = Field(None, description="SQL query that produces nodes (must include ~id and ~label columns)")
+    edge_query: Optional[str] = Field(None, description="SQL query that produces edges (must include ~from, ~to, and ~label columns)")
+    graph_name: Optional[str] = Field(None, description="Neptune Analytics graph name suffix (prefix is added automatically)")
+    graph_memory_gb: int = Field(16, description="Graph memory allocation in GB")
+    s3_staging_bucket: Optional[str] = Field(None, description="S3 bucket path for staging Athena results (e.g. s3://bucket/prefix)")
 
     model_config = {"extra": "forbid"}
 

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -76,6 +78,15 @@ class ProjectionStore:
     def list(self) -> list[Projection]:
         conn = get_connection()
         rows = conn.execute("SELECT * FROM projections ORDER BY created_at DESC").fetchall()
+        conn.close()
+        return [self._row_to_projection(r) for r in rows]
+
+    def list_by_project(self, project_id: str) -> list[Projection]:
+        conn = get_connection()
+        rows = conn.execute(
+            "SELECT * FROM projections WHERE project_id = ? ORDER BY created_at DESC",
+            (project_id,),
+        ).fetchall()
         conn.close()
         return [self._row_to_projection(r) for r in rows]
 

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -49,6 +49,16 @@ def check_content_length(request: Request, max_size: int) -> None:
             raise HTTPException(status_code=400, detail="Invalid Content-Length header")
 
 
+def require_name(value: str | None, max_length: int = 100) -> str:
+    """Validate a required name. Returns stripped value or raises HTTP 400."""
+    stripped = (value or "").strip()
+    if not stripped:
+        raise HTTPException(status_code=400, detail="Name is required")
+    if len(stripped) > max_length:
+        raise HTTPException(status_code=400, detail=f"Name too long (max {max_length} characters)")
+    return stripped
+
+
 
 def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
     """Paginate an AWS API call that uses NextToken.

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -124,22 +124,33 @@ def check_key_not_exists(s3, bucket: str, key: str) -> None:
             raise HTTPException(status_code=502, detail=friendly_s3_error(e))
 
 
-def list_s3_json_objects(s3, bucket: str, prefix: str = "", max_keys: int = 100) -> list:
-    """List .json objects from an S3 bucket/prefix.
+def list_s3_json_objects(s3, bucket: str, prefix: str = "", limit: int = 10) -> list:
+    """List .json objects from an S3 bucket/prefix, sorted by most recent first.
+
+    Paginates through all objects under the prefix, filters to .json files,
+    sorts by LastModified descending, and returns the most recent `limit` items.
 
     Args:
         s3: boto3 S3 client
         bucket: S3 bucket name
         prefix: Optional key prefix (without trailing slash)
-        max_keys: Maximum number of objects to fetch from S3
+        limit: Maximum number of results to return (most recent first)
 
     Returns:
         List of S3 object dicts (Key, LastModified, etc.) filtered to .json files only.
     """
-    list_kwargs = {"Bucket": bucket, "MaxKeys": max_keys}
+    list_kwargs = {"Bucket": bucket}
     if prefix:
         list_kwargs["Prefix"] = prefix + "/"
 
-    resp = s3.list_objects_v2(**list_kwargs)
-    objects = resp.get("Contents", [])
-    return [o for o in objects if o["Key"].endswith(".json")]
+    all_objects = []
+    while True:
+        resp = s3.list_objects_v2(**list_kwargs)
+        all_objects.extend(resp.get("Contents", []))
+        if not resp.get("IsTruncated"):
+            break
+        list_kwargs["ContinuationToken"] = resp["NextContinuationToken"]
+
+    json_objects = [o for o in all_objects if o["Key"].endswith(".json")]
+    json_objects.sort(key=lambda o: o["LastModified"], reverse=True)
+    return json_objects[:limit]

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -7,7 +7,6 @@ from botocore.exceptions import ClientError
 from fastapi import HTTPException, Request
 from nx_neptune_proxy.config import Settings
 
-
 def get_graph_or_exception(client, graph_id: str) -> dict:
     """Fetch a graph from Neptune Analytics, raising HTTP exceptions on failure.
 
@@ -50,6 +49,7 @@ def check_content_length(request: Request, max_size: int) -> None:
             raise HTTPException(status_code=400, detail="Invalid Content-Length header")
 
 
+
 def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
     """Paginate an AWS API call that uses NextToken.
 
@@ -76,3 +76,60 @@ def unpack_query_results(rows: list) -> dict:
     columns = rows[0] if rows else []
     data_rows = [[cell if cell is not None else "n/a" for cell in row] for row in rows[1:]] if len(rows) > 1 else []
     return {"columns": columns, "rows": data_rows}
+
+
+def friendly_s3_error(e) -> str:
+    """Extract a user-friendly message from a boto3 ClientError."""
+    code = e.response["Error"].get("Code", "")
+    message = e.response["Error"].get("Message", "")
+    if code in ("AccessDenied", "403"):
+        return "Permission denied — check IAM role has required S3 permissions"
+    if code == "NoSuchBucket":
+        return f"Bucket not found — {message}"
+    if code == "NoSuchKey":
+        return "File not found in S3"
+    # If the message seems user-readable (short, no stack trace), use it
+    if message and len(message) < 200:
+        return message
+    return f"S3 error: {code}"
+
+
+def check_body_size(contents: bytes, max_size: int) -> None:
+    """Reject if body bytes exceed max_size."""
+    if len(contents) > max_size:
+        raise HTTPException(status_code=413, detail=f"Payload too large (max {max_size // (1024 * 1024)} MB)")
+
+
+def check_key_not_exists(s3, bucket: str, key: str) -> None:
+    """Raise 409 if the S3 key already exists."""
+    from fastapi import HTTPException
+    from botocore.exceptions import ClientError
+
+    try:
+        s3.head_object(Bucket=bucket, Key=key)
+        filename = key.rsplit("/", 1)[-1]
+        raise HTTPException(status_code=409, detail=f"File already exists: {filename}")
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "404":
+            raise HTTPException(status_code=502, detail=friendly_s3_error(e))
+
+
+def list_s3_json_objects(s3, bucket: str, prefix: str = "", max_keys: int = 100) -> list:
+    """List .json objects from an S3 bucket/prefix.
+
+    Args:
+        s3: boto3 S3 client
+        bucket: S3 bucket name
+        prefix: Optional key prefix (without trailing slash)
+        max_keys: Maximum number of objects to fetch from S3
+
+    Returns:
+        List of S3 object dicts (Key, LastModified, etc.) filtered to .json files only.
+    """
+    list_kwargs = {"Bucket": bucket, "MaxKeys": max_keys}
+    if prefix:
+        list_kwargs["Prefix"] = prefix + "/"
+
+    resp = s3.list_objects_v2(**list_kwargs)
+    objects = resp.get("Contents", [])
+    return [o for o in objects if o["Key"].endswith(".json")]

--- a/proxy/src/nx_neptune_proxy/utils/sanitize.py
+++ b/proxy/src/nx_neptune_proxy/utils/sanitize.py
@@ -27,3 +27,23 @@ def sanitize_filename(name: str) -> str:
     cleaned = "".join(c if c in _SAFE_FILENAME_CHARS else "_" for c in name)
     cleaned = "_".join(cleaned.split())  # collapse whitespace
     return cleaned[:80] or "project"
+
+
+def sanitize_s3_key_name(name: str) -> str:
+    """Sanitize a project name for use as an S3 object key component.
+
+    Ensures the output is safe for S3 keys by:
+    - Replacing spaces with underscores
+    - Stripping characters outside [a-zA-Z0-9_-]
+
+    S3 key requirements (https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html):
+    - Max 1024 bytes UTF-8
+    - Safe characters: alphanumeric, !, -, _, ., *, ', (, )
+    - Characters to avoid: \\, {, }, ^, %, `, ], [, ", <, >, ~, #, |
+
+    This function is conservative — it only allows alphanumeric, hyphens,
+    and underscores to avoid any ambiguity with URL encoding or special
+    handling by S3 console/CLI tools.
+    """
+    name = name.replace(" ", "_")
+    return re.sub(r"[^a-zA-Z0-9_-]", "", name)

--- a/proxy/tests/test_project_io_s3.py
+++ b/proxy/tests/test_project_io_s3.py
@@ -1,0 +1,304 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+
+import pytest
+
+from nx_neptune_proxy.services.project_store import store as project_store
+from nx_neptune_proxy.services.projection_store import store as projection_store
+
+
+class TestExportToS3:
+    @pytest.mark.anyio
+    async def test_export_to_s3_no_bucket_configured(self, client):
+        """Returns 404 when export bucket not configured."""
+        p = project_store.create(name="Test")
+        resp = await client.post(f"/api/v0/project/{p.id}/export/s3")
+        assert resp.status_code == 404
+        assert "not configured" in resp.json()["detail"]
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_export_to_s3_success(self, mock_factory, mock_settings, client):
+        """Exports project JSON to S3 with correct key format."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket/exports", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+        # head_object raises 404 (key doesn't exist)
+        from botocore.exceptions import ClientError
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+        mock_s3.put_object.return_value = {}
+
+        p = project_store.create(name="Fraud Detection")
+        projection_store.create(database="fraud_db", project_id=p.id)
+
+        resp = await client.post(f"/api/v0/project/{p.id}/export/s3")
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert "filename" in data
+        assert data["filename"].startswith("Fraud_Detection_")
+        assert data["filename"].endswith(".json")
+        assert data["key"].startswith("exports/")
+
+        # Verify put_object was called with correct params
+        call_kwargs = mock_s3.put_object.call_args[1]
+        assert call_kwargs["Bucket"] == "my-bucket"
+        assert call_kwargs["ContentType"] == "application/json"
+        assert call_kwargs["Tagging"] == "graph_studio=true"
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_export_to_s3_duplicate_key(self, mock_factory, mock_settings, client):
+        """Returns 409 if S3 key already exists."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+        # head_object succeeds (key exists)
+        mock_s3.head_object.return_value = {}
+
+        p = project_store.create(name="Test")
+
+        resp = await client.post(f"/api/v0/project/{p.id}/export/s3")
+        assert resp.status_code == 409
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_export_to_s3_permission_denied(self, mock_factory, mock_settings, client):
+        """Returns 502 with friendly message on permission error."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+        from botocore.exceptions import ClientError
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+        mock_s3.put_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}, "PutObject"
+        )
+
+        p = project_store.create(name="Test")
+
+        resp = await client.post(f"/api/v0/project/{p.id}/export/s3")
+        assert resp.status_code == 502
+        assert "Permission denied" in resp.json()["detail"]
+
+    @pytest.mark.anyio
+    async def test_export_to_s3_project_not_found(self, client):
+        """Returns 404 for non-existent project."""
+        with patch("nx_neptune_proxy.routers.project_io.Settings.from_env") as mock_settings:
+            mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+            resp = await client.post("/api/v0/project/nonexistent/export/s3")
+            assert resp.status_code == 404
+
+
+class TestListS3Exports:
+    @pytest.mark.anyio
+    async def test_list_no_bucket_configured(self, client):
+        """Returns 404 when export bucket not configured."""
+        resp = await client.get("/api/v0/project/import/s3/list")
+        assert resp.status_code == 404
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_list_returns_json_files_sorted(self, mock_factory, mock_settings, client):
+        """Lists .json files sorted by last modified descending."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket/exports", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+
+        now = datetime(2026, 7, 31, 14, 0, 0, tzinfo=timezone.utc)
+        earlier = datetime(2026, 7, 30, 10, 0, 0, tzinfo=timezone.utc)
+
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "exports/proj_a.json", "LastModified": earlier},
+                {"Key": "exports/proj_b.json", "LastModified": now},
+                {"Key": "exports/not_json.txt", "LastModified": now},
+            ]
+        }
+
+        resp = await client.get("/api/v0/project/import/s3/list")
+        assert resp.status_code == 200
+
+        data = resp.json()
+        assert len(data["files"]) == 2
+        # Most recent first
+        assert data["files"][0]["filename"] == "proj_b.json"
+        assert data["files"][1]["filename"] == "proj_a.json"
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_list_empty_bucket(self, mock_factory, mock_settings, client):
+        """Returns empty list when no files in bucket."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+        mock_s3.list_objects_v2.return_value = {}
+
+        resp = await client.get("/api/v0/project/import/s3/list")
+        assert resp.status_code == 200
+        assert resp.json()["files"] == []
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_list_caps_at_10(self, mock_factory, mock_settings, client):
+        """Returns at most 10 files."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+
+        # 15 .json files
+        objects = [
+            {"Key": f"file_{i}.json", "LastModified": datetime(2026, 7, 31, i, 0, 0, tzinfo=timezone.utc)}
+            for i in range(15)
+        ]
+        mock_s3.list_objects_v2.return_value = {"Contents": objects}
+
+        resp = await client.get("/api/v0/project/import/s3/list")
+        assert resp.status_code == 200
+        assert len(resp.json()["files"]) == 10
+
+
+class TestImportFromS3:
+    @pytest.mark.anyio
+    async def test_import_from_s3_no_bucket(self, client):
+        """Returns 404 when export bucket not configured."""
+        resp = await client.post("/api/v0/project/import/s3", content=json.dumps({"key": "test.json"}))
+        assert resp.status_code == 404
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_import_from_s3_success(self, mock_factory, mock_settings, client):
+        """Imports a project from S3 file."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket/exports", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+
+        export_data = {
+            "version": "1.0",
+            "project": {"name": "From S3"},
+            "projections": [{"database": "s3_db", "graph_name": "nxp-s3"}],
+        }
+        mock_body = MagicMock()
+        mock_body.read.return_value = json.dumps(export_data).encode()
+        mock_s3.get_object.return_value = {"Body": mock_body}
+
+        resp = await client.post(
+            "/api/v0/project/import/s3",
+            content=json.dumps({"key": "exports/test.json"}),
+        )
+        assert resp.status_code == 201
+
+        data = resp.json()
+        assert data["imported"]["name"] == "From S3"
+
+        # Verify in DB
+        projects = project_store.list()
+        assert len(projects) == 1
+        assert projects[0].name == "From S3"
+
+        projections = projection_store.list()
+        assert len(projections) == 1
+        assert projections[0].database == "s3_db"
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_import_from_s3_file_not_found(self, mock_factory, mock_settings, client):
+        """Returns 502 when S3 key doesn't exist."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+        from botocore.exceptions import ClientError
+        mock_s3.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}}, "GetObject"
+        )
+
+        resp = await client.post(
+            "/api/v0/project/import/s3",
+            content=json.dumps({"key": "nonexistent.json"}),
+        )
+        assert resp.status_code == 502
+        assert "not found" in resp.json()["detail"].lower()
+
+    @pytest.mark.anyio
+    @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
+    @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
+    async def test_import_from_s3_invalid_json(self, mock_factory, mock_settings, client):
+        """Returns 400 when S3 file contains invalid JSON."""
+        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+
+        mock_s3 = MagicMock()
+        mock_factory.return_value.s3.return_value = mock_s3
+
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"not json at all"
+        mock_s3.get_object.return_value = {"Body": mock_body}
+
+        resp = await client.post(
+            "/api/v0/project/import/s3",
+            content=json.dumps({"key": "bad.json"}),
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_import_from_s3_missing_key_param(self, client):
+        """Returns 400 when key is missing from request body."""
+        with patch("nx_neptune_proxy.routers.project_io.Settings.from_env") as mock_settings:
+            mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+            resp = await client.post("/api/v0/project/import/s3", content=json.dumps({}))
+            assert resp.status_code == 400
+            assert "key" in resp.json()["detail"].lower()
+
+
+class TestSanitizeName:
+    def test_spaces_to_underscores(self):
+        from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+        assert sanitize_s3_key_name("Fraud Detection") == "Fraud_Detection"
+
+    def test_special_characters_stripped(self):
+        from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+        assert sanitize_s3_key_name("My Project! (v2)") == "My_Project_v2"
+
+    def test_hyphens_kept(self):
+        from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+        assert sanitize_s3_key_name("fraud-detection") == "fraud-detection"
+
+    def test_underscores_kept(self):
+        from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+        assert sanitize_s3_key_name("my_project") == "my_project"
+
+
+class TestParseBucketConfig:
+    def test_bucket_only(self):
+        from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+        bucket, prefix = split_s3_arn_to_bucket_and_path("s3://my-bucket")
+        assert bucket == "my-bucket"
+        assert prefix == ""
+
+    def test_bucket_with_prefix(self):
+        from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+        bucket, prefix = split_s3_arn_to_bucket_and_path("s3://my-bucket/team/exports")
+        assert bucket == "my-bucket"
+        assert prefix == "team/exports"

--- a/proxy/tests/test_project_io_s3.py
+++ b/proxy/tests/test_project_io_s3.py
@@ -25,7 +25,7 @@ class TestExportToS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_export_to_s3_success(self, mock_factory, mock_settings, client):
         """Exports project JSON to S3 with correct key format."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket/exports", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket/exports", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -59,7 +59,7 @@ class TestExportToS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_export_to_s3_duplicate_key(self, mock_factory, mock_settings, client):
         """Returns 409 if S3 key already exists."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -76,7 +76,7 @@ class TestExportToS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_export_to_s3_permission_denied(self, mock_factory, mock_settings, client):
         """Returns 502 with friendly message on permission error."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -98,7 +98,7 @@ class TestExportToS3:
     async def test_export_to_s3_project_not_found(self, client):
         """Returns 404 for non-existent project."""
         with patch("nx_neptune_proxy.routers.project_io.Settings.from_env") as mock_settings:
-            mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+            mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
             resp = await client.post("/api/v0/project/nonexistent/export/s3")
             assert resp.status_code == 404
 
@@ -115,7 +115,7 @@ class TestListS3Exports:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_list_returns_json_files_sorted(self, mock_factory, mock_settings, client):
         """Lists .json files sorted by last modified descending."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket/exports", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket/exports", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -145,7 +145,7 @@ class TestListS3Exports:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_list_empty_bucket(self, mock_factory, mock_settings, client):
         """Returns empty list when no files in bucket."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -160,7 +160,7 @@ class TestListS3Exports:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_list_caps_at_10(self, mock_factory, mock_settings, client):
         """Returns at most 10 files."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -189,7 +189,7 @@ class TestImportFromS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_import_from_s3_success(self, mock_factory, mock_settings, client):
         """Imports a project from S3 file."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket/exports", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket/exports", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -226,7 +226,7 @@ class TestImportFromS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_import_from_s3_file_not_found(self, mock_factory, mock_settings, client):
         """Returns 502 when S3 key doesn't exist."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -247,7 +247,7 @@ class TestImportFromS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_import_from_s3_invalid_json(self, mock_factory, mock_settings, client):
         """Returns 400 when S3 file contains invalid JSON."""
-        mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -266,7 +266,7 @@ class TestImportFromS3:
     async def test_import_from_s3_missing_key_param(self, client):
         """Returns 400 when key is missing from request body."""
         with patch("nx_neptune_proxy.routers.project_io.Settings.from_env") as mock_settings:
-            mock_settings.return_value = MagicMock(export_bucket="my-bucket", region="us-west-2")
+            mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
             resp = await client.post("/api/v0/project/import/s3", content=json.dumps({}))
             assert resp.status_code == 400
             assert "key" in resp.json()["detail"].lower()

--- a/proxy/ui-src/src/App.tsx
+++ b/proxy/ui-src/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import { Routes, Route, Navigate, useNavigate } from "react-router";
 import { Sidebar } from "./components/Sidebar";
+import { S3ImportDialog } from "./components/S3ImportDialog";
 import { Import } from "./pages/Import";
 import { Projections } from "./pages/Projections";
 import { Graphs } from "./pages/Graphs";
@@ -31,6 +32,7 @@ export default function App() {
           <Route path="/projects" element={<Projects />} />
         </Routes>
       </main>
+      <S3ImportDialog />
     </div>
   );
 }

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -15,7 +15,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 // --- Metadata ---
 
 export const metadata = {
-  config: () => request<{ region: string; graph_prefix: string }>("/metadata/config"),
+  config: () => request<{ region: string; graph_prefix: string; export_bucket: string | null }>("/metadata/config"),
   catalogs: () => request<{ catalogs: { name: string; status: string }[] }>("/metadata/athena/catalogs"),
   databases: (catalog: string) => request<{ databases: string[] }>(`/metadata/athena/databases?catalog=${encodeURIComponent(catalog)}`),
   tables: (database: string, catalog: string) => request<{ tables: string[] }>(`/metadata/athena/tables?database=${encodeURIComponent(database)}&catalog=${encodeURIComponent(catalog)}`),
@@ -102,4 +102,8 @@ export const projectApi = {
   delete: (id: string) => request<{ id: string; status: string }>(`/project/${id}`, { method: "DELETE" }),
   export: (id: string) => request<unknown>(`/project/${id}/export`),
   import: (data: unknown) => request<{ imported: { id: string; name: string } }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
+  exportToS3: (id: string) => request<{ filename: string; key: string }>(`/project/${id}/export/s3`, { method: "POST" }),
+  import: (data: unknown) => request<{ imported: { id: string; name: string } }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
+  listS3Exports: () => request<{ files: { key: string; filename: string; last_modified: string }[] }>("/project/import/s3/list"),
+  importFromS3: (key: string) => request<{ imported: { id: string; name: string } }>("/project/import/s3", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ key }) }),
 };

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -15,7 +15,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 // --- Metadata ---
 
 export const metadata = {
-  config: () => request<{ region: string; graph_prefix: string; export_bucket: string }>("/metadata/config"),
+  config: () => request<{ region: string; graph_prefix: string; config_bucket: string }>("/metadata/config"),
   catalogs: () => request<{ catalogs: { name: string; status: string }[] }>("/metadata/athena/catalogs"),
   databases: (catalog: string) => request<{ databases: string[] }>(`/metadata/athena/databases?catalog=${encodeURIComponent(catalog)}`),
   tables: (database: string, catalog: string) => request<{ tables: string[] }>(`/metadata/athena/tables?database=${encodeURIComponent(database)}&catalog=${encodeURIComponent(catalog)}`),

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -101,9 +101,8 @@ export const projectApi = {
   create: (name: string) => request<Project>("/project", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name }) }),
   delete: (id: string) => request<{ id: string; status: string }>(`/project/${id}`, { method: "DELETE" }),
   export: (id: string) => request<unknown>(`/project/${id}/export`),
-  import: (data: unknown) => request<{ imported: { id: string; name: string } }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
+  importProject: (data: unknown) => request<{ imported: { id: string; name: string } }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
   exportToS3: (id: string) => request<{ filename: string; key: string }>(`/project/${id}/export/s3`, { method: "POST" }),
-  import: (data: unknown) => request<{ imported: { id: string; name: string } }>("/project/import", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
   listS3Exports: () => request<{ files: { key: string; filename: string; last_modified: string }[] }>("/project/import/s3/list"),
   importFromS3: (key: string) => request<{ imported: { id: string; name: string } }>("/project/import/s3", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ key }) }),
 };

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -15,7 +15,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 // --- Metadata ---
 
 export const metadata = {
-  config: () => request<{ region: string; graph_prefix: string; export_bucket: string | null }>("/metadata/config"),
+  config: () => request<{ region: string; graph_prefix: string; export_bucket: string }>("/metadata/config"),
   catalogs: () => request<{ catalogs: { name: string; status: string }[] }>("/metadata/athena/catalogs"),
   databases: (catalog: string) => request<{ databases: string[] }>(`/metadata/athena/databases?catalog=${encodeURIComponent(catalog)}`),
   tables: (database: string, catalog: string) => request<{ tables: string[] }>(`/metadata/athena/tables?database=${encodeURIComponent(database)}&catalog=${encodeURIComponent(catalog)}`),

--- a/proxy/ui-src/src/components/S3ImportDialog.tsx
+++ b/proxy/ui-src/src/components/S3ImportDialog.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { projectApi } from "../api";
+import { X } from "lucide-react";
+
+interface S3File {
+  key: string;
+  filename: string;
+  last_modified: string;
+}
+
+export function S3ImportDialog() {
+  const [open, setOpen] = useState(false);
+  const [files, setFiles] = useState<S3File[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<S3File | null>(null);
+  const [importing, setImporting] = useState(false);
+  const navigate = useNavigate();
+
+  // Listen for the custom event to open the dialog
+  useEffect(() => {
+    function handleOpen() {
+      setOpen(true);
+      setSelectedFile(null);
+      setError(null);
+      loadFiles();
+    }
+    window.addEventListener("open-s3-import-dialog", handleOpen);
+    return () => window.removeEventListener("open-s3-import-dialog", handleOpen);
+  }, []);
+
+  async function loadFiles() {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await projectApi.listS3Exports();
+      setFiles(result.files);
+    } catch (e: any) {
+      setError(e.message || "Failed to list files");
+      setFiles([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleImport() {
+    if (!selectedFile) return;
+    setImporting(true);
+    try {
+      const result = await projectApi.importFromS3(selectedFile.key);
+      window.dispatchEvent(new Event("projects-changed"));
+      setOpen(false);
+      navigate(`/projections?project=${result.imported.id}`);
+    } catch (e: any) {
+      setError(e.message || "Import failed");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setOpen(false)}>
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold">Import from S3</h2>
+          <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {loading && <p className="text-sm text-gray-500">Loading...</p>}
+
+        {error && (
+          <p className="mb-3 rounded bg-red-50 p-2 text-xs text-red-700">{error}</p>
+        )}
+
+        {!loading && files.length === 0 && !error && (
+          <div className="py-6">
+            <table className="w-full text-sm">
+              <thead className="border-b">
+                <tr>
+                  <th className="pb-2 text-left font-medium text-gray-500">Filename</th>
+                  <th className="pb-2 text-left font-medium text-gray-500">Modified</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td colSpan={2} className="py-4 text-center text-gray-400">No exports found</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {!loading && files.length > 0 && (
+          <div className="max-h-64 overflow-y-auto">
+            <table className="w-full text-sm">
+              <thead className="border-b sticky top-0 bg-white">
+                <tr>
+                  <th className="pb-2 text-left font-medium text-gray-500">Filename</th>
+                  <th className="pb-2 text-left font-medium text-gray-500">Modified</th>
+                </tr>
+              </thead>
+              <tbody>
+                {files.map((file) => (
+                  <tr
+                    key={file.key}
+                    className={`cursor-pointer border-b last:border-0 hover:bg-gray-50 ${selectedFile?.key === file.key ? "bg-blue-50" : ""}`}
+                    onClick={() => setSelectedFile(file)}
+                  >
+                    <td className="py-2 pr-4 font-mono text-xs">{file.filename}</td>
+                    <td className="py-2 text-xs text-gray-500">
+                      {new Date(file.last_modified).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {selectedFile && (
+          <div className="mt-4 flex items-center justify-between rounded border border-blue-200 bg-blue-50 p-3">
+            <p className="text-xs text-blue-800">
+              Import <span className="font-medium">{selectedFile.filename}</span>?
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setSelectedFile(null)}
+                className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-200"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={importing}
+                className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {importing ? "Importing..." : "Import"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/proxy/ui-src/src/components/Sidebar.tsx
+++ b/proxy/ui-src/src/components/Sidebar.tsx
@@ -82,7 +82,7 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
     try {
       const text = await file.text();
       const data = JSON.parse(text);
-      const result = await projectApi.import(data);
+      const result = await projectApi.importProject(data);
       loadProjects();
       window.dispatchEvent(new Event("projects-changed"));
       navigate(`/projections?project=${result.imported.id}`);

--- a/proxy/ui-src/src/components/Sidebar.tsx
+++ b/proxy/ui-src/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { NavLink, useLocation, useNavigate } from "react-router";
 import { Network, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight, Circle, Plus, Trash2, Upload } from "lucide-react";
 import { clsx } from "clsx";
-import { projectApi, projection, type Project, type Projection } from "../api";
+import { projectApi, projection, metadata, type Project, type Projection } from "../api";
 
 const statusColor: Record<string, string> = {
   complete: "text-green-500",
@@ -15,7 +15,10 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
   const [projects, setProjects] = useState<Project[]>([]);
   const [projections, setProjections] = useState<Projection[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [exportBucket, setExportBucket] = useState<string | null>(null);
+  const [importDropdownOpen, setImportDropdownOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const importDropdownRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -41,9 +44,21 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
 
   useEffect(() => {
     loadProjects();
+    metadata.config().then(c => setExportBucket(c.export_bucket));
     const handler = () => loadProjects();
     window.addEventListener("projects-changed", handler);
     return () => window.removeEventListener("projects-changed", handler);
+  }, []);
+
+  // Close import dropdown on click outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (importDropdownRef.current && !importDropdownRef.current.contains(e.target as Node)) {
+        setImportDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
   function loadProjects() {
@@ -112,9 +127,39 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
             <div className="flex items-center justify-between px-3">
               <span className="text-xs font-semibold uppercase text-gray-400">Projects</span>
               <div className="flex items-center gap-1">
-                <button onClick={() => fileInputRef.current?.click()} className="rounded p-0.5 text-gray-400 hover:text-gray-600" title="Import Project">
-                  <Upload className="h-3 w-3" />
-                </button>
+                <div className="relative" ref={importDropdownRef}>
+                  <button
+                    onClick={() => setImportDropdownOpen(!importDropdownOpen)}
+                    className="rounded p-0.5 text-gray-400 hover:text-gray-600"
+                    title="Import Project"
+                  >
+                    <Upload className="h-3 w-3" />
+                  </button>
+                  {importDropdownOpen && (
+                    <div className="absolute right-0 z-10 mt-1 w-36 rounded-md border border-gray-200 bg-white py-1 shadow-lg">
+                      <button
+                        className="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100"
+                        onClick={() => {
+                          setImportDropdownOpen(false);
+                          fileInputRef.current?.click();
+                        }}
+                      >
+                        Upload file
+                      </button>
+                      {exportBucket && (
+                        <button
+                          className="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100"
+                          onClick={() => {
+                            setImportDropdownOpen(false);
+                            window.dispatchEvent(new Event("open-s3-import-dialog"));
+                          }}
+                        >
+                          Load from S3
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
                 <NavLink to="/projects" className="rounded p-0.5 text-gray-400 hover:text-gray-600" title="Add Project">
                   <Plus className="h-3 w-3" />
                 </NavLink>

--- a/proxy/ui-src/src/components/Sidebar.tsx
+++ b/proxy/ui-src/src/components/Sidebar.tsx
@@ -44,7 +44,7 @@ export function Sidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle:
 
   useEffect(() => {
     loadProjects();
-    metadata.config().then(c => setExportBucket(c.export_bucket));
+    metadata.config().then(c => setExportBucket(c.config_bucket));
     const handler = () => loadProjects();
     window.addEventListener("projects-changed", handler);
     return () => window.removeEventListener("projects-changed", handler);

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { useSearchParams, NavLink } from "react-router";
 import { projection, metadata, projectApi, graphActions, type Projection, type Project, type Inflight } from "../api";
 import { Card, Button, RefreshButton } from "../components/ui";
-import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Download, ChevronUp } from "lucide-react";
+import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Download } from "lucide-react";
 import { useNavigate } from "react-router";
 
 export function Projections() {

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useSearchParams, NavLink } from "react-router";
 import { projection, metadata, projectApi, graphActions, type Projection, type Project, type Inflight } from "../api";
 import { Card, Button, RefreshButton } from "../components/ui";
-import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Download } from "lucide-react";
+import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Download, ChevronUp } from "lucide-react";
 import { useNavigate } from "react-router";
 
 export function Projections() {
@@ -16,12 +16,16 @@ export function Projections() {
   const [actionStates, setActionStates] = useState<Record<string, { actions: string[]; inflight: Inflight | null }>>({});
   const [alerts, setAlerts] = useState<{ graphId: string; graphName: string; message: string }[]>([]);
   const [archivedOpen, setArchivedOpen] = useState(false);
+  const [exportBucket, setExportBucket] = useState<string | null>(null);
+  const [exportDropdownOpen, setExportDropdownOpen] = useState(false);
+  const [exportStatus, setExportStatus] = useState<string | null>(null);
+  const exportDropdownRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const filterProjectId = searchParams.get("project");
 
   useEffect(() => {
     load();
-    metadata.config().then(c => setRegion(c.region));
+    metadata.config().then(c => { setRegion(c.region); setExportBucket(c.export_bucket); });
     projectApi.list().then(list => setProjects(new Map(list.map(p => [p.id, p]))));
   }, []);
 
@@ -118,6 +122,17 @@ export function Projections() {
     ["STOPPING", "STARTING", "DELETING", "CREATING"].includes(s)
   );
 
+  // Close export dropdown on click outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (exportDropdownRef.current && !exportDropdownRef.current.contains(e.target as Node)) {
+        setExportDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
   useEffect(() => {
     if (!hasTransient) return;
     const interval = setInterval(() => load(), 30000);
@@ -152,26 +167,63 @@ export function Projections() {
           <h1 className="text-lg font-semibold">{projectName ? `${projectName} — Projections` : "Projections"}</h1>
           <div className="flex items-center gap-2">
             {filterProjectId && (
-              <button
-                onClick={async () => {
-                  try {
-                    const data = await projectApi.export(filterProjectId);
-                    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement("a");
-                    a.href = url;
-                    a.download = `${projectName || "project"}.json`;
-                    a.click();
-                    URL.revokeObjectURL(url);
-                  } catch (e) {
-                    console.error("Export failed", e);
-                  }
-                }}
-                className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
-                title="Export project"
-              >
-                <Download className="h-3.5 w-3.5" /> Export
-              </button>
+              <div className="relative" ref={exportDropdownRef}>
+                <button
+                  onClick={() => setExportDropdownOpen(!exportDropdownOpen)}
+                  className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+                  title="Export project"
+                >
+                  <Download className="h-3.5 w-3.5" /> Export
+                  {exportBucket && <ChevronDown className="h-3 w-3" />}
+                </button>
+                {exportDropdownOpen && (
+                  <div className="absolute right-0 z-10 mt-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg">
+                    <button
+                      className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
+                      onClick={async () => {
+                        setExportDropdownOpen(false);
+                        try {
+                          const data = await projectApi.export(filterProjectId);
+                          const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+                          const url = URL.createObjectURL(blob);
+                          const a = document.createElement("a");
+                          a.href = url;
+                          a.download = `${projectName || "project"}.json`;
+                          a.click();
+                          URL.revokeObjectURL(url);
+                        } catch (e) {
+                          console.error("Export failed", e);
+                        }
+                      }}
+                    >
+                      Download
+                    </button>
+                    {exportBucket && (
+                      <button
+                        className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100"
+                        onClick={async () => {
+                          setExportDropdownOpen(false);
+                          try {
+                            const result = await projectApi.exportToS3(filterProjectId);
+                            setExportStatus(`Saved to ${result.filename}`);
+                            setTimeout(() => setExportStatus(null), 4000);
+                          } catch (e: any) {
+                            setExportStatus(`Export failed: ${e.message}`);
+                            setTimeout(() => setExportStatus(null), 4000);
+                          }
+                        }}
+                      >
+                        Save to S3
+                      </button>
+                    )}
+                  </div>
+                )}
+                {exportStatus && (
+                  <div className="absolute right-0 mt-1 whitespace-nowrap rounded bg-gray-900 px-3 py-1.5 text-xs text-white shadow-lg">
+                    {exportStatus}
+                  </div>
+                )}
+              </div>
             )}
             <NavLink
               to={filterProjectId ? `/import?project=${filterProjectId}&t=${Date.now()}` : "/import"}

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -25,7 +25,7 @@ export function Projections() {
 
   useEffect(() => {
     load();
-    metadata.config().then(c => { setRegion(c.region); setExportBucket(c.export_bucket); });
+    metadata.config().then(c => { setRegion(c.region); setExportBucket(c.config_bucket); });
     projectApi.list().then(list => setProjects(new Map(list.map(p => [p.id, p]))));
   }, []);
 

--- a/proxy/ui-src/src/pages/Projects.tsx
+++ b/proxy/ui-src/src/pages/Projects.tsx
@@ -13,7 +13,7 @@ export function Projects() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    metadata.config().then(c => setExportBucket(c.export_bucket));
+    metadata.config().then(c => setExportBucket(c.config_bucket));
   }, []);
 
   // Close dropdown on click outside

--- a/proxy/ui-src/src/pages/Projects.tsx
+++ b/proxy/ui-src/src/pages/Projects.tsx
@@ -1,13 +1,31 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router";
-import { projectApi } from "../api";
+import { projectApi, metadata } from "../api";
 import { Card, Button } from "../components/ui";
 
 export function Projects() {
   const [name, setName] = useState("");
   const [importStatus, setImportStatus] = useState<string | null>(null);
+  const [exportBucket, setExportBucket] = useState<string | null>(null);
+  const [importDropdownOpen, setImportDropdownOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const importDropdownRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    metadata.config().then(c => setExportBucket(c.export_bucket));
+  }, []);
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (importDropdownRef.current && !importDropdownRef.current.contains(e.target as Node)) {
+        setImportDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
 
   async function handleCreate() {
     if (!name.trim()) return;
@@ -39,6 +57,23 @@ export function Projects() {
     e.target.value = "";
   }
 
+  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      const result = await projectApi.import(data);
+      setImportStatus(`Imported project "${result.imported.name}" successfully.`);
+      window.dispatchEvent(new Event("projects-changed"));
+    } catch (err) {
+      setImportStatus(`Import failed: ${err instanceof Error ? err.message : "Invalid file"}`);
+    }
+
+    e.target.value = "";
+  }
+
   return (
     <div className="mx-auto max-w-2xl space-y-6">
       <h1 className="text-lg font-semibold">Projects</h1>
@@ -58,6 +93,41 @@ export function Projects() {
           />
           <Button onClick={handleCreate} disabled={!name.trim()}>Create</Button>
           <Button onClick={handleImportClick}>Import</Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={handleFileSelected}
+            aria-label="Import project file"
+          />
+          <div className="relative" ref={importDropdownRef}>
+            <Button onClick={() => setImportDropdownOpen(!importDropdownOpen)}>Import</Button>
+            {importDropdownOpen && (
+              <div className="absolute right-0 z-10 mt-1 w-36 rounded-md border border-gray-200 bg-white py-1 shadow-lg">
+                <button
+                  className="block w-full px-3 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-100"
+                  onClick={() => {
+                    setImportDropdownOpen(false);
+                    fileInputRef.current?.click();
+                  }}
+                >
+                  Upload file
+                </button>
+                {exportBucket && (
+                  <button
+                    className="block w-full px-3 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-100"
+                    onClick={() => {
+                      setImportDropdownOpen(false);
+                      window.dispatchEvent(new Event("open-s3-import-dialog"));
+                    }}
+                  >
+                    Load from S3
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
           <input
             ref={fileInputRef}
             type="file"

--- a/proxy/ui-src/src/pages/Projects.tsx
+++ b/proxy/ui-src/src/pages/Projects.tsx
@@ -35,10 +35,6 @@ export function Projects() {
     navigate(`/projections?project=${project.id}`);
   }
 
-  function handleImportClick() {
-    fileInputRef.current?.click();
-  }
-
   async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -46,7 +42,7 @@ export function Projects() {
     try {
       const text = await file.text();
       const data = JSON.parse(text);
-      const result = await projectApi.import(data);
+      const result = await projectApi.importProject(data);
       setImportStatus(`Imported project "${result.imported.name}" successfully.`);
       window.dispatchEvent(new Event("projects-changed"));
     } catch (err) {
@@ -54,23 +50,6 @@ export function Projects() {
     }
 
     // Reset input so the same file can be re-selected
-    e.target.value = "";
-  }
-
-  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    try {
-      const text = await file.text();
-      const data = JSON.parse(text);
-      const result = await projectApi.import(data);
-      setImportStatus(`Imported project "${result.imported.name}" successfully.`);
-      window.dispatchEvent(new Event("projects-changed"));
-    } catch (err) {
-      setImportStatus(`Import failed: ${err instanceof Error ? err.message : "Invalid file"}`);
-    }
-
     e.target.value = "";
   }
 
@@ -92,15 +71,6 @@ export function Projects() {
             onKeyDown={(e) => e.key === "Enter" && handleCreate()}
           />
           <Button onClick={handleCreate} disabled={!name.trim()}>Create</Button>
-          <Button onClick={handleImportClick}>Import</Button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".json,application/json"
-            className="hidden"
-            onChange={handleFileSelected}
-            aria-label="Import project file"
-          />
           <div className="relative" ref={importDropdownRef}>
             <Button onClick={() => setImportDropdownOpen(!importDropdownOpen)}>Import</Button>
             {importDropdownOpen && (


### PR DESCRIPTION
**Description:**

Extends project import/export with optional S3 as a storage backend. When `NX_NEPTUNE_EXPORT_BUCKET` is configured, users can save exports to S3 and load from S3 directly in the UI.

## Changes

**Backend**
- 3 new endpoints: `POST /{id}/export/s3`, `GET /import/s3/list`, `POST /import/s3`
- Exports tagged with `graph_studio=true`; list endpoint returns last 10 `.json` files sorted by date
- Duplicate key check (409) before upload
- Friendly error messages for S3 failures
- Config: `export_bucket` field from `NX_NEPTUNE_EXPORT_BUCKET` env var, exposed via `/metadata/config`

**Frontend**
- Export button → dropdown ("Download" | "Save to S3") when bucket is configured
- Import button → dropdown ("Upload file" | "Load from S3") when bucket is configured
- `S3ImportDialog` modal with file list table, click-to-select, confirmation before import


https://github.com/user-attachments/assets/93e64737-ecc8-4ff8-8b57-58f45aad2e3d


https://github.com/user-attachments/assets/63cd657b-500f-440b-a5e4-3e4bdbc2699d


## Testing
- 20 new S3 tests, 120 total passing


## Configuration
Set `NX_NEPTUNE_EXPORT_BUCKET=bucket-name` or `NX_NEPTUNE_EXPORT_BUCKET=bucket-name/prefix` to enable.
