### PR TITLE
Fix: Make project_id mandatory for projections

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -61,7 +61,7 @@ class ProjectionCreate(BaseModel):
     graph_name: Optional[str] = None
     graph_memory_gb: int = 16
     s3_staging_bucket: Optional[str] = None
-    project_id: Optional[str] = None
+    project_id: str
 
 
 class ProjectionUpdate(BaseModel):

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -39,7 +39,7 @@ def init_db() -> None:
             s3_staging_bucket TEXT,
             graph_id TEXT,
             graph_endpoint TEXT,
-            project_id TEXT,
+            project_id TEXT NOT NULL,
             step TEXT,
             step_label TEXT,
             progress REAL DEFAULT 0,

--- a/proxy/tests/conftest.py
+++ b/proxy/tests/conftest.py
@@ -6,6 +6,7 @@ from httpx import ASGITransport, AsyncClient
 
 from nx_neptune_proxy.app import app
 from nx_neptune_proxy.services.db import get_connection
+from nx_neptune_proxy.services.project_store import store as project_store
 
 
 @pytest.fixture
@@ -38,3 +39,10 @@ def clear_store():
     conn.execute("DELETE FROM projects")
     conn.commit()
     conn.close()
+
+
+@pytest.fixture
+def test_project_id():
+    """Create a test project and return its ID."""
+    p = project_store.create(name="Test Project")
+    return p.id

--- a/proxy/tests/test_column_allowlist.py
+++ b/proxy/tests/test_column_allowlist.py
@@ -11,27 +11,27 @@ from nx_neptune_proxy.services.projection_store import store
 class TestColumnAllowlist:
     """Store.update() must reject columns not in _ALLOWED_UPDATE_COLUMNS."""
 
-    def test_invalid_column_raises_value_error(self):
-        p = store.create(database="testdb", graph_name="test")
+    def test_invalid_column_raises_value_error(self, test_project_id):
+        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, id="injected-id")
 
-    def test_invalid_column_created_at_rejected(self):
-        p = store.create(database="testdb", graph_name="test")
+    def test_invalid_column_created_at_rejected(self, test_project_id):
+        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, created_at="2020-01-01")
 
-    def test_arbitrary_column_rejected(self):
-        p = store.create(database="testdb", graph_name="test")
+    def test_arbitrary_column_rejected(self, test_project_id):
+        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, drop_table="yes")
 
-    def test_multiple_invalid_columns_rejected(self):
-        p = store.create(database="testdb", graph_name="test")
+    def test_multiple_invalid_columns_rejected(self, test_project_id):
+        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, malicious="x", another_bad="y")
 
-    def test_valid_column_accepted(self):
-        p = store.create(database="testdb", graph_name="test")
+    def test_valid_column_accepted(self, test_project_id):
+        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
         result = store.update(p.id, status="importing")
         assert result.status == "importing"

--- a/proxy/tests/test_no_secrets.py
+++ b/proxy/tests/test_no_secrets.py
@@ -19,7 +19,7 @@ class TestNoSecretsInDb:
         "password",
     ]
 
-    def test_no_secrets_after_creating_projections(self):
+    def test_no_secrets_after_creating_projections(self, test_project_id):
         """After CRUD operations, DB should contain no credential patterns."""
         # Create several projections with various data
         store.create(
@@ -27,6 +27,7 @@ class TestNoSecretsInDb:
             graph_name="fraud-graph",
             s3_staging_bucket="s3://my-bucket/staging/",
             node_query="SELECT user_id, name FROM users",
+            project_id=test_project_id,
         )
         store.create(
             database="analytics",
@@ -34,6 +35,7 @@ class TestNoSecretsInDb:
             s3_staging_bucket="s3://other-bucket/data/",
             node_query="SELECT id AS `~id`, type AS `~label` FROM nodes",
             edge_query="SELECT src AS `~from`, dst AS `~to` FROM edges",
+            project_id=test_project_id,
         )
 
         # Read the raw database content
@@ -57,9 +59,9 @@ class TestNoSecretsInDb:
                 f"Sensitive pattern '{pattern}' found in SQLite data"
             )
 
-    def test_no_secrets_after_update_with_error(self):
+    def test_no_secrets_after_update_with_error(self, test_project_id):
         """Error messages stored in DB should not contain credentials."""
-        p = store.create(database="testdb", graph_name="test")
+        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
         store.update(
             p.id,
             status="failed",

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from nx_neptune_proxy.app import app
 from nx_neptune_proxy.services.projection_store import store
+from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.db import get_connection
 
 
@@ -24,6 +25,10 @@ def clear_store():
     conn.execute("DELETE FROM projects")
     conn.commit()
     conn.close()
+    # Create a default project for tests
+    p = project_store.create(name="Test Project")
+    global _TEST_PROJECT_ID
+    _TEST_PROJECT_ID = p.id
     yield
     conn = get_connection()
     conn.execute("DELETE FROM projections")
@@ -32,13 +37,18 @@ def clear_store():
     conn.close()
 
 
-SAMPLE_BODY = {
-    "database": "mydb",
-    "node_query": "SELECT id AS `~id`, type AS `~label` FROM nodes",
-    "edge_query": "SELECT src AS `~from`, dst AS `~to`, rel AS `~label` FROM edges",
-    "graph_name": "test-graph",
-    "s3_staging_bucket": "s3://my-bucket/staging/",
-}
+_TEST_PROJECT_ID = ""
+
+
+def SAMPLE_BODY():
+    return {
+        "database": "mydb",
+        "node_query": "SELECT id AS `~id`, type AS `~label` FROM nodes",
+        "edge_query": "SELECT src AS `~from`, dst AS `~to`, rel AS `~label` FROM edges",
+        "graph_name": "test-graph",
+        "s3_staging_bucket": "s3://my-bucket/staging/",
+        "project_id": _TEST_PROJECT_ID,
+    }
 
 
 # --- CRUD ---
@@ -46,7 +56,7 @@ SAMPLE_BODY = {
 
 @pytest.mark.asyncio
 async def test_create_projection(client):
-    resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     assert resp.status_code == 201
     data = resp.json()
     assert data["status"] == "draft"
@@ -58,7 +68,7 @@ async def test_create_projection(client):
 
 @pytest.mark.asyncio
 async def test_get_projection(client):
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     resp = await client.get(f"/api/v0/projection/{pid}")
@@ -74,7 +84,7 @@ async def test_get_projection_not_found(client):
 
 @pytest.mark.asyncio
 async def test_update_projection(client):
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     resp = await client.put(f"/api/v0/projection/{pid}", json={
@@ -99,7 +109,7 @@ async def test_update_projection_not_found(client):
 
 @pytest.mark.asyncio
 async def test_get_status(client):
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     resp = await client.get(f"/api/v0/projection/{pid}/status")
@@ -121,7 +131,7 @@ async def test_validate_projection(mock_validate, client):
         {"check": "query_valid", "passed": True, "error": None},
     ]
 
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     resp = await client.post(f"/api/v0/projection/{pid}/validate")
@@ -138,7 +148,7 @@ async def test_validate_projection_fails(mock_validate, client):
         {"check": "bucket_region", "passed": False, "error": "Wrong region"},
     ]
 
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     resp = await client.post(f"/api/v0/projection/{pid}/validate")
@@ -157,7 +167,7 @@ async def test_validate_query(mock_check, client):
     mock_result.message = ""
     mock_check.return_value = mock_result
 
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     resp = await client.post(f"/api/v0/projection/{pid}/validate-query")
@@ -181,7 +191,7 @@ async def test_preview(mock_cf, mock_wait, mock_results, client):
     mock_cf.return_value.athena.return_value = mock_athena
     mock_results.return_value = [["id", "name"], ["1", "Alice"]]
 
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     resp = await client.post(f"/api/v0/projection/{pid}/preview")
@@ -197,7 +207,7 @@ async def test_preview(mock_cf, mock_wait, mock_results, client):
 
 @pytest.mark.asyncio
 async def test_execute_returns_202(client):
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     with patch("nx_neptune_proxy.routers.projection.run_pipeline"):
@@ -208,7 +218,7 @@ async def test_execute_returns_202(client):
 
 @pytest.mark.asyncio
 async def test_execute_conflict_if_already_running(client):
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
     store.update(pid, status="executing")
 
@@ -221,8 +231,8 @@ async def test_execute_conflict_if_already_running(client):
 
 @pytest.mark.asyncio
 async def test_list_projections(client):
-    await client.post("/api/v0/projection", json=SAMPLE_BODY)
-    await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    await client.post("/api/v0/projection", json=SAMPLE_BODY())
+    await client.post("/api/v0/projection", json=SAMPLE_BODY())
 
     resp = await client.get("/api/v0/projection")
     assert resp.status_code == 200
@@ -243,7 +253,7 @@ async def test_create_projection_invalid_body(client):
 
 @pytest.mark.asyncio
 async def test_execute_poll_lifecycle(client):
-    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
     with patch("nx_neptune_proxy.routers.projection.run_pipeline"):

--- a/proxy/tests/test_sql_injection.py
+++ b/proxy/tests/test_sql_injection.py
@@ -9,40 +9,40 @@ from nx_neptune_proxy.services.projection_store import store
 class TestSqlInjection:
     """Parameterized queries must store injection payloads as literal strings."""
 
-    def test_injection_in_graph_name(self):
+    def test_injection_in_graph_name(self, test_project_id):
         payload = "'; DROP TABLE projections; --"
-        p = store.create(database="testdb", graph_name=payload)
+        p = store.create(database="testdb", graph_name=payload, project_id=test_project_id)
         # Table still exists and projection is retrievable
         retrieved = store.get(p.id)
         assert retrieved is not None
         assert retrieved.graph_name == payload
 
-    def test_injection_in_database_field(self):
+    def test_injection_in_database_field(self, test_project_id):
         payload = "x' OR '1'='1"
-        p = store.create(database=payload, graph_name="test")
+        p = store.create(database=payload, graph_name="test", project_id=test_project_id)
         retrieved = store.get(p.id)
         assert retrieved.database == payload
 
-    def test_injection_in_update_value(self):
-        p = store.create(database="testdb", graph_name="test")
+    def test_injection_in_update_value(self, test_project_id):
+        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
         payload = "'; DELETE FROM projections WHERE '1'='1"
         store.update(p.id, error=payload)
         # Projection still exists with payload stored as literal
         retrieved = store.get(p.id)
         assert retrieved.error == payload
         # Verify other projections are not affected
-        p2 = store.create(database="testdb2", graph_name="test2")
+        p2 = store.create(database="testdb2", graph_name="test2", project_id=test_project_id)
         assert store.get(p2.id) is not None
 
-    def test_injection_in_node_query_field(self):
+    def test_injection_in_node_query_field(self, test_project_id):
         payload = "SELECT * FROM t; DROP TABLE projections;--"
-        p = store.create(database="testdb", node_query=payload, graph_name="test")
+        p = store.create(database="testdb", node_query=payload, graph_name="test", project_id=test_project_id)
         retrieved = store.get(p.id)
         assert retrieved.node_query == payload
 
-    def test_unicode_injection(self):
+    def test_unicode_injection(self, test_project_id):
         payload = "test\u0000'; DROP TABLE projections;--"
-        p = store.create(database="testdb", graph_name=payload)
+        p = store.create(database="testdb", graph_name=payload, project_id=test_project_id)
         retrieved = store.get(p.id)
         assert retrieved is not None
         assert retrieved.graph_name == payload

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -54,7 +54,7 @@ export interface Projection {
   graph_endpoint?: string;
   graph_memory_gb: number;
   s3_staging_bucket?: string;
-  project_id?: string;
+  project_id: string;
   step?: string;
   step_label?: string;
   progress: number;

--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -91,7 +91,8 @@ export function Import() {
 
   // --- Projection management ---
   async function ensureProjection(): Promise<string> {
-    const data = { catalog, database, node_query: nodeQuery || undefined, edge_query: edgeQuery || undefined, s3_staging_bucket: bucket, graph_name: graphName, graph_memory_gb: graphMemoryGb, project_id: projectId || undefined };
+    if (!projectId) throw new Error("Please select a project first");
+    const data = { catalog, database, node_query: nodeQuery || undefined, edge_query: edgeQuery || undefined, s3_staging_bucket: bucket, graph_name: graphName, graph_memory_gb: graphMemoryGb, project_id: projectId };
     if (currentId) {
       await projection.update(currentId, data);
       return currentId;
@@ -223,7 +224,7 @@ export function Import() {
                   value={projectId}
                   onChange={(e) => setProjectId(e.target.value)}
                 >
-                  <option value="">No project</option>
+                  <option value="" disabled>Select a project</option>
                   {projects.map((ws) => (
                     <option key={ws.id} value={ws.id}>{ws.name}</option>
                   ))}

--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -106,6 +106,7 @@ export function Import() {
 
   function loadProjection(p: Projection) {
     setCurrentId(p.id);
+    if (p.project_id) setProjectId(p.project_id);
     if (p.catalog) setCatalog(p.catalog);
     if (p.database) setDatabase(p.database);
     if (p.node_query) setNodeQuery(p.node_query);
@@ -218,25 +219,16 @@ export function Import() {
         <div className="space-y-4">
           <label className="block space-y-1">
               <span className="text-sm font-medium text-gray-700">Project</span>
-              <div className="flex gap-2">
-                <Select
-                  className="flex-1"
-                  value={projectId}
-                  onChange={(e) => setProjectId(e.target.value)}
-                >
-                  <option value="" disabled>Select a project</option>
-                  {projects.map((ws) => (
-                    <option key={ws.id} value={ws.id}>{ws.name}</option>
-                  ))}
-                </Select>
-                <Button variant="secondary" onClick={async () => {
-                  const name = prompt("Project name:");
-                  if (!name) return;
-                  const ws = await projectApi.create(name);
-                  setProjects(prev => [...prev, ws]);
-                  setProjectId(ws.id);
-                }}>+</Button>
-              </div>
+              <Select
+                className="flex-1"
+                value={projectId}
+                disabled
+              >
+                <option value="" disabled>Select a project</option>
+                {projects.map((ws) => (
+                  <option key={ws.id} value={ws.id}>{ws.name}</option>
+                ))}
+              </Select>
             </label>
           <label className="block space-y-1">
               <span className="text-sm font-medium text-gray-700">Copy config from</span>


### PR DESCRIPTION
## Summary

Projections can no longer exist without a parent project. Enforced at API, DB, and UI levels.

<img width="616" height="793" alt="Screenshot 2026-08-13 at 3 32 50 PM" src="https://github.com/user-attachments/assets/66234f4c-0b87-49e7-b6a1-4b64d3412efb" />


## Changes

### Backend
- `ProjectionCreate.project_id` — changed from `Optional[str] = None` to `str` (required). Pydantic returns 422 if missing.
- DB schema: `project_id TEXT NOT NULL` with foreign key constraint on projections table.

### Frontend
- Project dropdown is now read-only (disabled) — project is set by navigation context, not user selection.
- Removed the `+` create project button from Import page.
- `loadProjection` now sets `projectId` from the loaded projection's `project_id` field.
- `ensureProjection()` throws if no project is selected.
- TypeScript: `project_id` is non-optional in `Projection` interface.

### Tests
- Added `test_project_id` fixture in `conftest.py` for tests that call `store.create()` directly.
- Updated `test_sql_injection.py`, `test_column_allowlist.py`, `test_no_secrets.py`, `test_projection.py` to always pass `project_id`.
