### PR TITLE
Fix: Reuse graphs by exact id and validate graph_name

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -4,7 +4,19 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+# --- graph_name validation ---
+
+# Neptune Analytics graph names in this tool are formed as `{prefix}{graph_name}`.
+# Constrain the user-supplied portion so it cannot be empty/short and collide with
+# the managed prefix (which previously allowed adopting/resetting an unrelated
+# graph). First character must be alphanumeric; remaining may include
+# hyphen/underscore. Upper- and lower-case are both allowed.
+GRAPH_NAME_MIN_LENGTH = 3
+GRAPH_NAME_MAX_LENGTH = 63
+GRAPH_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_-]{2,62}$"
 
 
 # --- Metadata responses ---
@@ -59,7 +71,12 @@ class ProjectionCreate(BaseModel):
     sql_query: Optional[str] = None
     node_query: Optional[str] = None
     edge_query: Optional[str] = None
-    graph_name: Optional[str] = None
+    graph_name: Optional[str] = Field(
+        default=None,
+        min_length=GRAPH_NAME_MIN_LENGTH,
+        max_length=GRAPH_NAME_MAX_LENGTH,
+        pattern=GRAPH_NAME_PATTERN,
+    )
     graph_memory_gb: int = 16
     s3_staging_bucket: Optional[str] = None
     project_id: Optional[str] = None
@@ -71,7 +88,12 @@ class ProjectionUpdate(BaseModel):
     sql_query: Optional[str] = None
     node_query: Optional[str] = None
     edge_query: Optional[str] = None
-    graph_name: Optional[str] = None
+    graph_name: Optional[str] = Field(
+        default=None,
+        min_length=GRAPH_NAME_MIN_LENGTH,
+        max_length=GRAPH_NAME_MAX_LENGTH,
+        pattern=GRAPH_NAME_PATTERN,
+    )
     graph_memory_gb: Optional[int] = None
     s3_staging_bucket: Optional[str] = None
 

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -17,7 +17,7 @@ def _assert_managed(graph_name: str | None) -> None:
     than HTTPException because the pipeline runs as a background task where an
     HTTP response cannot be returned.
     """
-    prefix = Settings.from_env().graph_prefix
+    prefix = get_settings().graph_prefix
     if not graph_name or not graph_name.startswith(prefix):
         raise RuntimeError(
             f"Refusing to reset graph '{graph_name or ''}': not managed by this tool "

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -10,8 +10,24 @@ from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 logger = logging.getLogger(__name__)
 
 
+def _assert_managed(graph_name: str | None) -> None:
+    """Raise if graph_name isn't managed by this tool (doesn't carry the prefix).
+
+    Mirrors aws_helper.assert_managed_graph, but raises a plain exception rather
+    than HTTPException because the pipeline runs as a background task where an
+    HTTP response cannot be returned.
+    """
+    prefix = Settings.from_env().graph_prefix
+    if not graph_name or not graph_name.startswith(prefix):
+        raise RuntimeError(
+            f"Refusing to reset graph '{graph_name or ''}': not managed by this tool "
+            f"(expected prefix '{prefix}')"
+        )
+
+
 async def run_pipeline(projection: Projection) -> None:
     """Execute the full pipeline: create graph → Athena → import."""
+    from nx_neptune.clients.client_factory import ClientFactory
     from nx_neptune.session_manager import SessionManager
 
     graph_name = f"{get_settings().graph_prefix}{projection.graph_name}"
@@ -28,8 +44,27 @@ async def run_pipeline(projection: Projection) -> None:
             progress=5,
         )
         sm = SessionManager(session_name=graph_name)
-        graphs = sm.list_graphs()
-        existing = next((g for g in graphs if g.status == "AVAILABLE"), None)
+
+        # Only reuse a graph we previously recorded for THIS projection, matched by
+        # exact graph_id — never adopt an arbitrary graph by name prefix (a short or
+        # empty graph_name would otherwise collide with, and reset, an unrelated graph).
+        existing = None
+        if projection.graph_id:
+            neptune = ClientFactory().neptune()
+            try:
+                resp = neptune.get_graph(graphIdentifier=projection.graph_id)
+            except Exception:
+                # Recorded graph no longer exists (or is unreachable): treat as a
+                # fresh run and create a new graph below rather than adopting one.
+                logger.warning(
+                    "Recorded graph_id %s not retrievable; creating a new graph",
+                    projection.graph_id,
+                )
+                resp = None
+            if resp is not None and resp.get("status") == "AVAILABLE":
+                # Guard: confirm the recorded graph is one this tool manages before reset.
+                _assert_managed(resp.get("name"))
+                existing = sm.get_graph(projection.graph_id)
 
         if existing:
             # Reuse existing graph (retry scenario) — reset data

--- a/proxy/tests/test_graph_name_collision.py
+++ b/proxy/tests/test_graph_name_collision.py
@@ -1,0 +1,141 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the graph_name prefix-collision reset vulnerability.
+
+Previously an unvalidated / short / empty ``graph_name`` collapsed to just the
+managed prefix and was matched against existing graphs with ``startswith``, so
+the pipeline could adopt and reset an unrelated graph. The fix:
+
+1. Constrains ``graph_name`` in the request schema (min length + pattern), so it
+   can no longer be empty or a 1-2 char prefix-colliding value.
+2. Reworks the pipeline so it only reuses a graph recorded for the projection by
+   *exact* ``graph_id`` (and only after confirming it is managed by this tool);
+   a first run always creates a brand-new graph rather than adopting one by name.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nx_neptune_proxy.services.pipeline import run_pipeline
+from nx_neptune_proxy.services.projection_store import store
+
+
+# --- Schema validation (defense-in-depth) ---
+
+
+class TestGraphNameSchemaValidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_name", ["", "a", "ab", "-abc", "has space", "bad!char"])
+    async def test_rejects_invalid_graph_name(self, client, bad_name):
+        """Empty, too-short, or illegal graph_name is rejected with 422."""
+        resp = await client.post(
+            "/api/v0/projection",
+            json={"database": "mydb", "graph_name": bad_name},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ok_name", ["abc", "Test-Graph", "my_graph_1", "ABC123"])
+    async def test_accepts_valid_graph_name(self, client, ok_name):
+        """Valid names (incl. uppercase and underscore) are accepted."""
+        resp = await client.post(
+            "/api/v0/projection",
+            json={"database": "mydb", "graph_name": ok_name},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["graph_name"] == ok_name
+
+
+# --- Pipeline adoption logic ---
+
+
+def _make_projection(**overrides):
+    defaults = dict(
+        database="mydb",
+        node_query="SELECT * FROM t",
+        graph_name="my-graph",
+        s3_staging_bucket="s3://bucket/staging/",
+    )
+    defaults.update(overrides)
+    return store.create(**defaults)
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune.clients.client_factory.ClientFactory")
+@patch("nx_neptune.session_manager.SessionManager")
+async def test_first_run_never_adopts_existing_graph(mock_sm_cls, mock_cf, clear_store):
+    """With no recorded graph_id, the pipeline must create a new graph and must
+    NOT list/adopt an existing graph by prefix."""
+    projection = _make_projection()
+    assert projection.graph_id is None
+
+    sm = mock_sm_cls.return_value
+    created = MagicMock(graph_id="g-new", name="nxp-my-graph")
+    sm.get_or_create_graph = AsyncMock(return_value=created)
+    sm.reset_graph = AsyncMock()
+    sm.import_from_table = AsyncMock(return_value="task-1")
+
+    await run_pipeline(projection)
+
+    # Brand-new graph created; no reset of any pre-existing graph.
+    sm.get_or_create_graph.assert_awaited_once()
+    sm.reset_graph.assert_not_called()
+    # The neptune client is only consulted when a graph_id is recorded.
+    mock_cf.return_value.neptune.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune.clients.client_factory.ClientFactory")
+@patch("nx_neptune.session_manager.SessionManager")
+async def test_retry_resets_only_the_recorded_graph_by_id(mock_sm_cls, mock_cf, clear_store):
+    """With a recorded graph_id pointing at a managed AVAILABLE graph, the
+    pipeline reuses that exact graph and resets it."""
+    projection = _make_projection()
+    store.update(projection.id, graph_id="g-mine")
+    projection = store.get(projection.id)
+
+    neptune = mock_cf.return_value.neptune.return_value
+    neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "nxp-my-graph"}
+
+    sm = mock_sm_cls.return_value
+    recorded = MagicMock(graph_id="g-mine")
+    recorded.name = "nxp-my-graph"  # .name must be set explicitly (reserved MagicMock kwarg)
+    sm.get_graph.return_value = recorded
+    sm.get_or_create_graph = AsyncMock()
+    sm.reset_graph = AsyncMock()
+    sm.import_from_table = AsyncMock(return_value="task-1")
+
+    await run_pipeline(projection)
+
+    # Looked up by EXACT id, reset only that graph, did not create a new one.
+    neptune.get_graph.assert_called_once_with(graphIdentifier="g-mine")
+    sm.get_graph.assert_called_once_with("g-mine")
+    sm.reset_graph.assert_awaited_once_with("nxp-my-graph")
+    sm.get_or_create_graph.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("nx_neptune.clients.client_factory.ClientFactory")
+@patch("nx_neptune.session_manager.SessionManager")
+async def test_recorded_graph_not_managed_fails_without_reset(mock_sm_cls, mock_cf, clear_store):
+    """If the recorded graph does not carry the managed prefix, the pipeline
+    refuses to reset it and marks the projection failed."""
+    projection = _make_projection()
+    store.update(projection.id, graph_id="g-foreign")
+    projection = store.get(projection.id)
+
+    neptune = mock_cf.return_value.neptune.return_value
+    # AVAILABLE, but name lacks the managed prefix (nxp-).
+    neptune.get_graph.return_value = {"status": "AVAILABLE", "name": "prod-analytics"}
+
+    sm = mock_sm_cls.return_value
+    sm.reset_graph = AsyncMock()
+    sm.get_or_create_graph = AsyncMock()
+
+    await run_pipeline(projection)
+
+    sm.reset_graph.assert_not_called()
+    sm.get_or_create_graph.assert_not_called()
+    assert store.get(projection.id).status == "failed"


### PR DESCRIPTION
## Summary

The pipeline previously matched existing graphs by `startswith({prefix}{graph_name})` and reused the first match. With a short or empty `graph_name` this could match more broadly than intended. This makes graph reuse identity-based (exact `graph_id`) and adds input validation on `graph_name`, so reuse is predictable and scoped to the projection's own graph.

## Changes

- **`schemas.py`** — validate `graph_name` (`ProjectionCreate`/`Update`):  min 3 / max 63, pattern `^[A-Za-z0-9][A-Za-z0-9_-]{2,62}$` (upper/lower, digit, `-`, `_`). Empty/short values now return 422.
- **`pipeline.py`** — first run always creates a new graph rather than adopting one by name; retry looks up the recorded `graph_id` exactly and resets only that graph, after confirming it carries the managed prefix. If it's not a managed graph the run stops and the projection is marked `failed` (no reset).  Shared `list_graphs()` behaviour is unchanged.
- **`test_graph_name_collision.py`** (new) — covers the validation rules and the reuse/adoption behaviour.

## Testing

Full proxy suite green: 115 passed (102 existing + 13 new).