### PR TITLE
Misc: Remove unused `sql_query` field

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -117,8 +117,6 @@ async def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le
     client = ClientFactory().athena()
 
     queries = [q for q in [p.node_query, p.edge_query] if q]
-    if not queries and p.sql_query:
-        queries = [q.strip() for q in p.sql_query.split(";") if q.strip()]
     all_results = []
 
     for q in queries:

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -56,7 +56,6 @@ class NeptuneAnalyticsGraphsResponse(BaseModel):
 class ProjectionCreate(BaseModel):
     catalog: str = "AwsDataCatalog"
     database: Optional[str] = None
-    sql_query: Optional[str] = None
     node_query: Optional[str] = None
     edge_query: Optional[str] = None
     graph_name: Optional[str] = None
@@ -68,7 +67,6 @@ class ProjectionCreate(BaseModel):
 class ProjectionUpdate(BaseModel):
     catalog: Optional[str] = None
     database: Optional[str] = None
-    sql_query: Optional[str] = None
     node_query: Optional[str] = None
     edge_query: Optional[str] = None
     graph_name: Optional[str] = None
@@ -112,7 +110,6 @@ class ProjectionResponse(BaseModel):
     status: str
     catalog: str
     database: Optional[str] = None
-    sql_query: Optional[str] = None
     node_query: Optional[str] = None
     edge_query: Optional[str] = None
     graph_name: Optional[str] = None

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -32,7 +32,6 @@ def init_db() -> None:
             status TEXT NOT NULL DEFAULT 'draft',
             catalog TEXT DEFAULT 'AwsDataCatalog',
             database TEXT,
-            sql_query TEXT,
             node_query TEXT,
             edge_query TEXT,
             graph_name TEXT,

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -11,7 +11,7 @@ from typing import Optional
 from .db import get_connection
 
 _FIELDS = [
-    "id", "status", "catalog", "database", "sql_query", "node_query", "edge_query",
+    "id", "status", "catalog", "database", "node_query", "edge_query",
     "graph_name", "graph_memory_gb", "s3_staging_bucket", "graph_id", "graph_endpoint",
     "project_id", "step", "step_label", "progress", "error", "created_at",
 ]
@@ -25,7 +25,6 @@ class Projection:
     status: str
     catalog: str = "AwsDataCatalog"
     database: Optional[str] = None
-    sql_query: Optional[str] = None
     node_query: Optional[str] = None
     edge_query: Optional[str] = None
     graph_name: Optional[str] = None
@@ -43,7 +42,7 @@ class Projection:
 
 class ProjectionStore:
     def create(self, catalog: str = "AwsDataCatalog", database: str = None,
-               sql_query: str = None, node_query: str = None,
+               node_query: str = None,
                edge_query: str = None, graph_name: str = None,
                graph_memory_gb: int = 16, s3_staging_bucket: str = None,
                project_id: str = None) -> Projection:
@@ -52,7 +51,6 @@ class ProjectionStore:
             status="draft",
             catalog=catalog,
             database=database,
-            sql_query=sql_query,
             node_query=node_query,
             edge_query=edge_query,
             graph_name=graph_name,
@@ -91,7 +89,7 @@ class ProjectionStore:
         return [self._row_to_projection(r) for r in rows]
 
     _ALLOWED_UPDATE_COLUMNS = {
-        "status", "catalog", "database", "sql_query", "node_query", "edge_query",
+        "status", "catalog", "database", "node_query", "edge_query",
         "graph_name", "graph_memory_gb", "s3_staging_bucket", "graph_id", "graph_endpoint",
         "project_id", "step", "step_label", "progress", "error",
     }
@@ -124,7 +122,6 @@ class ProjectionStore:
             status=row["status"],
             catalog=row["catalog"],
             database=row["database"],
-            sql_query=row["sql_query"],
             node_query=row["node_query"],
             edge_query=row["edge_query"],
             graph_name=row["graph_name"],

--- a/proxy/tests/test_no_secrets.py
+++ b/proxy/tests/test_no_secrets.py
@@ -26,7 +26,7 @@ class TestNoSecretsInDb:
             database="production_db",
             graph_name="fraud-graph",
             s3_staging_bucket="s3://my-bucket/staging/",
-            sql_query="SELECT user_id, name FROM users",
+            node_query="SELECT user_id, name FROM users",
         )
         store.create(
             database="analytics",

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -34,7 +34,8 @@ def clear_store():
 
 SAMPLE_BODY = {
     "database": "mydb",
-    "node_query": "SELECT * FROM t",
+    "node_query": "SELECT id AS `~id`, type AS `~label` FROM nodes",
+    "edge_query": "SELECT src AS `~from`, dst AS `~to`, rel AS `~label` FROM edges",
     "graph_name": "test-graph",
     "s3_staging_bucket": "s3://my-bucket/staging/",
 }
@@ -76,16 +77,20 @@ async def test_update_projection(client):
     create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
     pid = create_resp.json()["id"]
 
-    resp = await client.put(f"/api/v0/projection/{pid}", json={"node_query": "SELECT id FROM t"})
+    resp = await client.put(f"/api/v0/projection/{pid}", json={
+        "node_query": "SELECT id FROM t",
+        "edge_query": "SELECT src, dst FROM edges",
+    })
     assert resp.status_code == 200
     assert resp.json()["node_query"] == "SELECT id FROM t"
+    assert resp.json()["edge_query"] == "SELECT src, dst FROM edges"
     # Other fields unchanged
     assert resp.json()["database"] == "mydb"
 
 
 @pytest.mark.asyncio
 async def test_update_projection_not_found(client):
-    resp = await client.put("/api/v0/projection/nonexistent", json={"node_query": "x"})
+    resp = await client.put("/api/v0/projection/nonexistent", json={"node_query": "x", "edge_query": "y"})
     assert resp.status_code == 404
 
 

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -34,7 +34,6 @@ def clear_store():
 
 SAMPLE_BODY = {
     "database": "mydb",
-    "sql_query": "SELECT * FROM t",
     "node_query": "SELECT * FROM t",
     "graph_name": "test-graph",
     "s3_staging_bucket": "s3://my-bucket/staging/",
@@ -77,16 +76,16 @@ async def test_update_projection(client):
     create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
     pid = create_resp.json()["id"]
 
-    resp = await client.put(f"/api/v0/projection/{pid}", json={"sql_query": "SELECT id FROM t"})
+    resp = await client.put(f"/api/v0/projection/{pid}", json={"node_query": "SELECT id FROM t"})
     assert resp.status_code == 200
-    assert resp.json()["sql_query"] == "SELECT id FROM t"
+    assert resp.json()["node_query"] == "SELECT id FROM t"
     # Other fields unchanged
     assert resp.json()["database"] == "mydb"
 
 
 @pytest.mark.asyncio
 async def test_update_projection_not_found(client):
-    resp = await client.put("/api/v0/projection/nonexistent", json={"sql_query": "x"})
+    resp = await client.put("/api/v0/projection/nonexistent", json={"node_query": "x"})
     assert resp.status_code == 404
 
 

--- a/proxy/tests/test_sql_injection.py
+++ b/proxy/tests/test_sql_injection.py
@@ -34,11 +34,11 @@ class TestSqlInjection:
         p2 = store.create(database="testdb2", graph_name="test2")
         assert store.get(p2.id) is not None
 
-    def test_injection_in_sql_query_field(self):
+    def test_injection_in_node_query_field(self):
         payload = "SELECT * FROM t; DROP TABLE projections;--"
-        p = store.create(database="testdb", sql_query=payload, graph_name="test")
+        p = store.create(database="testdb", node_query=payload, graph_name="test")
         retrieved = store.get(p.id)
-        assert retrieved.sql_query == payload
+        assert retrieved.node_query == payload
 
     def test_unicode_injection(self):
         payload = "test\u0000'; DROP TABLE projections;--"

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -47,7 +47,6 @@ export interface Projection {
   status: string;
   catalog: string;
   database?: string;
-  sql_query?: string;
   node_query?: string;
   edge_query?: string;
   graph_name?: string;


### PR DESCRIPTION
### Summary :memo:
Remove dead `sql_query` field.

`sql_query` is a leftover from the original single-query design — the UI only uses `node_query`/`edge_query` and never populates this field. The only code path that read it (preview fallback) was unreachable. Removed from dataclass, DB schema, Pydantic models, API types, and tests.


### Test plan:

- 137 unit tests pass (`NX_NEPTUNE_CONFIG_BUCKET="" python -m pytest tests/ -q`)
- TypeScript compiles clean (`npx tsc --noEmit`)
- No behavioral changes


### Permissions
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
