### PR TITLE
Feat: Sign and attest release artifacts (PyPI + GitHub Releases)

### DIFF
--- a/.github/workflows/python-prerelease.yml
+++ b/.github/workflows/python-prerelease.yml
@@ -49,6 +49,9 @@ jobs:
     needs: prerelease-build
     permissions:
       contents: write
+      # Required for keyless build-provenance attestation (Sigstore via OIDC).
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -63,8 +66,22 @@ jobs:
       - name: Package notebooks
         run: zip -j notebooks.zip notebooks/*.ipynb notebooks/README.md
 
+      - name: Generate checksums
+        run: |
+          ( cd dist && sha256sum *.whl ) > SHA256SUMS
+          sha256sum notebooks.zip >> SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            dist/*.whl
+            notebooks.zip
+            SHA256SUMS
+
       - name: Upload assets to GitHub Prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl notebooks.zip
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl notebooks.zip SHA256SUMS

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -50,6 +50,7 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      attestations: write
 
     # Dedicated environments with protections for publishing are strongly recommended.
     # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
@@ -68,12 +69,18 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
+          # Explicitly declare Sigstore attestations rather than relying on the
+          # action's default, so a future version bump can't silently drop them.
+          attestations: true
 
   github-release-upload:
     runs-on: ubuntu-latest
     needs: release-build
     permissions:
       contents: write
+      # Required for keyless build-provenance attestation (Sigstore via OIDC).
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -88,8 +95,22 @@ jobs:
       - name: Package notebooks
         run: zip -j notebooks.zip notebooks/*.ipynb notebooks/README.md
 
+      - name: Generate checksums
+        run: |
+          ( cd dist && sha256sum *.whl ) > SHA256SUMS
+          sha256sum notebooks.zip >> SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            dist/*.whl
+            notebooks.zip
+            SHA256SUMS
+
       - name: Upload assets to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl notebooks.zip
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/*.whl notebooks.zip SHA256SUMS

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,56 @@ This repository contains three independently released components:
 | Athena Databricks Connector | Java | SAM / Lambda | Manual deploy from `connectors/athena-databricks-connector/` |
 | Athena S3Vector Connector | Java | SAM / Lambda | Manual deploy from `connectors/athena-s3vector-connector/` |
 
+## Verifying release artifacts
+
+Every `nx_neptune` GitHub Release (and prerelease) ships with:
+
+- the wheel (`nx_neptune-<version>-py3-none-any.whl`),
+- `notebooks.zip`,
+- a `SHA256SUMS` checksum manifest.
+
+The wheel, `notebooks.zip`, and `SHA256SUMS` are covered by a **Sigstore build
+provenance attestation** generated in the release workflow
+([`python-publish.yml`](.github/workflows/python-publish.yml) /
+[`python-prerelease.yml`](.github/workflows/python-prerelease.yml)) via
+`actions/attest-build-provenance`. Signing is keyless (GitHub OIDC) — no signing
+keys are stored in the repository.
+
+### Verify provenance (recommended)
+
+Requires the [GitHub CLI](https://cli.github.com/) (`gh` ≥ 2.49). Download the
+asset from the Releases page, then:
+
+```bash
+gh attestation verify nx_neptune-<version>-py3-none-any.whl --repo awslabs/nx-neptune
+```
+
+To pin verification to the exact release workflow that is allowed to sign:
+
+```bash
+gh attestation verify nx_neptune-<version>-py3-none-any.whl \
+  --repo awslabs/nx-neptune \
+  --signer-workflow awslabs/nx-neptune/.github/workflows/python-publish.yml
+```
+
+The same command works for `notebooks.zip` and `SHA256SUMS`.
+
+### Verify checksums
+
+After verifying provenance on `SHA256SUMS`, confirm the downloaded files match
+it (run from the directory containing the downloaded assets):
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+### PyPI provenance
+
+Wheels published to [PyPI](https://pypi.org/project/nx-neptune/) also carry
+Sigstore attestations (the publish step sets `attestations: true`). PyPI exposes
+these on the project's files page; note that `pip install` does not verify them
+automatically today.
+
 ## Pre-release checklist
 
 ### 1. Ensure CI is green


### PR DESCRIPTION
## Summary

Release artifacts had no explicit signing or provenance: the PyPI path relied on the action's implicit default, and the GitHub Release `.whl` + `notebooks.zip` were unsigned. This adds keyless Sigstore build provenance, makes the PyPI attestation explicit, and documents verification. Mirrors the sibling awslabs project graphrag-toolkit.

## Changes

- **`python-publish.yml`** — explicit `attestations: true` on the PyPI step; `attestations: write` on that job; and on `github-release-upload`: provenance via `actions/attest-build-provenance` (SHA-pinned) + a `SHA256SUMS` manifest  over `dist/*.whl` + `notebooks.zip`.
- **`python-prerelease.yml`** — same provenance + checksums on the upload job.
- **`RELEASE.md`** — "Verifying release artifacts": `gh attestation verify`, `sha256sum -c SHA256SUMS`, and a note that PyPI attestations aren't checked by `pip`.

## Notes

Keyless (GitHub OIDC / Sigstore), no keys in the repo. nx-neptune ships only a wheel, so no sdist in the subject paths. Full signing runs on the next tagged release; both YAMLs validated as well-formed.

  > **Prior art:** this mirrors the release setup already used by the sibling
  > awslabs project [graphrag-toolkit](https://github.com/awslabs/graphrag-toolkit)
  > — see its
  >
  [`lexical-graph-release.yml`](https://github.com/awslabs/graphrag-toolkit/blob/main/.github/workflows/lexical-graph-release.yml)
  > (`actions/attest-build-provenance` + explicit `attestations: true` + a
  > `SHA256SUMS` step). Same action version (v4.2.2) and pattern.
  