### PR TITLE
Fix: Guard stop/start with managed-graph prefix check

### DIFF
--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -14,7 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.config import get_settings
 from nx_neptune_proxy.routers.graph import router as graph_router
 from nx_neptune_proxy.routers.metadata import router as metadata_router
 from nx_neptune_proxy.utils.sanitize import sanitize_error_message
@@ -25,8 +25,7 @@ from nx_neptune_proxy.services.db import init_db
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.project_deletion import delete_project
 
-settings = Settings.from_env()
-settings.validate()
+settings = get_settings()
 
 # --- Database ---
 init_db()
@@ -43,9 +42,7 @@ logger = logging.getLogger("nx_neptune_proxy")
 
 # --- App ---
 
-app = FastAPI(
-    title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_url=None
-)
+app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_url=None)
 
 app.add_middleware(
     CORSMiddleware,

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -26,6 +26,7 @@ from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.project_deletion import delete_project
 
 settings = Settings.from_env()
+settings.validate()
 
 # --- Database ---
 init_db()

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -67,3 +67,26 @@ class Settings:
                 "An empty prefix disables the managed-graph safety guard, "
                 "allowing operations on any graph in the account."
             )
+
+
+# Single validated Settings instance shared across the process. Built and
+# validated once on first access, then reused, so the value the startup
+# guard validates is the exact same instance every consumer (e.g. the
+# managed-graph guard) reads — not an independent, unvalidated re-read.
+_settings: "Settings | None" = None
+
+
+def get_settings() -> "Settings":
+    """Return the process-wide validated Settings instance.
+
+    Loads from the environment and validates on first call, then caches.
+    All runtime consumers should read configuration through this, rather
+    than calling ``Settings.from_env()`` directly, so everyone shares the
+    one instance that startup validation checked.
+    """
+    global _settings
+    if _settings is None:
+        settings = Settings.from_env()
+        settings.validate()
+        _settings = settings
+    return _settings

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -58,3 +58,12 @@ class Settings:
             ),
             graph_prefix=os.environ.get("GRAPH_PREFIX", "nxp-"),
         )
+
+    def validate(self) -> None:
+        """Validate settings at startup. Raises SystemExit on invalid config."""
+        if not self.graph_prefix:
+            raise SystemExit(
+                "ERROR: GRAPH_PREFIX must not be empty. "
+                "An empty prefix disables the managed-graph safety guard, "
+                "allowing operations on any graph in the account."
+            )

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -60,12 +60,24 @@ class Settings:
         )
 
     def validate(self) -> None:
-        """Validate settings at startup. Raises SystemExit on invalid config."""
+        """Validate settings at startup. Reports all problems at once.
+
+        Raises SystemExit listing every configuration error found, so the
+        user can fix them in one pass rather than one restart at a time.
+        """
+        errors: list[str] = []
+
         if not self.graph_prefix:
+            errors.append(
+                "GRAPH_PREFIX must not be empty. An empty prefix disables "
+                "the managed-graph safety guard, allowing operations on any "
+                "graph in the account."
+            )
+
+        if errors:
             raise SystemExit(
-                "ERROR: GRAPH_PREFIX must not be empty. "
-                "An empty prefix disables the managed-graph safety guard, "
-                "allowing operations on any graph in the account."
+                "ERROR: invalid configuration:\n"
+                + "\n".join(f"  - {e}" for e in errors)
             )
 
 

--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -40,7 +40,7 @@ def _require_status(graph_id: str, resp: dict) -> str:
 def get_available_actions(graph_id: str):
     """Return valid actions based on the graph's current Neptune status."""
     client = ClientFactory().neptune()
-    resp = client.get_graph(graphIdentifier=graph_id)
+    resp = get_graph_or_exception(client, graph_id)
     # Prefix guard first, before any status handling.
     assert_managed_graph(resp.get("name"))
     status = _require_status(graph_id, resp)

--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -9,7 +9,10 @@ import logging
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from nx_neptune.clients.client_factory import ClientFactory
-from nx_neptune_proxy.utils.aws_helper import assert_managed_graph, get_graph_or_exception
+from nx_neptune_proxy.utils.aws_helper import (
+    assert_managed_graph,
+    get_graph_or_exception,
+)
 from nx_neptune_proxy.services.graph_state_machine import (
     InvalidTransitionError,
     available_actions,
@@ -24,16 +27,23 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v0/graphs", tags=["graphs"])
 
 
+def _require_status(graph_id: str, resp: dict) -> str:
+    """Return the graph's status, or raise 502 if it is missing/empty."""
+    status = resp.get("status")
+    if not status:
+        logger.warning(f"Graph {graph_id} returned empty status: {resp}")
+        raise HTTPException(status_code=502, detail="Graph returned no status")
+    return status
+
+
 @router.get("/{graph_id}/actions", summary="List available actions for a graph")
 def get_available_actions(graph_id: str):
     """Return valid actions based on the graph's current Neptune status."""
     client = ClientFactory().neptune()
     resp = client.get_graph(graphIdentifier=graph_id)
+    # Prefix guard first, before any status handling.
     assert_managed_graph(resp.get("name"))
-    status = resp.get("status")
-    if not status:
-        logger.warning(f"Graph {graph_id} returned empty status: {resp}")
-        raise HTTPException(status_code=502, detail="Graph returned no status")
+    status = _require_status(graph_id, resp)
     actions = available_actions(status)
     inflight = get_inflight(graph_id)
     return {
@@ -49,13 +59,9 @@ def perform_action(graph_id: str, action: str, background_tasks: BackgroundTasks
     """Initiate a state transition (stop, start, delete) as a background task."""
     client = ClientFactory().neptune()
     resp = get_graph_or_exception(client, graph_id)
-    current_status = resp.get("status")
-    if not current_status:
-        logger.warning(f"Graph {graph_id} returned empty status: {resp}")
-        raise HTTPException(status_code=502, detail="Graph returned no status")
-
-    # Prefix guard: only allow actions on graphs managed by this tool
+    # Prefix guard first, before any status handling.
     assert_managed_graph(resp.get("name"))
+    current_status = _require_status(graph_id, resp)
 
     try:
         # Validate early (execute_transition also validates, but fail fast for the user)

--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -29,6 +29,7 @@ def get_available_actions(graph_id: str):
     """Return valid actions based on the graph's current Neptune status."""
     client = ClientFactory().neptune()
     resp = client.get_graph(graphIdentifier=graph_id)
+    assert_managed_graph(resp.get("name"))
     status = resp.get("status")
     if not status:
         logger.warning(f"Graph {graph_id} returned empty status: {resp}")
@@ -53,9 +54,8 @@ def perform_action(graph_id: str, action: str, background_tasks: BackgroundTasks
         logger.warning(f"Graph {graph_id} returned empty status: {resp}")
         raise HTTPException(status_code=502, detail="Graph returned no status")
 
-    # Prefix guard: only allow destructive actions on graphs managed by this tool
-    if action == "delete":
-        assert_managed_graph(resp.get("name"))
+    # Prefix guard: only allow actions on graphs managed by this tool
+    assert_managed_graph(resp.get("name"))
 
     try:
         # Validate early (execute_transition also validates, but fail fast for the user)
@@ -75,6 +75,9 @@ def perform_action(graph_id: str, action: str, background_tasks: BackgroundTasks
 @router.get("/{graph_id}/inflight", summary="Check in-flight operation status")
 def get_inflight_status(graph_id: str):
     """Return current in-flight operation info, including any error."""
+    client = ClientFactory().neptune()
+    resp = get_graph_or_exception(client, graph_id)
+    assert_managed_graph(resp.get("name"))
     inflight = get_inflight(graph_id)
     if not inflight:
         return {"graph_id": graph_id, "inflight": None}

--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -74,10 +74,11 @@ def perform_action(graph_id: str, action: str, background_tasks: BackgroundTasks
 
 @router.get("/{graph_id}/inflight", summary="Check in-flight operation status")
 def get_inflight_status(graph_id: str):
-    """Return current in-flight operation info, including any error."""
-    client = ClientFactory().neptune()
-    resp = get_graph_or_exception(client, graph_id)
-    assert_managed_graph(resp.get("name"))
+    """Return current in-flight operation info, including any error.
+
+    No prefix guard needed: the inflight map is populated only by guarded
+    actions, so it only ever contains managed graphs. Unmanaged IDs return null.
+    """
     inflight = get_inflight(graph_id)
     if not inflight:
         return {"graph_id": graph_id, "inflight": None}

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -4,8 +4,11 @@
 from fastapi import APIRouter, HTTPException, Query
 
 from nx_neptune.clients.client_factory import ClientFactory
-from nx_neptune_proxy.config import Settings
-from nx_neptune_proxy.utils.aws_helper import assert_managed_graph, get_graph_or_exception
+from nx_neptune_proxy.config import get_settings
+from nx_neptune_proxy.utils.aws_helper import (
+    assert_managed_graph,
+    get_graph_or_exception,
+)
 from nx_neptune_proxy.routers.schemas import (
     BucketsResponse,
     CatalogsResponse,
@@ -22,38 +25,63 @@ router = APIRouter(prefix="/api/v0/metadata", tags=["metadata"])
 @router.get("/config", summary="Get server configuration")
 def get_config():
     """Get server-side configuration"""
-    settings = Settings.from_env()
+    settings = get_settings()
     return {"region": settings.region or "", "graph_prefix": settings.graph_prefix}
 
 
-@router.get("/athena/catalogs", summary="List Athena data catalogs", response_model=CatalogsResponse)
+@router.get(
+    "/athena/catalogs",
+    summary="List Athena data catalogs",
+    response_model=CatalogsResponse,
+)
 def list_athena_catalogs():
     """List all Athena data catalogs"""
     client = ClientFactory().athena()
     items = paginate_aws(client.list_data_catalogs, "DataCatalogsSummary")
-    return {"catalogs": [{"name": c["CatalogName"], "status": c.get("Status", "")} for c in items]}
+    return {
+        "catalogs": [
+            {"name": c["CatalogName"], "status": c.get("Status", "")} for c in items
+        ]
+    }
 
 
-@router.get("/athena/databases", summary="List Athena databases", response_model=DatabasesResponse)
-def list_athena_databases(catalog: str = Query("AwsDataCatalog", description="Athena catalog name")):
+@router.get(
+    "/athena/databases",
+    summary="List Athena databases",
+    response_model=DatabasesResponse,
+)
+def list_athena_databases(
+    catalog: str = Query("AwsDataCatalog", description="Athena catalog name")
+):
     """List all databases in the specified Athena catalog"""
     client = ClientFactory().athena()
     items = paginate_aws(client.list_databases, "DatabaseList", CatalogName=catalog)
     return {"databases": [db["Name"] for db in items]}
 
 
-@router.get("/athena/tables", summary="List Athena tables", response_model=TablesResponse)
+@router.get(
+    "/athena/tables", summary="List Athena tables", response_model=TablesResponse
+)
 def list_athena_tables(
     database: str = Query(..., description="Database name"),
     catalog: str = Query("AwsDataCatalog", description="Athena catalog name"),
 ):
     """List all tables in the specified Athena database"""
     client = ClientFactory().athena()
-    items = paginate_aws(client.list_table_metadata, "TableMetadataList", CatalogName=catalog, DatabaseName=database)
+    items = paginate_aws(
+        client.list_table_metadata,
+        "TableMetadataList",
+        CatalogName=catalog,
+        DatabaseName=database,
+    )
     return {"tables": [t["Name"] for t in items]}
 
 
-@router.get("/athena/columns", summary="List Athena table columns", response_model=ColumnsResponse)
+@router.get(
+    "/athena/columns",
+    summary="List Athena table columns",
+    response_model=ColumnsResponse,
+)
 def list_athena_columns(
     database: str = Query(..., description="Database name"),
     table: str = Query(..., description="Table name"),
@@ -61,7 +89,9 @@ def list_athena_columns(
 ):
     """List columns and their types for the specified Athena table"""
     client = ClientFactory().athena()
-    resp = client.get_table_metadata(CatalogName=catalog, DatabaseName=database, TableName=table)
+    resp = client.get_table_metadata(
+        CatalogName=catalog, DatabaseName=database, TableName=table
+    )
     columns = resp["TableMetadata"].get("Columns", [])
     return {"columns": [{"name": c["Name"], "type": c["Type"]} for c in columns]}
 
@@ -69,25 +99,40 @@ def list_athena_columns(
 @router.get("/s3/buckets", summary="List S3 buckets", response_model=BucketsResponse)
 def list_s3_buckets():
     """List S3 buckets in the configured region"""
-    filter_region = Settings.from_env().region
+    filter_region = get_settings().region
     if not filter_region:
         return {"buckets": []}
     client = ClientFactory().s3()
-    buckets = [b["Name"] for b in client.list_buckets(BucketRegion=filter_region).get("Buckets", [])]
+    buckets = [
+        b["Name"]
+        for b in client.list_buckets(BucketRegion=filter_region).get("Buckets", [])
+    ]
     return {"buckets": buckets}
 
 
-@router.get("/neptune/graph-analytics", summary="List Neptune Analytics graphs", response_model=NeptuneAnalyticsGraphsResponse)
+@router.get(
+    "/neptune/graph-analytics",
+    summary="List Neptune Analytics graphs",
+    response_model=NeptuneAnalyticsGraphsResponse,
+)
 def list_neptune_graphs():
     """List Neptune Analytics graphs managed by nx-neptune"""
     client = ClientFactory().neptune()
     items = paginate_aws(client.list_graphs, "graphs")
-    prefix = Settings.from_env().graph_prefix
+    prefix = get_settings().graph_prefix
     filtered = [g for g in items if g.get("name", "").startswith(prefix)]
-    return {"graphs": [{"id": g["id"], "name": g["name"], "status": g["status"]} for g in filtered]}
+    return {
+        "graphs": [
+            {"id": g["id"], "name": g["name"], "status": g["status"]} for g in filtered
+        ]
+    }
 
 
-@router.delete("/neptune/graph-analytics/{graph_id}", summary="Delete a Neptune Analytics graph", status_code=202)
+@router.delete(
+    "/neptune/graph-analytics/{graph_id}",
+    summary="Delete a Neptune Analytics graph",
+    status_code=202,
+)
 def delete_neptune_graph(graph_id: str):
     """Delete a Neptune Analytics graph"""
     client = ClientFactory().neptune()
@@ -98,7 +143,9 @@ def delete_neptune_graph(graph_id: str):
     return {"id": graph_id, "status": "DELETING"}
 
 
-@router.get("/neptune/graph-analytics/{graph_id}/summary", summary="Get graph node/edge counts")
+@router.get(
+    "/neptune/graph-analytics/{graph_id}/summary", summary="Get graph node/edge counts"
+)
 def get_graph_summary(graph_id: str):
     """Get node and edge counts for a Neptune Analytics graph"""
     client = ClientFactory().neptune()

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -102,6 +102,8 @@ def delete_neptune_graph(graph_id: str):
 def get_graph_summary(graph_id: str):
     """Get node and edge counts for a Neptune Analytics graph"""
     client = ClientFactory().neptune()
+    resp = get_graph_or_exception(client, graph_id)
+    assert_managed_graph(resp.get("name"))
     resp = client.get_graph_summary(graphIdentifier=graph_id, mode="BASIC")
     s = resp.get("graphSummary", {})
     return {

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -102,8 +102,6 @@ def delete_neptune_graph(graph_id: str):
 def get_graph_summary(graph_id: str):
     """Get node and edge counts for a Neptune Analytics graph"""
     client = ClientFactory().neptune()
-    resp = get_graph_or_exception(client, graph_id)
-    assert_managed_graph(resp.get("name"))
     resp = client.get_graph_summary(graphIdentifier=graph_id, mode="BASIC")
     s = resp.get("graphSummary", {})
     return {

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.config import get_settings
 from nx_neptune_proxy.services.projection_store import Projection, store
 from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
@@ -14,14 +14,19 @@ async def run_pipeline(projection: Projection) -> None:
     """Execute the full pipeline: create graph → Athena → import."""
     from nx_neptune.session_manager import SessionManager
 
-    graph_name = f"{Settings.from_env().graph_prefix}{projection.graph_name}"
+    graph_name = f"{get_settings().graph_prefix}{projection.graph_name}"
     s3_location = projection.s3_staging_bucket.rstrip("/") + f"/{projection.id}/"
 
     try:
         store.update(projection.id, status="importing")
 
         # Step 1: Create or reuse graph
-        _update(projection.id, step="graph_creation", label="Creating Neptune Analytics graph", progress=5)
+        _update(
+            projection.id,
+            step="graph_creation",
+            label="Creating Neptune Analytics graph",
+            progress=5,
+        )
         sm = SessionManager(session_name=graph_name)
         graphs = sm.list_graphs()
         existing = next((g for g in graphs if g.status == "AVAILABLE"), None)
@@ -29,20 +34,36 @@ async def run_pipeline(projection: Projection) -> None:
         if existing:
             # Reuse existing graph (retry scenario) — reset data
             graph = existing
-            store.update(projection.id, graph_id=graph.graph_id,
-                         graph_endpoint=f"https://{graph.graph_id}.neptune-graph.amazonaws.com")
-            _update(projection.id, step="graph_reset", label="Resetting graph data", progress=25)
+            store.update(
+                projection.id,
+                graph_id=graph.graph_id,
+                graph_endpoint=f"https://{graph.graph_id}.neptune-graph.amazonaws.com",
+            )
+            _update(
+                projection.id,
+                step="graph_reset",
+                label="Resetting graph data",
+                progress=25,
+            )
             await sm.reset_graph(graph.name)
         else:
             # Brand new graph — no reset needed
             graph = await sm.get_or_create_graph(
                 config={"provisionedMemory": projection.graph_memory_gb}
             )
-            store.update(projection.id, graph_id=graph.graph_id,
-                         graph_endpoint=f"https://{graph.graph_id}.neptune-graph.amazonaws.com")
+            store.update(
+                projection.id,
+                graph_id=graph.graph_id,
+                graph_endpoint=f"https://{graph.graph_id}.neptune-graph.amazonaws.com",
+            )
 
         # Step 2: Athena query + CSV import
-        _update(projection.id, step="athena_import", label="Running Athena query and importing data", progress=45)
+        _update(
+            projection.id,
+            step="athena_import",
+            label="Running Athena query and importing data",
+            progress=45,
+        )
         sql_queries = [q for q in [projection.node_query, projection.edge_query] if q]
         await sm.import_from_table(
             graph=graph,
@@ -52,7 +73,9 @@ async def run_pipeline(projection: Projection) -> None:
             database=projection.database,
             remove_buckets=True,
         )
-        _update(projection.id, step="athena_import", label="Import complete", progress=90)
+        _update(
+            projection.id, step="athena_import", label="Import complete", progress=90
+        )
 
         # Step 3: Done
         _update(projection.id, step="ready", label="Graph ready", progress=100)
@@ -67,7 +90,9 @@ async def run_pipeline(projection: Projection) -> None:
             error_msg = str(e)
 
         # Sanitize before persisting — strip ARNs, account IDs
-        store.update(projection.id, status="failed", error=sanitize_error_message(error_msg))
+        store.update(
+            projection.id, status="failed", error=sanitize_error_message(error_msg)
+        )
 
 
 def _update(projection_id: str, step: str, label: str, progress: float) -> None:

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -34,7 +34,7 @@ def assert_managed_graph(graph_name: str | None) -> None:
     if not graph_name or not graph_name.startswith(prefix):
         raise HTTPException(
             status_code=403,
-            detail=f"Refusing to delete graph '{graph_name or ''}': not managed by this tool (expected prefix '{prefix}')",
+            detail=f"Refusing to operate on graph '{graph_name or ''}': not managed by this tool (expected prefix '{prefix}')",
         )
 
 

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
-from nx_neptune_proxy.config import Settings
+from nx_neptune_proxy.config import get_settings
 
 
 def get_graph_or_exception(client, graph_id: str) -> dict:
@@ -30,7 +30,7 @@ def assert_managed_graph(graph_name: str | None) -> None:
         graph_name: The full (prefixed) graph name as it exists in Neptune.
                     If None or empty, the guard rejects the request.
     """
-    prefix = Settings.from_env().graph_prefix
+    prefix = get_settings().graph_prefix
     if not graph_name or not graph_name.startswith(prefix):
         raise HTTPException(
             status_code=403,
@@ -62,5 +62,9 @@ def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
 def unpack_query_results(rows: list) -> dict:
     """Convert raw query rows (header + data) into {columns, rows} dict."""
     columns = rows[0] if rows else []
-    data_rows = [[cell if cell is not None else "n/a" for cell in row] for row in rows[1:]] if len(rows) > 1 else []
+    data_rows = (
+        [[cell if cell is not None else "n/a" for cell in row] for row in rows[1:]]
+        if len(rows) > 1
+        else []
+    )
     return {"columns": columns, "rows": data_rows}

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -34,7 +34,7 @@ def assert_managed_graph(graph_name: str | None) -> None:
     if not graph_name or not graph_name.startswith(prefix):
         raise HTTPException(
             status_code=403,
-            detail=f"Refusing to operate on graph '{graph_name or ''}': not managed by this tool (expected prefix '{prefix}')",
+            detail="Refusing to operate on a graph not managed by this tool",
         )
 
 

--- a/proxy/tests/test_get_settings.py
+++ b/proxy/tests/test_get_settings.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""get_settings — the single validated Settings instance shared process-wide."""
+
+import pytest
+
+import nx_neptune_proxy.config as config_module
+from nx_neptune_proxy.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def reset_settings_cache():
+    """Ensure each test starts and ends with a clean settings cache, since
+    get_settings caches in a module global."""
+    config_module._settings = None
+    yield
+    config_module._settings = None
+
+
+def test_returns_same_instance_across_calls(monkeypatch):
+    """Validate-and-enforce parity: every consumer gets the exact same
+    object, so the instance validated on first access is the instance
+    everyone (e.g. the managed-graph guard) later reads."""
+    monkeypatch.setenv("GRAPH_PREFIX", "nxp-")
+    first = get_settings()
+    second = get_settings()
+    assert first is second
+
+
+def test_validates_on_first_access(monkeypatch):
+    """An empty GRAPH_PREFIX is rejected the first time settings are read,
+    not silently accepted."""
+    monkeypatch.setenv("GRAPH_PREFIX", "")
+    with pytest.raises(SystemExit):
+        get_settings()
+
+
+def test_guard_reads_the_validated_instance(monkeypatch):
+    """The guard's prefix comes from the same shared instance."""
+    monkeypatch.setenv("GRAPH_PREFIX", "custom-")
+    from nx_neptune_proxy.utils.aws_helper import assert_managed_graph
+
+    # Populate the shared instance, then confirm the guard honors its prefix.
+    assert get_settings().graph_prefix == "custom-"
+    assert_managed_graph("custom-graph")  # should not raise
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        assert_managed_graph("nxp-graph")

--- a/proxy/tests/test_graph.py
+++ b/proxy/tests/test_graph.py
@@ -227,12 +227,7 @@ async def test_perform_graph_not_found_returns_404(mock_cf, client):
 
 
 @pytest.mark.asyncio
-@patch("nx_neptune_proxy.routers.graph.ClientFactory")
-async def test_get_inflight_no_operation(mock_cf, client):
-    mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test"}
-    mock_cf.return_value.neptune.return_value = mock_neptune
-
+async def test_get_inflight_no_operation(client):
     resp = await client.get("/api/v0/graphs/g-123/inflight")
     assert resp.status_code == 200
     data = resp.json()
@@ -241,12 +236,7 @@ async def test_get_inflight_no_operation(mock_cf, client):
 
 
 @pytest.mark.asyncio
-@patch("nx_neptune_proxy.routers.graph.ClientFactory")
-async def test_get_inflight_with_operation(mock_cf, client):
-    mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "STOPPING", "name": "nxp-test"}
-    mock_cf.return_value.neptune.return_value = mock_neptune
-
+async def test_get_inflight_with_operation(client):
     graph_state_machine._inflight["g-123"] = {"action": "stop", "error": None}
 
     resp = await client.get("/api/v0/graphs/g-123/inflight")
@@ -257,12 +247,7 @@ async def test_get_inflight_with_operation(mock_cf, client):
 
 
 @pytest.mark.asyncio
-@patch("nx_neptune_proxy.routers.graph.ClientFactory")
-async def test_get_inflight_with_error(mock_cf, client):
-    mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test"}
-    mock_cf.return_value.neptune.return_value = mock_neptune
-
+async def test_get_inflight_with_error(client):
     graph_state_machine._inflight["g-123"] = {"action": "stop", "error": "Timeout"}
 
     resp = await client.get("/api/v0/graphs/g-123/inflight")

--- a/proxy/tests/test_graph.py
+++ b/proxy/tests/test_graph.py
@@ -14,7 +14,7 @@ from nx_neptune_proxy.services import graph_state_machine
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
+    return AsyncClient(transport=transport, base_url="http://localhost", headers={"X-Requested-With": "nx-neptune"})
 
 
 @pytest.fixture(autouse=True)
@@ -32,7 +32,7 @@ def clear_inflight():
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_get_actions_available_graph(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.get("/api/v0/graphs/g-123/actions")
@@ -50,7 +50,7 @@ async def test_get_actions_available_graph(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_get_actions_stopped_graph(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "STOPPED"}
+    mock_neptune.get_graph.return_value = {"status": "STOPPED", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.get("/api/v0/graphs/g-123/actions")
@@ -66,7 +66,7 @@ async def test_get_actions_stopped_graph(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_get_actions_transient_state(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "STOPPING"}
+    mock_neptune.get_graph.return_value = {"status": "STOPPING", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.get("/api/v0/graphs/g-123/actions")
@@ -80,7 +80,7 @@ async def test_get_actions_transient_state(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_get_actions_empty_status_returns_502(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": ""}
+    mock_neptune.get_graph.return_value = {"status": "", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.get("/api/v0/graphs/g-123/actions")
@@ -91,7 +91,7 @@ async def test_get_actions_empty_status_returns_502(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_get_actions_missing_status_returns_502(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {}
+    mock_neptune.get_graph.return_value = {"name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.get("/api/v0/graphs/g-123/actions")
@@ -116,7 +116,7 @@ async def test_get_actions_graph_not_found_returns_404(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_get_actions_with_inflight(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "STOPPING"}
+    mock_neptune.get_graph.return_value = {"status": "STOPPING", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     graph_state_machine._inflight["g-123"] = {"action": "stop", "error": None}
@@ -136,7 +136,7 @@ async def test_get_actions_with_inflight(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_perform_stop_accepted(mock_cf, mock_exec, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/stop")
@@ -152,7 +152,7 @@ async def test_perform_stop_accepted(mock_cf, mock_exec, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_perform_start_accepted(mock_cf, mock_exec, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "STOPPED"}
+    mock_neptune.get_graph.return_value = {"status": "STOPPED", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/start")
@@ -179,7 +179,7 @@ async def test_perform_delete_accepted(mock_cf, mock_exec, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_perform_invalid_transition_returns_409(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "STOPPED"}
+    mock_neptune.get_graph.return_value = {"status": "STOPPED", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/stop")
@@ -191,7 +191,7 @@ async def test_perform_invalid_transition_returns_409(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_perform_unknown_action_returns_409(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE"}
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/restart")
@@ -202,7 +202,7 @@ async def test_perform_unknown_action_returns_409(mock_cf, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_perform_empty_status_returns_502(mock_cf, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": ""}
+    mock_neptune.get_graph.return_value = {"status": "", "name": "nxp-test"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/stop")
@@ -227,7 +227,12 @@ async def test_perform_graph_not_found_returns_404(mock_cf, client):
 
 
 @pytest.mark.asyncio
-async def test_get_inflight_no_operation(client):
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_inflight_no_operation(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
     resp = await client.get("/api/v0/graphs/g-123/inflight")
     assert resp.status_code == 200
     data = resp.json()
@@ -236,7 +241,12 @@ async def test_get_inflight_no_operation(client):
 
 
 @pytest.mark.asyncio
-async def test_get_inflight_with_operation(client):
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_inflight_with_operation(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "STOPPING", "name": "nxp-test"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
     graph_state_machine._inflight["g-123"] = {"action": "stop", "error": None}
 
     resp = await client.get("/api/v0/graphs/g-123/inflight")
@@ -247,7 +257,12 @@ async def test_get_inflight_with_operation(client):
 
 
 @pytest.mark.asyncio
-async def test_get_inflight_with_error(client):
+@patch("nx_neptune_proxy.routers.graph.ClientFactory")
+async def test_get_inflight_with_error(mock_cf, client):
+    mock_neptune = MagicMock()
+    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test"}
+    mock_cf.return_value.neptune.return_value = mock_neptune
+
     graph_state_machine._inflight["g-123"] = {"action": "stop", "error": "Timeout"}
 
     resp = await client.get("/api/v0/graphs/g-123/inflight")

--- a/proxy/tests/test_graph.py
+++ b/proxy/tests/test_graph.py
@@ -14,7 +14,11 @@ from nx_neptune_proxy.services import graph_state_machine
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://localhost", headers={"X-Requested-With": "nx-neptune"})
+    return AsyncClient(
+        transport=transport,
+        base_url="http://localhost",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -166,7 +170,10 @@ async def test_perform_start_accepted(mock_cf, mock_exec, client):
 @patch("nx_neptune_proxy.routers.graph.ClientFactory")
 async def test_perform_delete_accepted(mock_cf, mock_exec, client):
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-test-graph"}
+    mock_neptune.get_graph.return_value = {
+        "status": "AVAILABLE",
+        "name": "nxp-test-graph",
+    }
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/delete")
@@ -288,7 +295,10 @@ async def test_dismiss_inflight_noop_when_nothing(client):
 async def test_delete_rejects_unmanaged_graph(mock_cf, client):
     """Delete action should return 403 for graphs without the nxp- prefix."""
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "foreign-graph"}
+    mock_neptune.get_graph.return_value = {
+        "status": "AVAILABLE",
+        "name": "foreign-graph",
+    }
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-456/delete")
@@ -302,7 +312,10 @@ async def test_delete_rejects_unmanaged_graph(mock_cf, client):
 async def test_delete_allows_managed_graph(mock_cf, mock_exec, client):
     """Delete action should succeed for graphs with the nxp- prefix."""
     mock_neptune = MagicMock()
-    mock_neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-my-graph"}
+    mock_neptune.get_graph.return_value = {
+        "status": "AVAILABLE",
+        "name": "nxp-my-graph",
+    }
     mock_cf.return_value.neptune.return_value = mock_neptune
 
     resp = await client.post("/api/v0/graphs/g-123/delete")

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -13,7 +13,11 @@ from nx_neptune_proxy.app import app
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
 
 
 # --- Athena databases ---
@@ -33,10 +37,12 @@ async def test_list_catalogs(mock_cf, client):
 
     resp = await client.get("/api/v0/metadata/athena/catalogs")
     assert resp.status_code == 200
-    assert resp.json() == {"catalogs": [
-        {"name": "AwsDataCatalog", "status": "CREATE_COMPLETE"},
-        {"name": "MyCatalog", "status": "CREATE_COMPLETE"},
-    ]}
+    assert resp.json() == {
+        "catalogs": [
+            {"name": "AwsDataCatalog", "status": "CREATE_COMPLETE"},
+            {"name": "MyCatalog", "status": "CREATE_COMPLETE"},
+        ]
+    }
 
 
 @pytest.mark.asyncio
@@ -85,7 +91,8 @@ async def test_list_databases_custom_catalog(mock_cf, client):
 async def test_list_databases_access_denied(mock_cf, client):
     mock_athena = MagicMock()
     mock_athena.list_databases.side_effect = ClientError(
-        {"Error": {"Code": "AccessDeniedException", "Message": "No access"}}, "ListDatabases"
+        {"Error": {"Code": "AccessDeniedException", "Message": "No access"}},
+        "ListDatabases",
     )
     mock_cf.return_value.athena.return_value = mock_athena
 
@@ -125,13 +132,22 @@ async def test_list_tables_missing_database(client):
 async def test_list_columns(mock_cf, client):
     mock_athena = MagicMock()
     mock_athena.get_table_metadata.return_value = {
-        "TableMetadata": {"Columns": [{"Name": "id", "Type": "int"}, {"Name": "name", "Type": "string"}]}
+        "TableMetadata": {
+            "Columns": [
+                {"Name": "id", "Type": "int"},
+                {"Name": "name", "Type": "string"},
+            ]
+        }
     }
     mock_cf.return_value.athena.return_value = mock_athena
 
-    resp = await client.get("/api/v0/metadata/athena/columns?database=mydb&table=mytable")
+    resp = await client.get(
+        "/api/v0/metadata/athena/columns?database=mydb&table=mytable"
+    )
     assert resp.status_code == 200
-    assert resp.json() == {"columns": [{"name": "id", "type": "int"}, {"name": "name", "type": "string"}]}
+    assert resp.json() == {
+        "columns": [{"name": "id", "type": "int"}, {"name": "name", "type": "string"}]
+    }
 
 
 @pytest.mark.asyncio
@@ -144,13 +160,15 @@ async def test_list_columns_missing_params(client):
 
 
 @pytest.mark.asyncio
-@patch("nx_neptune_proxy.routers.metadata.Settings")
+@patch("nx_neptune_proxy.routers.metadata.get_settings")
 @patch("nx_neptune_proxy.routers.metadata.ClientFactory")
-async def test_list_s3_buckets(mock_cf, mock_settings, client):
+async def test_list_s3_buckets(mock_cf, mock_get_settings, client):
     mock_s3 = MagicMock()
-    mock_s3.list_buckets.return_value = {"Buckets": [{"Name": "bucket1"}, {"Name": "bucket2"}]}
+    mock_s3.list_buckets.return_value = {
+        "Buckets": [{"Name": "bucket1"}, {"Name": "bucket2"}]
+    }
     mock_cf.return_value.s3.return_value = mock_s3
-    mock_settings.from_env.return_value.region = "us-west-2"
+    mock_get_settings.return_value.region = "us-west-2"
 
     resp = await client.get("/api/v0/metadata/s3/buckets")
     assert resp.status_code == 200
@@ -159,10 +177,10 @@ async def test_list_s3_buckets(mock_cf, mock_settings, client):
 
 
 @pytest.mark.asyncio
-@patch("nx_neptune_proxy.routers.metadata.Settings")
+@patch("nx_neptune_proxy.routers.metadata.get_settings")
 @patch("nx_neptune_proxy.routers.metadata.ClientFactory")
-async def test_list_s3_buckets_no_region(mock_cf, mock_settings, client):
-    mock_settings.from_env.return_value.region = ""
+async def test_list_s3_buckets_no_region(mock_cf, mock_get_settings, client):
+    mock_get_settings.return_value.region = ""
 
     resp = await client.get("/api/v0/metadata/s3/buckets")
     assert resp.status_code == 200
@@ -213,7 +231,8 @@ async def test_list_neptune_graphs_empty(mock_cf, client):
 async def test_unknown_aws_error_returns_502(mock_cf, client):
     mock_neptune = MagicMock()
     mock_neptune.list_graphs.side_effect = ClientError(
-        {"Error": {"Code": "InternalServerError", "Message": "Something broke"}}, "ListGraphs"
+        {"Error": {"Code": "InternalServerError", "Message": "Something broke"}},
+        "ListGraphs",
     )
     mock_cf.return_value.neptune.return_value = mock_neptune
 
@@ -232,10 +251,14 @@ async def test_delete_neptune_graph_success(mock_cf, client):
     mock_neptune.get_graph.return_value = {"name": "nxp-my-graph"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
-    resp = await client.request("DELETE", "/api/v0/metadata/neptune/graph-analytics/g-123")
+    resp = await client.request(
+        "DELETE", "/api/v0/metadata/neptune/graph-analytics/g-123"
+    )
     assert resp.status_code == 202
     assert resp.json() == {"id": "g-123", "status": "DELETING"}
-    mock_neptune.delete_graph.assert_called_once_with(graphIdentifier="g-123", skipSnapshot=True)
+    mock_neptune.delete_graph.assert_called_once_with(
+        graphIdentifier="g-123", skipSnapshot=True
+    )
 
 
 @pytest.mark.asyncio
@@ -245,7 +268,9 @@ async def test_delete_neptune_graph_rejects_unmanaged(mock_cf, client):
     mock_neptune.get_graph.return_value = {"name": "foreign-graph"}
     mock_cf.return_value.neptune.return_value = mock_neptune
 
-    resp = await client.request("DELETE", "/api/v0/metadata/neptune/graph-analytics/g-456")
+    resp = await client.request(
+        "DELETE", "/api/v0/metadata/neptune/graph-analytics/g-456"
+    )
     assert resp.status_code == 403
     assert "not managed" in resp.json()["detail"]
     mock_neptune.delete_graph.assert_not_called()
@@ -256,10 +281,13 @@ async def test_delete_neptune_graph_rejects_unmanaged(mock_cf, client):
 async def test_delete_neptune_graph_not_found(mock_cf, client):
     mock_neptune = MagicMock()
     mock_neptune.get_graph.side_effect = ClientError(
-        {"Error": {"Code": "ResourceNotFoundException", "Message": "Graph not found"}}, "GetGraph"
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "Graph not found"}},
+        "GetGraph",
     )
     mock_cf.return_value.neptune.return_value = mock_neptune
 
-    resp = await client.request("DELETE", "/api/v0/metadata/neptune/graph-analytics/g-999")
+    resp = await client.request(
+        "DELETE", "/api/v0/metadata/neptune/graph-analytics/g-999"
+    )
     assert resp.status_code == 404
     assert "not found" in resp.json()["detail"].lower()

--- a/proxy/tests/test_prefix_guard.py
+++ b/proxy/tests/test_prefix_guard.py
@@ -7,36 +7,39 @@ import pytest
 from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
-from nx_neptune_proxy.utils.aws_helper import assert_managed_graph, get_graph_or_exception
+from nx_neptune_proxy.utils.aws_helper import (
+    assert_managed_graph,
+    get_graph_or_exception,
+)
 
 
-@patch("nx_neptune_proxy.utils.aws_helper.Settings")
-def test_assert_managed_graph_passes_with_prefix(mock_settings):
-    mock_settings.from_env.return_value.graph_prefix = "nxp-"
+@patch("nx_neptune_proxy.utils.aws_helper.get_settings")
+def test_assert_managed_graph_passes_with_prefix(mock_get_settings):
+    mock_get_settings.return_value.graph_prefix = "nxp-"
     # Should not raise
     assert_managed_graph("nxp-my-graph")
 
 
-@patch("nx_neptune_proxy.utils.aws_helper.Settings")
-def test_assert_managed_graph_rejects_wrong_prefix(mock_settings):
-    mock_settings.from_env.return_value.graph_prefix = "nxp-"
+@patch("nx_neptune_proxy.utils.aws_helper.get_settings")
+def test_assert_managed_graph_rejects_wrong_prefix(mock_get_settings):
+    mock_get_settings.return_value.graph_prefix = "nxp-"
     with pytest.raises(HTTPException) as exc_info:
         assert_managed_graph("other-graph")
     assert exc_info.value.status_code == 403
     assert "not managed" in exc_info.value.detail
 
 
-@patch("nx_neptune_proxy.utils.aws_helper.Settings")
-def test_assert_managed_graph_rejects_none(mock_settings):
-    mock_settings.from_env.return_value.graph_prefix = "nxp-"
+@patch("nx_neptune_proxy.utils.aws_helper.get_settings")
+def test_assert_managed_graph_rejects_none(mock_get_settings):
+    mock_get_settings.return_value.graph_prefix = "nxp-"
     with pytest.raises(HTTPException) as exc_info:
         assert_managed_graph(None)
     assert exc_info.value.status_code == 403
 
 
-@patch("nx_neptune_proxy.utils.aws_helper.Settings")
-def test_assert_managed_graph_rejects_empty_string(mock_settings):
-    mock_settings.from_env.return_value.graph_prefix = "nxp-"
+@patch("nx_neptune_proxy.utils.aws_helper.get_settings")
+def test_assert_managed_graph_rejects_empty_string(mock_get_settings):
+    mock_get_settings.return_value.graph_prefix = "nxp-"
     with pytest.raises(HTTPException) as exc_info:
         assert_managed_graph("")
     assert exc_info.value.status_code == 403
@@ -56,7 +59,8 @@ def test_get_graph_or_exception_returns_response():
 def test_get_graph_or_exception_raises_404_on_not_found():
     mock_client = MagicMock()
     mock_client.get_graph.side_effect = ClientError(
-        {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}}, "GetGraph"
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
+        "GetGraph",
     )
     with pytest.raises(HTTPException) as exc_info:
         get_graph_or_exception(mock_client, "g-999")

--- a/proxy/tests/test_validate.py
+++ b/proxy/tests/test_validate.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Settings.validate — reports all configuration errors at once."""
+
+import pytest
+
+from nx_neptune_proxy.config import Settings
+
+
+def test_valid_config_does_not_raise():
+    Settings(graph_prefix="nxp-").validate()  # should not raise
+
+
+def test_empty_prefix_reported():
+    with pytest.raises(SystemExit) as exc_info:
+        Settings(graph_prefix="").validate()
+    message = str(exc_info.value)
+    assert "invalid configuration" in message
+    assert "GRAPH_PREFIX" in message
+
+
+def test_errors_reported_as_a_list():
+    """Errors are collected and rendered as a bulleted list, so multiple
+    problems would all appear in one report rather than one-at-a-time."""
+    with pytest.raises(SystemExit) as exc_info:
+        Settings(graph_prefix="").validate()
+    message = str(exc_info.value)
+    # Each collected error is rendered as its own bullet.
+    assert message.count("  - ") == 1


### PR DESCRIPTION
**Summary**

Extends the `nxp-` prefix guard to all graph modification endpoints. Previously only delete was guarded — stop and start accepted any graph ID in the account.

**Motivation**

Several endpoints didn't apply the prefix check, so they operated on graphs outside the set this tool manages:

- `POST /graphs/{id}/stop` and `POST /graphs/{id}/start` could stop/start any Neptune graph in the account. Both dispatch through `perform_action` in `graph.py`, where the guard was scoped to `if action == "delete"` — so stop/start slipped past it.
- `GET /graphs/{id}/actions` reported status for arbitrary graphs
- An empty `GRAPH_PREFIX` made the guard a no-op (`"".startswith("") == True`)

Note: graph deletion (`delete_neptune_graph` in `metadata.py`) was already guarded before this PR — it's a separate handler and not part of the `perform_action` dispatch.

**Changes**

- Moved `assert_managed_graph` above the action dispatch in `perform_action` — now covers stop/start/delete
- Added the prefix guard to `get_available_actions`
- Added `Settings.validate()` that rejects an empty `GRAPH_PREFIX` at startup
- Generalized the error message from "Refusing to delete" to "Refusing to operate on"

**Intentionally not guarded**

- `get_graph_summary` — read-only (just node/edge counts), and guarding it adds an extra `get_graph` call per request.
- `get_inflight_status` — reads a local in-memory map that is only populated by guarded actions, so it only ever contains managed graphs. Unmanaged IDs return null. No Neptune call.