### PR TITLE
Feat: Make graph connectivity and deletion protection configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ environment, or a SageMaker notebook configured for that VPC — with a
 [Neptune Analytics private endpoint](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/vpc.html)
 reachable from the client's subnet and security group.
 
-### Working from a laptop (public connectivity)
+### Connecting to a public graph (local development)
 
 If you are developing locally and connecting directly to the graph from your
 machine, opt into a public endpoint and (optionally) relax deletion protection:

--- a/README.md
+++ b/README.md
@@ -180,6 +180,52 @@ Analytics instance. Make sure your AWS credentials are properly configured and
 your IAM role/user has the required permissions (ReadDataViaQuery,
 WriteDataViaQuery, DeleteDataViaQuery).
 
+## Graph creation defaults
+
+When nx-neptune creates a Neptune Analytics graph for you (via `SessionManager`,
+the instance-management APIs, or the proxy), it applies **secure defaults**:
+
+| Setting | Default | Environment variable | Effect |
+|---|---|---|---|
+| Public connectivity | `false` | `NETWORKX_PUBLIC_CONNECTIVITY` | Graph has **no public endpoint** — reachable only from within its VPC |
+| Deletion protection | `true` | `NETWORKX_DELETION_PROTECTION` | Graph **cannot be deleted** until protection is turned off |
+
+These defaults favor safety over convenience: a freshly created graph is private
+and cannot be accidentally destroyed. Public connectivity is **opt-in** — set
+`NETWORKX_PUBLIC_CONNECTIVITY=true` to enable it. Deletion protection is
+**opt-out** — set `NETWORKX_DELETION_PROTECTION=false` to disable it. Values are
+case-insensitive, and any unrecognized value keeps the secure default.
+
+An explicit value passed in the `config` dict always wins over the environment
+variable, which in turn wins over the default.
+
+### Connecting to a private graph (VPC)
+
+With `NETWORKX_PUBLIC_CONNECTIVITY=false`, the graph is only reachable over a
+private endpoint. The client (your notebook, script, or the proxy) must run
+inside the same VPC as the graph — for example on an EC2 instance, a Cloud9
+environment, or a SageMaker notebook configured for that VPC — with a
+[Neptune Analytics private endpoint](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/vpc.html)
+reachable from the client's subnet and security group.
+
+### Working from a laptop (public connectivity)
+
+If you are developing locally and connecting directly to the graph from your
+machine, opt into a public endpoint and (optionally) relax deletion protection:
+
+```bash
+export NETWORKX_PUBLIC_CONNECTIVITY=true
+export NETWORKX_DELETION_PROTECTION=false
+```
+
+> **Note on the local proxy:** the proxy's `make dev`, `make run`, and `make up`
+> targets already set these two variables, because the proxy is a local
+> development tool that creates and tears down short-lived graphs. If you launch
+> the proxy **outside** the Makefile (e.g. raw `uvicorn`, or a container that
+> does not set them), you get the secure defaults — a private graph you cannot
+> reach from a laptop and that will refuse deletion — so set the variables
+> explicitly in that case.
+
 ## Running tests
 
 Unit tests can be run with make, this runs all tests in the `test` folder:

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -734,9 +734,18 @@ def _get_create_instance_config(graph_name, config=None):
 
     config = config or {}
     # Ensure mandatory config present.
-    config.setdefault("publicConnectivity", True)
+    # Secure by default: private graph + deletion protection. Public connectivity
+    # is opt-in ("true"); deletion protection is opt-out ("false"). Any other
+    # value keeps the secure state. An explicit `config` value wins over both.
+    config.setdefault(
+        "publicConnectivity",
+        os.getenv("NETWORKX_PUBLIC_CONNECTIVITY", "false").strip().lower() == "true",
+    )
     config.setdefault("replicaCount", 0)
-    config.setdefault("deletionProtection", False)
+    config.setdefault(
+        "deletionProtection",
+        os.getenv("NETWORKX_DELETION_PROTECTION", "true").strip().lower() != "false",
+    )
     config.setdefault("provisionedMemory", 16)
 
     # Make sure agent tag shows regardless
@@ -777,9 +786,18 @@ def _get_create_instance_with_import_config(
 
     config = config or {}
     # Ensure mandatory config present.
-    config.setdefault("publicConnectivity", True)
+    # Secure by default: private graph + deletion protection. Public connectivity
+    # is opt-in ("true"); deletion protection is opt-out ("false"). Any other
+    # value keeps the secure state. An explicit `config` value wins over both.
+    config.setdefault(
+        "publicConnectivity",
+        os.getenv("NETWORKX_PUBLIC_CONNECTIVITY", "false").strip().lower() == "true",
+    )
     config.setdefault("replicaCount", 0)
-    config.setdefault("deletionProtection", False)
+    config.setdefault(
+        "deletionProtection",
+        os.getenv("NETWORKX_DELETION_PROTECTION", "true").strip().lower() != "false",
+    )
     config.setdefault("minProvisionedMemory", 16)
     config.setdefault("maxProvisionedMemory", 32)
     config.setdefault("format", "CSV")

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -880,6 +880,19 @@ def _delete_na_instance_task(client, graph_id: str):
     Raises:
         ClientError: If there's an issue with the AWS API call
     """
+    # Graphs are created with deletion protection enabled by default (secure
+    # default). delete_graph fails with ConflictException on a protected graph,
+    # so clear protection first. This is best-effort: if the graph is already
+    # unprotected the update is a harmless no-op, and any failure here is logged
+    # rather than masking the delete the caller asked for.
+    try:
+        client.update_graph(graphIdentifier=graph_id, deletionProtection=False)
+    except ClientError as e:
+        logger.warning(
+            "Could not clear deletion protection for graph %s before delete: %s",
+            graph_id,
+            e,
+        )
     response = client.delete_graph(graphIdentifier=graph_id, skipSnapshot=True)
     return response
 

--- a/nx_neptune/instance_management.py
+++ b/nx_neptune/instance_management.py
@@ -716,6 +716,22 @@ async def update_na_instance_size(
         )
 
 
+def _log_connectivity_hint(config):
+    """Log a hint when a graph will be created without public connectivity.
+
+    A private graph is only reachable from within its VPC, so a caller that
+    creates one and then tries to connect from outside the VPC will hang until
+    the connection times out with no obvious cause. Surfacing the resolved
+    setting makes that failure diagnosable and points at the opt-in env var.
+    """
+    if not config.get("publicConnectivity"):
+        logger.info(
+            "Creating graph with publicConnectivity=false (private, VPC-only). "
+            "To connect from outside the VPC, set NETWORKX_PUBLIC_CONNECTIVITY=true "
+            "or pass publicConnectivity=True in config."
+        )
+
+
 def _get_create_instance_config(graph_name, config=None):
     """
     Build and sanitize the configuration dictionary for creating a graph instance.
@@ -752,6 +768,7 @@ def _get_create_instance_config(graph_name, config=None):
     config["graphName"] = graph_name
     config.setdefault("tags", {}).setdefault("agent", _PROJECT_IDENTIFIER)
 
+    _log_connectivity_hint(config)
     return config
 
 
@@ -808,6 +825,7 @@ def _get_create_instance_with_import_config(
     config["roleArn"] = role_arn
     config.setdefault("tags", {}).setdefault("agent", _PROJECT_IDENTIFIER)
 
+    _log_connectivity_hint(config)
     return config
 
 

--- a/proxy/Makefile
+++ b/proxy/Makefile
@@ -6,6 +6,7 @@ ui:               ## Build frontend into ui/ directory.
 	cd ui-src && npm install && npm run build
 
 dev:              ## Run with auto-reload for development.
+	NETWORKX_PUBLIC_CONNECTIVITY=true NETWORKX_DELETION_PROTECTION=false \
 	uvicorn nx_neptune_proxy.app:app --reload --host 127.0.0.1 --port 8080
 
 install:          ## Install proxy in editable mode with test deps.
@@ -25,6 +26,8 @@ run:              ## Run container with AWS credentials from environment.
 		-e AWS_DEFAULT_REGION \
 		-e CORS_ALLOWED_ORIGINS \
 		-e LOG_LEVEL \
+		-e NETWORKX_PUBLIC_CONNECTIVITY=true \
+		-e NETWORKX_DELETION_PROTECTION=false \
 		nx-neptune-proxy
 
 stop:             ## Stop running container.
@@ -35,6 +38,7 @@ clean:            ## Remove container and image.
 	@$(RUNTIME) rmi nx-neptune-proxy 2>/dev/null || true
 
 up:               ## Start proxy + Graph Explorer with compose.
+	NETWORKX_PUBLIC_CONNECTIVITY=true NETWORKX_DELETION_PROTECTION=false \
 	$(RUNTIME) compose up --build --force-recreate -d
 
 up-ge:            ## Start only Graph Explorer.

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
       - CORS_ALLOWED_ORIGINS=http://localhost:8080,https://localhost:6373
       - LOG_LEVEL=info
+      # Pass-through from the host env. If unset, the library applies its secure
+      # defaults (private graph + deletion protection). `make up` sets both.
+      - NETWORKX_PUBLIC_CONNECTIVITY
+      - NETWORKX_DELETION_PROTECTION
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8080/health"]
       interval: 10s

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -954,6 +954,26 @@ def test_delete_proceeds_when_clearing_protection_fails():
     )
 
 
+def test_private_graph_logs_connectivity_hint(caplog, monkeypatch):
+    """A private (default) graph logs a hint pointing at the opt-in env var."""
+    from nx_neptune.instance_management import _get_create_instance_config
+
+    monkeypatch.delenv("NETWORKX_PUBLIC_CONNECTIVITY", raising=False)
+    with caplog.at_level("INFO", logger="nx_neptune.instance_management"):
+        _get_create_instance_config("test")
+    assert "NETWORKX_PUBLIC_CONNECTIVITY=true" in caplog.text
+
+
+def test_public_graph_does_not_log_connectivity_hint(caplog, monkeypatch):
+    """A public graph (opt-in) does not emit the private-connectivity hint."""
+    from nx_neptune.instance_management import _get_create_instance_config
+
+    monkeypatch.setenv("NETWORKX_PUBLIC_CONNECTIVITY", "true")
+    with caplog.at_level("INFO", logger="nx_neptune.instance_management"):
+        _get_create_instance_config("test")
+    assert "publicConnectivity=false" not in caplog.text
+
+
 @pytest.mark.asyncio
 @patch("boto3.client")
 async def test_delete_na_instance_insufficient_permissions(mock_boto3_client):
@@ -991,7 +1011,10 @@ async def test_delete_na_instance_failure(mock_boto3_client):
 
 
 @pytest.mark.asyncio
-async def test_create_graph_config_base():
+async def test_create_graph_config_base(monkeypatch):
+    # Assert the secure defaults independent of the developer's environment.
+    monkeypatch.delenv("NETWORKX_PUBLIC_CONNECTIVITY", raising=False)
+    monkeypatch.delenv("NETWORKX_DELETION_PROTECTION", raising=False)
     result = _get_create_instance_config("test")
     expected = {
         "graphName": "test",
@@ -1005,7 +1028,10 @@ async def test_create_graph_config_base():
 
 
 @pytest.mark.asyncio
-async def test_create_graph_config_custom_parameters():
+async def test_create_graph_config_custom_parameters(monkeypatch):
+    # Assert the secure defaults independent of the developer's environment.
+    monkeypatch.delenv("NETWORKX_PUBLIC_CONNECTIVITY", raising=False)
+    monkeypatch.delenv("NETWORKX_DELETION_PROTECTION", raising=False)
     # Unrelated parameters will be discarded.
     config = {
         "custom_parameter": 123,
@@ -1314,10 +1340,13 @@ async def test_create_na_instance_with_s3_import_success(
     assert task_id == "test-task-id"
 
 
-def test_get_create_instance_with_import_config():
+def test_get_create_instance_with_import_config(monkeypatch):
     """Test _get_create_instance_with_import_config function."""
     from nx_neptune.instance_management import _get_create_instance_with_import_config
 
+    # Assert the secure defaults independent of the developer's environment.
+    monkeypatch.delenv("NETWORKX_PUBLIC_CONNECTIVITY", raising=False)
+    monkeypatch.delenv("NETWORKX_DELETION_PROTECTION", raising=False)
     result = _get_create_instance_with_import_config(
         "test-graph",
         "s3://test-bucket/data",

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -954,9 +954,9 @@ async def test_create_graph_config_base():
     result = _get_create_instance_config("test")
     expected = {
         "graphName": "test",
-        "publicConnectivity": True,
+        "publicConnectivity": False,
         "replicaCount": 0,
-        "deletionProtection": False,
+        "deletionProtection": True,
         "provisionedMemory": 16,
         "tags": {"agent": "nx-neptune"},
     }
@@ -974,9 +974,9 @@ async def test_create_graph_config_custom_parameters():
     result = _get_create_instance_config("test", config)
     expected = {
         "graphName": "test",
-        "publicConnectivity": True,
+        "publicConnectivity": False,
         "replicaCount": 0,
-        "deletionProtection": False,
+        "deletionProtection": True,
         "provisionedMemory": 16,
         "tags": {"agent": "nx-neptune"},
         "custom_parameter": 123,
@@ -1006,6 +1006,39 @@ async def test_create_graph_config_override_default_options():
         "tags": {"agent": "nx-neptune", "additional_tag": "test_value"},
     }
     assert expected == result
+
+
+@pytest.mark.asyncio
+async def test_create_graph_config_env_override(monkeypatch):
+    # Env vars flip the secure defaults when no explicit config is given.
+    monkeypatch.setenv("NETWORKX_PUBLIC_CONNECTIVITY", "true")
+    monkeypatch.setenv("NETWORKX_DELETION_PROTECTION", "false")
+    result = _get_create_instance_config("test")
+    assert result["publicConnectivity"] is True
+    assert result["deletionProtection"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_graph_config_explicit_beats_env(monkeypatch):
+    # Explicit config always wins over env vars.
+    monkeypatch.setenv("NETWORKX_PUBLIC_CONNECTIVITY", "true")
+    monkeypatch.setenv("NETWORKX_DELETION_PROTECTION", "false")
+    result = _get_create_instance_config(
+        "test", {"publicConnectivity": False, "deletionProtection": True}
+    )
+    assert result["publicConnectivity"] is False
+    assert result["deletionProtection"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_graph_config_unrecognized_env_keeps_secure(monkeypatch):
+    # A typo / unrecognized value must land on the secure side for both:
+    # public stays private, deletion stays protected.
+    monkeypatch.setenv("NETWORKX_PUBLIC_CONNECTIVITY", "yes")
+    monkeypatch.setenv("NETWORKX_DELETION_PROTECTION", "ture")
+    result = _get_create_instance_config("test")
+    assert result["publicConnectivity"] is False
+    assert result["deletionProtection"] is True
 
 
 @pytest.mark.asyncio
@@ -1254,7 +1287,8 @@ def test_get_create_instance_with_import_config():
     assert result["source"] == "s3://test-bucket/data"
     assert result["roleArn"] == "arn:aws:iam::123456789012:role/test-role"
     assert result["format"] == "CSV"
-    assert result["publicConnectivity"] is True
+    assert result["publicConnectivity"] is False
+    assert result["deletionProtection"] is True
     assert result["tags"]["agent"] == "nx-neptune"
 
 

--- a/tests/clients/test_instance_management.py
+++ b/tests/clients/test_instance_management.py
@@ -913,6 +913,47 @@ async def test_delete_na_instance_success(mock_boto3_client):
     assert result == "test-123"
 
 
+def test_delete_clears_deletion_protection_before_delete():
+    """The teardown path must clear deletion protection (update_graph) before
+    delete_graph, otherwise Neptune rejects deleting a protected graph."""
+    from nx_neptune.instance_management import _delete_na_instance_task
+
+    client = MagicMock()
+    manager = MagicMock()
+    manager.attach_mock(client.update_graph, "update_graph")
+    manager.attach_mock(client.delete_graph, "delete_graph")
+
+    _delete_na_instance_task(client, "g-123")
+
+    client.update_graph.assert_called_once_with(
+        graphIdentifier="g-123", deletionProtection=False
+    )
+    client.delete_graph.assert_called_once_with(
+        graphIdentifier="g-123", skipSnapshot=True
+    )
+    # update_graph must come before delete_graph
+    order = [c[0] for c in manager.mock_calls]
+    assert order.index("update_graph") < order.index("delete_graph")
+
+
+def test_delete_proceeds_when_clearing_protection_fails():
+    """If clearing deletion protection errors (e.g. already unprotected), the
+    delete the caller asked for still proceeds."""
+    from nx_neptune.instance_management import _delete_na_instance_task
+
+    client = MagicMock()
+    client.update_graph.side_effect = ClientError(
+        error_response={"Error": {"Code": "ValidationException"}},
+        operation_name="UpdateGraph",
+    )
+
+    _delete_na_instance_task(client, "g-123")
+
+    client.delete_graph.assert_called_once_with(
+        graphIdentifier="g-123", skipSnapshot=True
+    )
+
+
 @pytest.mark.asyncio
 @patch("boto3.client")
 async def test_delete_na_instance_insufficient_permissions(mock_boto3_client):


### PR DESCRIPTION
## Summary

Graph creation previously hardcoded `publicConnectivity=true` and `deletionProtection=false`. This makes both configurable via environment variables so users can set them per environment without passing an explicit config dict.

## What changed

Both config builders (`_get_create_instance_config` and `_get_create_instance_with_import_config`) now read two env vars:

| Setting | Default | Env var | Behavior |
|---------|---------|---------|----------|
| `publicConnectivity` | `False` | `NETWORKX_PUBLIC_CONNECTIVITY` | set `true` to enable |
| `deletionProtection` | `True` | `NETWORKX_DELETION_PROTECTION` | set `false` to disable |

Precedence: explicit value in `config` > env var > default. An unrecognized env value falls back to the default, so a typo won't flip a setting unexpectedly.

Defaults changed from the previous values; anyone who wants the old behavior sets the two env vars (the proxy does exactly this — see below).

## Proxy (local dev)

The proxy creates and tears down short-lived graphs from a laptop, so it sets public connectivity on and deletion protection off at launch, rather than changing the library:

- `make dev` / `make run` set both env vars inline
- `make up` sets them and `docker-compose.yml` passes them through from the host
  (unset → library defaults)

## Tests

- Updated the two config-builder tests for the new defaults.
- Added: env override, explicit-beats-env, and unrecognized-value-falls-back.
- 72 tests pass in `test_instance_management.py`.