### PR TITLE
Feat: Harden openCypher query construction for algorithm parameters and labels

### DIFF
--- a/integ_test/graph_operations/test_security_injection.py
+++ b/integ_test/graph_operations/test_security_injection.py
@@ -139,6 +139,74 @@ class TestInjectionUpdateNode:
         props = results[0]["n"].get("~properties", {})
         assert props["injected"] == payload
 
+class TestInjectionAlgorithmParameters:
+    """Prove label / property-key / algorithm-parameter injection is neutralized.
+
+    These exercise the identifier and algorithm-parameter interpolation paths
+    (vertex_label, edge_labels, write_property) that are NOT covered by the
+    property-value / node-ID parameterization above.
+    """
+
+    def test_pagerank_vertex_label_injection(self, na_graph):
+        import networkx as nx
+
+        # Contains a double-quote (the breakout char for a quoted string literal),
+        # a backslash, and a backtick — so it exercises the double-quote/backslash
+        # escaping applied to identifier-valued algorithm parameters.
+        payload = 'X"`\\ }) MATCH (m) DETACH DELETE m //'
+        # Must never execute the injected DETACH DELETE — either runs harmlessly
+        # (label matches nothing) or raises.
+        try:
+            nx.pagerank(nx.Graph(), backend="neptune", vertex_label=payload)
+        except Exception:
+            pass
+
+        results = na_graph.na_client.execute_generic_query(
+            "MATCH (n:Canary) WHERE id(n) = $id RETURN n",
+            parameter_map={"id": CANARY_NODE_ID},
+        )
+        assert len(results) == 1, "Canary destroyed via vertex_label injection"
+
+    def test_pagerank_write_property_injection(self, na_graph):
+        import networkx as nx
+
+        payload = 'X"`\\ }) MATCH (m) DETACH DELETE m //'
+        try:
+            nx.pagerank(nx.Graph(), backend="neptune", write_property=payload)
+        except Exception:
+            pass
+
+        results = na_graph.na_client.execute_generic_query(
+            "MATCH (n:Canary) WHERE id(n) = $id RETURN n",
+            parameter_map={"id": CANARY_NODE_ID},
+        )
+        assert len(results) == 1, "Canary destroyed via write_property injection"
+
+    def test_bfs_edge_labels_injection(self, na_graph):
+        import networkx as nx
+
+        # Double-quote is the breakout char for the quoted list element; include
+        # a backtick and backslash too.
+        payload = '"`\\] }) MATCH (m) DETACH DELETE m //'
+        try:
+            list(
+                nx.bfs_edges(
+                    nx.Graph(),
+                    source=CANARY_NODE_ID,
+                    backend="neptune",
+                    edge_labels=[payload],
+                )
+            )
+        except Exception:
+            pass
+
+        results = na_graph.na_client.execute_generic_query(
+            "MATCH (n:Canary) WHERE id(n) = $id RETURN n",
+            parameter_map={"id": CANARY_NODE_ID},
+        )
+        assert len(results) == 1, "Canary destroyed via edge_labels injection"
+
+
 
 class TestInjectionCanarySurvival:
     """Final check: canary node must still exist after all injection tests."""

--- a/nx_neptune/clients/neptune_constants.py
+++ b/nx_neptune/clients/neptune_constants.py
@@ -68,3 +68,77 @@ RESPONSE_SUCCESS = "success"
 
 # Misc
 MAX_INT = 9223372036854775807
+
+# ---------------------------------------------------------------------------
+# Algorithm-parameter validation allowlists
+#
+# neptune.algo.* procedures take their configuration as an inline openCypher map
+# literal ({key:value,...}) in the CALL clause, so those keys/values cannot be
+# bound as query parameters ($n) the way MATCH/WHERE values can. To prevent
+# openCypher injection through algorithm parameters they are validated/encoded
+# in opencypher_builder._to_parameter_list against the sets below.
+#
+# Value ranges are taken from the Neptune Analytics algorithm documentation, e.g.
+# https://docs.aws.amazon.com/neptune-analytics/latest/userguide/label-propagation.html
+# ---------------------------------------------------------------------------
+
+# Every algorithm-parameter key the library is allowed to emit. Any key outside
+# this set is rejected (fail closed) rather than interpolated.
+ALLOWED_ALGO_PARAM_KEYS = {
+    PARAM_MAX_DEPTH,
+    PARAM_TRAVERSAL_DIRECTION,
+    PARAM_DISTANCE,
+    PARAM_DAMPING_FACTOR,
+    PARAM_NUM_OF_ITERATIONS,
+    PARAM_NUM_SOURCES,
+    PARAM_NORMALIZE,
+    PARAM_TOLERANCE,
+    PARAM_SEED,
+    PARAM_RESOLUTION,
+    PARAM_VERTEX_LABEL,
+    PARAM_VERTEX_WEIGHT_PROPERTY,
+    PARAM_VERTEX_WEIGHT_TYPE,
+    PARAM_EDGE_LABELS,
+    PARAM_LEVEL_TOLERANCE,
+    PARAM_CONCURRENCY,
+    PARAM_EDGE_WEIGHT_PROPERTY,
+    PARAM_EDGE_WEIGHT_TYPE,
+    PARAM_MAX_ITERATIONS,
+    PARAM_SOURCE_NODES,
+    PARAM_SOURCE_WEIGHTS,
+    PARAM_WRITE_PROPERTY,
+    PARAM_MAX_LEVEL,
+    PARAM_ITERATION_TOLERANCE,
+}
+
+# String parameters that name a label or property (open-domain identifiers).
+# openCypher permits almost any name when backtick-quoted, so these are
+# backtick-escaped + wrapped rather than matched against a narrow charset.
+ALGO_PARAM_IDENTIFIER_KEYS = {
+    PARAM_VERTEX_LABEL,
+    PARAM_WRITE_PROPERTY,
+    PARAM_EDGE_WEIGHT_PROPERTY,
+    PARAM_VERTEX_WEIGHT_PROPERTY,
+}
+
+# String parameters with a closed set of legal values (rejected if not a member).
+PARAM_TRAVERSAL_DIRECTIONS = {
+    PARAM_TRAVERSAL_DIRECTION_INBOUND,
+    PARAM_TRAVERSAL_DIRECTION_OUTBOUND,
+    PARAM_TRAVERSAL_DIRECTION_BOTH,
+}
+PARAM_WEIGHT_TYPES = {"int", "long", "float", "double"}
+
+ALGO_PARAM_ENUM_VALUES = {
+    PARAM_TRAVERSAL_DIRECTION: PARAM_TRAVERSAL_DIRECTIONS,
+    PARAM_EDGE_WEIGHT_TYPE: PARAM_WEIGHT_TYPES,
+    PARAM_VERTEX_WEIGHT_TYPE: PARAM_WEIGHT_TYPES,
+}
+
+# List-valued parameters whose string elements are label/identifier-like and are
+# backtick-escaped per element; numeric elements pass through.
+ALGO_PARAM_LIST_KEYS = {
+    PARAM_EDGE_LABELS,
+    PARAM_SOURCE_NODES,
+    PARAM_SOURCE_WEIGHTS,
+}

--- a/nx_neptune/clients/opencypher_builder.py
+++ b/nx_neptune/clients/opencypher_builder.py
@@ -74,6 +74,19 @@ __all__ = [
 ]
 
 
+def _truncate_for_error(value: Any, limit: int = 40) -> str:
+    """Return a repr of ``value`` safe to embed in an error message.
+
+    Validation errors can carry attacker-supplied input; reflecting the whole
+    value verbatim into exceptions/logs is undesirable. Truncate long values so
+    the message stays useful for debugging without echoing an unbounded payload.
+    """
+    text = repr(value)
+    if len(text) > limit:
+        return text[:limit] + "…"
+    return text
+
+
 def _escape_labels(labels) -> list:
     """Backtick-escape a list of node/edge labels.
 
@@ -142,8 +155,8 @@ def _render_parameter_value(key: str, value: Any) -> str:
         allowed = ALGO_PARAM_ENUM_VALUES[key]
         if value not in allowed:
             raise ValueError(
-                f"Invalid value {value!r} for parameter {key!r}; "
-                f"expected one of {sorted(allowed)}"
+                f"Invalid value {_truncate_for_error(value)} for parameter "
+                f"{key!r}; expected one of {sorted(allowed)}"
             )
         return _escape_string_literal(value)
 
@@ -162,7 +175,9 @@ def _render_parameter_value(key: str, value: Any) -> str:
     # List-valued parameters: encode each element.
     if key in ALGO_PARAM_LIST_KEYS:
         if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
-            raise ValueError(f"Parameter {key!r} must be a list, got {type(value).__name__}")
+            raise ValueError(
+                f"Parameter {key!r} must be a list, got {type(value).__name__}"
+            )
         return "[" + ", ".join(_render_list_element(v) for v in value) + "]"
 
     # Everything else is expected to be numeric or boolean. Reject strings and
@@ -173,7 +188,8 @@ def _render_parameter_value(key: str, value: Any) -> str:
         return str(value)
 
     raise ValueError(
-        f"Invalid value {value!r} for parameter {key!r}: expected a numeric value"
+        f"Invalid value {_truncate_for_error(value)} for parameter "
+        f"{key!r}: expected a numeric value"
     )
 
 
@@ -1225,7 +1241,7 @@ def _get_nodes_in_list(source_nodes: list[str]):
     nodes = [source_nodes] if isinstance(source_nodes, str) else source_nodes
     for node_id in nodes:
         if not _NODE_ID_RE.match(str(node_id)):
-            raise ValueError(f"Invalid node ID: {node_id!r}")
+            raise ValueError(f"Invalid node ID: {_truncate_for_error(node_id)}")
     return "[" + ",".join(f"'{s}'" for s in nodes) + "]"
 
 

--- a/nx_neptune/clients/opencypher_builder.py
+++ b/nx_neptune/clients/opencypher_builder.py
@@ -17,7 +17,13 @@ from cymple import QueryBuilder
 
 from . import PARAM_MAX_DEPTH
 from .na_models import Edge, ImmutableEdgeGroupBy, Node
-from .neptune_constants import RESPONSE_SUCCESS
+from .neptune_constants import (
+    ALGO_PARAM_ENUM_VALUES,
+    ALGO_PARAM_IDENTIFIER_KEYS,
+    ALGO_PARAM_LIST_KEYS,
+    ALLOWED_ALGO_PARAM_KEYS,
+    RESPONSE_SUCCESS,
+)
 
 # Internal constants for reference names
 _SRC_NODE_REF = "a"
@@ -68,26 +74,135 @@ __all__ = [
 ]
 
 
+def _escape_labels(labels) -> list:
+    """Backtick-escape a list of node/edge labels.
+
+    Labels are interpolated into queries with escape=False (or directly into
+    f-strings), so each is backtick-quoted here to prevent injection through a
+    caller-supplied label. Returns a new list; accepts None.
+    """
+    if not labels:
+        return labels
+    if isinstance(labels, str):
+        return _escape_identifier(labels)
+    return [_escape_identifier(label) for label in labels]
+
+
+def _escape_identifier(value: str) -> str:
+    """Backtick-quote an openCypher identifier (label / property name).
+
+    openCypher permits almost any character in a backtick-quoted identifier, so
+    rather than matching against a narrow charset (which would reject legitimate
+    Neptune label/property names) we wrap the value in backticks and escape any
+    embedded backtick by doubling it — the openCypher-standard escape. This makes
+    it impossible to break out of the identifier and inject query syntax.
+
+    Example:
+        >>> _escape_identifier("pageRank")
+        '`pageRank`'
+        >>> _escape_identifier('a`) DETACH DELETE n //')
+        '`a``) DETACH DELETE n //`'
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"Expected a string identifier, got {type(value).__name__}")
+    return "`" + value.replace("`", "``") + "`"
+
+
+def _escape_string_literal(value: str) -> str:
+    """Encode a string as a double-quoted openCypher string literal.
+
+    Backslashes and double quotes are escaped so the value cannot terminate the
+    literal and inject query syntax. Used for list elements (e.g. edge labels).
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _render_list_element(value: Any) -> str:
+    """Render one element of a list-valued algorithm parameter safely."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return _escape_string_literal(value)
+    raise ValueError(f"Unsupported list element type: {type(value).__name__}")
+
+
+def _render_parameter_value(key: str, value: Any) -> str:
+    """Validate and safely encode a single algorithm parameter value.
+
+    Fail closed (raise ValueError) for closed-domain values (enums, numeric
+    types, wrong types); backtick-escape open-domain identifier values; and
+    encode list elements individually. This is the choke point that prevents
+    openCypher injection through algorithm parameters.
+    """
+    # Enum-valued string parameters: must be one of the documented values.
+    if key in ALGO_PARAM_ENUM_VALUES:
+        allowed = ALGO_PARAM_ENUM_VALUES[key]
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid value {value!r} for parameter {key!r}; "
+                f"expected one of {sorted(allowed)}"
+            )
+        return _escape_string_literal(value)
+
+    # Identifier-valued string parameters (label / property names). Inside a
+    # neptune.algo.* config map these are passed as string VALUES, so they must
+    # be double-quoted string literals (backticks would be parsed as an
+    # undefined variable reference). Escaping the quote/backslash prevents the
+    # value from terminating the literal and injecting query syntax.
+    if key in ALGO_PARAM_IDENTIFIER_KEYS:
+        if not isinstance(value, str):
+            raise ValueError(
+                f"Parameter {key!r} must be a string, got {type(value).__name__}"
+            )
+        return _escape_string_literal(value)
+
+    # List-valued parameters: encode each element.
+    if key in ALGO_PARAM_LIST_KEYS:
+        if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+            raise ValueError(f"Parameter {key!r} must be a list, got {type(value).__name__}")
+        return "[" + ", ".join(_render_list_element(v) for v in value) + "]"
+
+    # Everything else is expected to be numeric or boolean. Reject strings and
+    # other types so a value can never carry query syntax.
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    raise ValueError(
+        f"Invalid value {value!r} for parameter {key!r}: expected a numeric value"
+    )
+
+
 def _to_parameter_list(parameters: Dict[str, Any]) -> str:
     """
     Convert a dictionary of parameters to a formatted parameter string for OpenCypher queries.
+
+    Each key is validated against the allowlist of known algorithm parameters and
+    each value is validated/encoded by type (see _render_parameter_value), so that
+    labels, property keys, and parameter values cannot inject openCypher syntax.
+    Unknown keys or values that fail validation raise ValueError (fail closed).
 
     :param parameters: Dictionary of algorithm parameters
     :return: Formatted parameter string for inclusion in OpenCypher query
 
     Example:
-        >>> _to_parameter_list({'dampingFactor': 0.9, 'maxIterations': 50})
-        'dampingFactor:0.9, maxIterations:50'
+        >>> _to_parameter_list({'dampingFactor': 0.9, 'numOfIterations': 50})
+        'dampingFactor:0.9, numOfIterations:50'
     """
     if not parameters:
         return ""
 
-    return ", ".join(
-        [
-            f'{key}:"{value}"' if isinstance(value, str) else f"{key}:{value}"
-            for key, value in parameters.items()
-        ]
-    )
+    rendered = []
+    for key, value in parameters.items():
+        if key not in ALLOWED_ALGO_PARAM_KEYS:
+            raise ValueError(f"Unknown algorithm parameter: {key!r}")
+        rendered.append(f"{key}:{_render_parameter_value(key, value)}")
+
+    return ", ".join(rendered)
 
 
 class ParameterMapBuilder:
@@ -225,7 +340,7 @@ def insert_node(node: Node) -> Tuple[str, Dict[str, Any]]:
         QueryBuilder()
         .create()
         .node(
-            labels=node.labels,
+            labels=_escape_labels(node.labels),
             properties=masked_properties,
             escape=False,
         )
@@ -283,14 +398,14 @@ def insert_edge(edge: Edge) -> Tuple[str, Dict[str, Any]]:
     qb = qb.merge().node(ref_name=_SRC_NODE_REF)
     if edge.is_directed:
         qb = qb.related_to(
-            label=edge.label,
+            label=_escape_identifier(edge.label),
             ref_name=_RELATION_REF,
             properties=masked_properties,
             escape=False,
         ).node(ref_name=_DEST_NODE_REF)
     else:
         qb = qb.related(
-            label=edge.label,
+            label=_escape_identifier(edge.label),
             ref_name=_RELATION_REF,
             properties=masked_properties,
             escape=False,
@@ -302,12 +417,12 @@ def insert_edge(edge: Edge) -> Tuple[str, Dict[str, Any]]:
 def get_edge_batch_query_str(group_by_key: ImmutableEdgeGroupBy):
     # TODO: Replace with cymple when it provide wider support of UNWIND.
     src_labels = (
-        ":" + ":".join(group_by_key.labels_src_node)
+        ":" + ":".join(_escape_labels(group_by_key.labels_src_node))
         if group_by_key.labels_src_node
         else ""
     )
     dest_labels = (
-        ":" + ":".join(group_by_key.labels_dest_node)
+        ":" + ":".join(_escape_labels(group_by_key.labels_dest_node))
         if group_by_key.labels_dest_node
         else ""
     )
@@ -315,19 +430,19 @@ def get_edge_batch_query_str(group_by_key: ImmutableEdgeGroupBy):
     if group_by_key.directed:
         return (
             f"UNWIND $relations AS rel MATCH (a{src_labels} {{`~id`: rel.from}}), (b{dest_labels} {{`~id`: rel.to}}) "
-            f"CREATE (a)-[r:{group_by_key.label}]->(b) SET r += rel.properties"
+            f"CREATE (a)-[r:{_escape_identifier(group_by_key.label)}]->(b) SET r += rel.properties"
         )
     else:
         return (
             f"UNWIND $relations AS rel MATCH (a{src_labels} {{`~id`: rel.from}}), (b{dest_labels} {{`~id`: rel.to}}) "
-            f"CREATE (a)-[r1:{group_by_key.label}]->(b), (b)-[r2:{group_by_key.label}]->(a)"
+            f"CREATE (a)-[r1:{_escape_identifier(group_by_key.label)}]->(b), (b)-[r2:{_escape_identifier(group_by_key.label)}]->(a)"
             f"SET r1 += rel.properties, r2 += rel.properties"
         )
 
 
 def get_node_batch_query_str(labels_tuple):
     # TODO: Replace with cymple when it provide wider support of UNWIND.
-    labels = ":" + ":".join(labels_tuple) if labels_tuple else ""
+    labels = ":" + ":".join(_escape_labels(labels_tuple)) if labels_tuple else ""
 
     return f"UNWIND $nodes as node CREATE (n{labels} {{`~id`: node.id}}) SET n += node"
 
@@ -384,7 +499,7 @@ def update_node(
     return (
         QueryBuilder()
         .match()
-        .node(labels=match_labels, ref_name=ref_name)
+        .node(labels=_escape_labels(match_labels), ref_name=ref_name, escape=False)
         .where_literal(literal_where_clause)
         .set(masked_properties_set, escape_values=False)
         .query
@@ -426,9 +541,9 @@ def update_edge(
     qb = QueryBuilder().match()
     qb = _append_node(qb, param_builder, edge.node_src, ref_name_src)
     if edge.is_directed:
-        qb = qb.related_to(label=edge.label, ref_name=ref_name_edge)
+        qb = qb.related_to(label=_escape_identifier(edge.label), ref_name=ref_name_edge)
     else:
-        qb = qb.relates(label=edge.label, ref_name=ref_name_edge)
+        qb = qb.relates(label=_escape_identifier(edge.label), ref_name=ref_name_edge)
     qb = _append_node(qb, param_builder, edge.node_dest, ref_name_des)
 
     masked_where_filters = param_builder.read_map(where_filters)
@@ -482,9 +597,9 @@ def delete_edge(edge: Edge) -> Tuple[str, Dict[str, Any]]:
     qb = QueryBuilder().match()
     qb = _append_node(qb, param_builder, edge.node_src, _SRC_NODE_REF)
     if edge.is_directed:
-        qb = qb.related_to(label=edge.label, ref_name=_RELATION_REF)
+        qb = qb.related_to(label=_escape_identifier(edge.label), ref_name=_RELATION_REF)
     else:
-        qb = qb.relates(label=edge.label, ref_name=_RELATION_REF)
+        qb = qb.relates(label=_escape_identifier(edge.label), ref_name=_RELATION_REF)
     qb = _append_node(qb, param_builder, edge.node_dest, _DEST_NODE_REF)
     qb = qb.delete(ref_name=_RELATION_REF)
 
@@ -1090,7 +1205,7 @@ def _append_node(
     # Append the node to the query builder
     query_builder = query_builder.node(
         ref_name=ref_name,
-        labels=node.labels,
+        labels=_escape_labels(node.labels),
         properties=masked_properties,
         escape=False,
     )

--- a/tests/clients/test_opencypher_builder.py
+++ b/tests/clients/test_opencypher_builder.py
@@ -146,7 +146,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MERGE (a: Person {name : $0, `~id` : $1}) MERGE (b: Person {name : $2, `~id` : $3}) MERGE (a)-[r: FRIEND_WITH]->(b)",
+                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Person` {name : $2, `~id` : $3}) MERGE (a)-[r: `FRIEND_WITH`]->(b)",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             # Edge without properties
@@ -158,7 +158,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     node_src=Node(id="123", labels=["Person"]),
                     node_dest=Node(id="456", labels=["Person"]),
                 ),
-                " MERGE (a: Person {`~id` : $0}) MERGE (b: Person {`~id` : $1}) MERGE (a)-[r: FRIEND_WITH]->(b)",
+                " MERGE (a: `Person` {`~id` : $0}) MERGE (b: `Person` {`~id` : $1}) MERGE (a)-[r: `FRIEND_WITH`]->(b)",
                 {"0": "123", "1": "456"},
             ),
             # Edge with properties
@@ -174,7 +174,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MERGE (a: Person {name : $0, `~id` : $1}) MERGE (b: Person {name : $2, `~id` : $3}) MERGE (a)-[r: FRIEND_WITH {since : $4}]->(b)",
+                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Person` {name : $2, `~id` : $3}) MERGE (a)-[r: `FRIEND_WITH` {since : $4}]->(b)",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456", "4": "2020"},
             ),
             # Edge between nodes with multiple labels
@@ -194,7 +194,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         properties={"name": "Bob"},
                     ),
                 ),
-                " MERGE (a: Person: Employee {name : $0, `~id` : $1}) MERGE (b: Person: Manager {name : $2, `~id` : $3}) MERGE (a)-[r: REPORTS_TO]->(b)",
+                " MERGE (a: `Person`: `Employee` {name : $0, `~id` : $1}) MERGE (b: `Person`: `Manager` {name : $2, `~id` : $3}) MERGE (a)-[r: `REPORTS_TO`]->(b)",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             # Edge with numeric property values
@@ -210,7 +210,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Product"], properties={"id": "1001"}
                     ),
                 ),
-                " MERGE (a: Person {name : $0, `~id` : $1}) MERGE (b: Product {id : $2, `~id` : $3}) MERGE (a)-[r: PURCHASED {quantity : $4, price : $5}]->(b)",
+                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Product` {id : $2, `~id` : $3}) MERGE (a)-[r: `PURCHASED` {quantity : $4, price : $5}]->(b)",
                 {"0": "Alice", "1": "123", "2": "1001", "3": "456", "4": 5, "5": 29.99},
             ),
             # Edge with boolean property values
@@ -226,7 +226,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Content"], properties={"id": "content-456"}
                     ),
                 ),
-                " MERGE (a: User {username : $0, `~id` : $1}) MERGE (b: Content {id : $2, `~id` : $3}) MERGE (a)-[r: LIKED {public : $4, notified : $5}]->(b)",
+                " MERGE (a: `User` {username : $0, `~id` : $1}) MERGE (b: `Content` {id : $2, `~id` : $3}) MERGE (a)-[r: `LIKED` {public : $4, notified : $5}]->(b)",
                 {
                     "0": "alice123",
                     "1": "123",
@@ -249,7 +249,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Company"], properties={"name": "ACME Inc"}
                     ),
                 ),
-                " MERGE (a: Person {name : $0, `~id` : $1}) MERGE (b: Company {name : $2, `~id` : $3}) MERGE (a)-[r: WORKS_FOR {role : $4}]->(b)",
+                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Company` {name : $2, `~id` : $3}) MERGE (a)-[r: `WORKS_FOR` {role : $4}]->(b)",
                 {
                     "0": "Alice",
                     "1": "123",
@@ -276,7 +276,7 @@ class TestOpencypherBuilder(unittest.TestCase):
             (
                 "Single label with properties",
                 Node(id="123", labels=["Person"], properties={"name": "Alice"}),
-                " CREATE (: Person {name : $0, `~id` : $1})",
+                " CREATE (: `Person` {name : $0, `~id` : $1})",
                 {"0": "Alice", "1": "123"},
             ),
             (
@@ -284,13 +284,13 @@ class TestOpencypherBuilder(unittest.TestCase):
                 Node(
                     id="456", labels=["Person", "Employee"], properties={"id": "12345"}
                 ),
-                " CREATE (: Person: Employee {id : $0, `~id` : $1})",
+                " CREATE (: `Person`: `Employee` {id : $0, `~id` : $1})",
                 {"0": "12345", "1": "456"},
             ),
             (
                 "Single label without properties",
                 Node(id="789", labels=["Person"]),
-                " CREATE (: Person {`~id` : $0})",
+                " CREATE (: `Person` {`~id` : $0})",
                 {"0": "789"},
             ),
             (
@@ -306,7 +306,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["Product"],
                     properties={"price": 29.99, "stock": 100},
                 ),
-                " CREATE (: Product {price : $0, stock : $1, `~id` : $2})",
+                " CREATE (: `Product` {price : $0, stock : $1, `~id` : $2})",
                 {"0": 29.99, "1": 100, "2": "222"},
             ),
             (
@@ -316,7 +316,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["User"],
                     properties={"active": True, "verified": False},
                 ),
-                " CREATE (: User {active : $0, verified : $1, `~id` : $2})",
+                " CREATE (: `User` {active : $0, verified : $1, `~id` : $2})",
                 {"0": True, "1": False, "2": "333"},
             ),
         ]
@@ -346,7 +346,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.since": "2020"},
-                " MATCH (a: Person {`~id` : $0})-[r: FRIEND_WITH]->(b: Person {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.since = $4",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.since = $4",
                 {"0": "123", "1": "456", "2": "Alice", "3": "Bob", "4": "2020"},
             ),
             (
@@ -362,7 +362,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.since": "2020", "r.strength": "strong", "r.active": "true"},
-                " MATCH (a: Person {`~id` : $0})-[r: FRIEND_WITH]->(b: Person {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.since = $4, r.strength = $5, r.active = $6",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.since = $4, r.strength = $5, r.active = $6",
                 {
                     "0": "123",
                     "1": "456",
@@ -386,7 +386,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "ACME Inc"},
                 {"r.role": "Engineer", "r.startDate": "2022-01-15"},
-                " MATCH (a: Person {`~id` : $0})-[r: WORKS_FOR]->(b: Company {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.role = $4, r.startDate = $5",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `WORKS_FOR`]->(b: `Company` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.role = $4, r.startDate = $5",
                 {
                     "0": "123",
                     "1": "456",
@@ -413,7 +413,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.strength": "very strong"},
-                " MATCH (a: Person {age : $0, `~id` : $1})-[r: FRIEND_WITH]->(b: Person {age : $2, `~id` : $3}) WHERE a.name = $4 AND b.name = $5 SET r.strength = $6",
+                " MATCH (a: `Person` {age : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {age : $2, `~id` : $3}) WHERE a.name = $4 AND b.name = $5 SET r.strength = $6",
                 {
                     "0": "30",
                     "1": "123",
@@ -441,7 +441,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.department": "Engineering"},
-                " MATCH (a: Person: Employee {`~id` : $0})-[r: REPORTS_TO]->(b: Person: Manager {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.department = $4",
+                " MATCH (a: `Person`: `Employee` {`~id` : $0})-[r: `REPORTS_TO`]->(b: `Person`: `Manager` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.department = $4",
                 {"0": "123", "1": "456", "2": "Alice", "3": "Bob", "4": "Engineering"},
             ),
             (
@@ -463,7 +463,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     "r.since": "2018",
                 },
                 {"r.strength": "best friends"},
-                " MATCH (a: Person {`~id` : $0})-[r: FRIEND_WITH]->(b: Person {`~id` : $1}) WHERE a.name = $2 AND a.age = $3 AND b.name = $4 AND b.city = $5 AND r.since = $6 SET r.strength = $7",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND a.age = $3 AND b.name = $4 AND b.city = $5 AND r.since = $6 SET r.strength = $7",
                 {
                     "0": "123",
                     "1": "456",
@@ -488,7 +488,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.id": "1001"},
                 {"r.quantity": 5, "r.price": 29.99},
-                " MATCH (a: Person {`~id` : $0})-[r: PURCHASED]->(b: Product {`~id` : $1}) WHERE a.name = $2 AND b.id = $3 SET r.quantity = $4, r.price = $5",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `PURCHASED`]->(b: `Product` {`~id` : $1}) WHERE a.name = $2 AND b.id = $3 SET r.quantity = $4, r.price = $5",
                 {"0": "123", "1": "456", "2": "Alice", "3": "1001", "4": 5, "5": 29.99},
             ),
             (
@@ -504,7 +504,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.username": "alice123", "b.id": "content-456"},
                 {"r.public": True, "r.notified": False},
-                " MATCH (a: User {`~id` : $0})-[r: LIKED]->(b: Content {`~id` : $1}) WHERE a.username = $2 AND b.id = $3 SET r.public = $4, r.notified = $5",
+                " MATCH (a: `User` {`~id` : $0})-[r: `LIKED`]->(b: `Content` {`~id` : $1}) WHERE a.username = $2 AND b.id = $3 SET r.public = $4, r.notified = $5",
                 {
                     "0": "123",
                     "1": "456",
@@ -527,7 +527,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.endDate": None},
-                " MATCH (a: Person {`~id` : $0})-[r: FRIEND_WITH]->(b: Person {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.endDate = $4",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.endDate = $4",
                 {"0": "123", "1": "456", "2": "Alice", "3": "Bob", "4": None},
             ),
             (
@@ -543,7 +543,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "actor",
                 {"movie.title": "The Matrix", "actor.name": "Keanu Reeves"},
                 {"role.character": "Neo"},
-                " MATCH (movie: Movie {`~id` : $0})-[role: ACTED_IN]->(actor: Person {`~id` : $1}) WHERE movie.title = $2 AND actor.name = $3 SET role.character = $4",
+                " MATCH (movie: `Movie` {`~id` : $0})-[role: `ACTED_IN`]->(actor: `Person` {`~id` : $1}) WHERE movie.title = $2 AND actor.name = $3 SET role.character = $4",
                 {
                     "0": "123",
                     "1": "456",
@@ -589,7 +589,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["Alice"],
                 {"a.age": "25"},
-                " MATCH (a: Person) WHERE id(a)=$0 SET a.age = $1",
+                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.age = $1",
                 {"0": "Alice", "1": "25"},
             ),
             (
@@ -598,7 +598,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["12345"],
                 {"a.age": "30", "a.status": "Active", "a.updated": "true"},
-                " MATCH (a: Person) WHERE id(a)=$0 SET a.age = $1, a.status = $2, a.updated = $3",
+                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.age = $1, a.status = $2, a.updated = $3",
                 {"0": "12345", "1": "30", "2": "Active", "3": "true"},
             ),
             (
@@ -607,7 +607,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["alice@example.com"],
                 {"a.department": "Engineering"},
-                " MATCH (a: Person: Employee) WHERE id(a)=$0 SET a.department = $1",
+                " MATCH (a: `Person`: `Employee`) WHERE id(a)=$0 SET a.department = $1",
                 {"0": "alice@example.com", "1": "Engineering"},
             ),
             (
@@ -616,7 +616,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["Alice", "Bob"],
                 {"a.lastLogin": "2023-04-01"},
-                " MATCH (a: Person) WHERE id(a)=$0 OR id(a)=$1 SET a.lastLogin = $2",
+                " MATCH (a: `Person`) WHERE id(a)=$0 OR id(a)=$1 SET a.lastLogin = $2",
                 {"0": "Alice", "1": "Bob", "2": "2023-04-01"},
             ),
             (
@@ -625,7 +625,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "p",
                 ["1001"],
                 {"p.price": 29.99, "p.stock": 100},
-                " MATCH (p: Product) WHERE id(p)=$0 SET p.price = $1, p.stock = $2",
+                " MATCH (p: `Product`) WHERE id(p)=$0 SET p.price = $1, p.stock = $2",
                 {"0": "1001", "1": 29.99, "2": 100},
             ),
             (
@@ -634,7 +634,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "u",
                 ["alice123"],
                 {"u.verified": True, "u.active": False},
-                " MATCH (u: User) WHERE id(u)=$0 SET u.verified = $1, u.active = $2",
+                " MATCH (u: `User`) WHERE id(u)=$0 SET u.verified = $1, u.active = $2",
                 {"0": "alice123", "1": True, "2": False},
             ),
             (
@@ -643,7 +643,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["Alice"],
                 {"a.previousJob": None},
-                " MATCH (a: Person) WHERE id(a)=$0 SET a.previousJob = $1",
+                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.previousJob = $1",
                 {"0": "Alice", "1": None},
             ),
             (
@@ -652,7 +652,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "movie",
                 ["The Matrix"],
                 {"movie.rating": 4.8},
-                " MATCH (movie: Movie) WHERE id(movie)=$0 SET movie.rating = $1",
+                " MATCH (movie: `Movie`) WHERE id(movie)=$0 SET movie.rating = $1",
                 {"0": "The Matrix", "1": 4.8},
             ),
         ]
@@ -682,7 +682,7 @@ class TestOpencypherBuilder(unittest.TestCase):
             (
                 "Single label with properties",
                 Node(id="123", labels=["Person"], properties={"name": "Alice"}),
-                " MATCH (n: Person {name : $0, `~id` : $1}) DELETE n",
+                " MATCH (n: `Person` {name : $0, `~id` : $1}) DELETE n",
                 {"0": "Alice", "1": "123"},
             ),
             (
@@ -690,13 +690,13 @@ class TestOpencypherBuilder(unittest.TestCase):
                 Node(
                     id="456", labels=["Person", "Employee"], properties={"id": "12345"}
                 ),
-                " MATCH (n: Person: Employee {id : $0, `~id` : $1}) DELETE n",
+                " MATCH (n: `Person`: `Employee` {id : $0, `~id` : $1}) DELETE n",
                 {"0": "12345", "1": "456"},
             ),
             (
                 "Single label without properties",
                 Node(id="789", labels=["Person"]),
-                " MATCH (n: Person {`~id` : $0}) DELETE n",
+                " MATCH (n: `Person` {`~id` : $0}) DELETE n",
                 {"0": "789"},
             ),
             (
@@ -712,7 +712,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["Product"],
                     properties={"price": 29.99, "stock": 100},
                 ),
-                " MATCH (n: Product {price : $0, stock : $1, `~id` : $2}) DELETE n",
+                " MATCH (n: `Product` {price : $0, stock : $1, `~id` : $2}) DELETE n",
                 {"0": 29.99, "1": 100, "2": "222"},
             ),
             (
@@ -722,13 +722,13 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["User"],
                     properties={"active": True, "verified": False},
                 ),
-                " MATCH (n: User {active : $0, verified : $1, `~id` : $2}) DELETE n",
+                " MATCH (n: `User` {active : $0, verified : $1, `~id` : $2}) DELETE n",
                 {"0": True, "1": False, "2": "333"},
             ),
             (
                 "Null property value",
                 Node(id="444", labels=["Person"], properties={"previousJob": None}),
-                " MATCH (n: Person {previousJob : $0, `~id` : $1}) DELETE n",
+                " MATCH (n: `Person` {previousJob : $0, `~id` : $1}) DELETE n",
                 {"0": None, "1": "444"},
             ),
         ]
@@ -757,7 +757,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MATCH (a: Person {name : $0, `~id` : $1})-[r: FRIEND_WITH]->(b: Person {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {name : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             (
@@ -772,7 +772,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MATCH (a: Person {name : $0, `~id` : $1})-[r: FRIEND_WITH]->(b: Person {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {name : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             (
@@ -783,7 +783,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     node_src=Node(id="123", labels=["Person"]),
                     node_dest=Node(id="456", labels=["Person"]),
                 ),
-                " MATCH (a: Person {`~id` : $0})-[r: FRIEND_WITH]->(b: Person {`~id` : $1}) DELETE r",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) DELETE r",
                 {"0": "123", "1": "456"},
             ),
             (
@@ -798,7 +798,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Company"], properties={"name": "ACME Inc"}
                     ),
                 ),
-                " MATCH (a: Person {name : $0, `~id` : $1})-[r: WORKS_FOR]->(b: Company {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `WORKS_FOR`]->(b: `Company` {name : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "ACME Inc", "3": "456"},
             ),
             (
@@ -817,7 +817,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         properties={"name": "Bob"},
                     ),
                 ),
-                " MATCH (a: Person: Employee {name : $0, `~id` : $1})-[r: REPORTS_TO]->(b: Person: Manager {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person`: `Employee` {name : $0, `~id` : $1})-[r: `REPORTS_TO`]->(b: `Person`: `Manager` {name : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             (
@@ -832,7 +832,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Product"], properties={"id": "1001"}
                     ),
                 ),
-                " MATCH (a: Person {name : $0, `~id` : $1})-[r: PURCHASED]->(b: Product {id : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `PURCHASED`]->(b: `Product` {id : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "1001", "3": "456"},
             ),
             (
@@ -847,7 +847,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Content"], properties={"id": "content-456"}
                     ),
                 ),
-                " MATCH (a: User {username : $0, `~id` : $1})-[r: LIKED]->(b: Content {id : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `User` {username : $0, `~id` : $1})-[r: `LIKED`]->(b: `Content` {id : $2, `~id` : $3}) DELETE r",
                 {"0": "alice123", "1": "123", "2": "content-456", "3": "456"},
             ),
             (
@@ -862,7 +862,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MATCH (a: Person {name : $0, `~id` : $1})-[r: FRIEND_WITH]->(b: Person {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {name : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
         ]

--- a/tests/clients/test_opencypher_injection.py
+++ b/tests/clients/test_opencypher_injection.py
@@ -17,6 +17,7 @@ These run in CI (no live Neptune needed), complementing the integration test in
 integ_test/graph_operations/test_security_injection.py which covers node IDs and
 property values against a real graph.
 """
+
 import pytest
 
 from nx_neptune.clients import Edge, Node
@@ -55,8 +56,14 @@ class TestParameterValueInjection:
             _to_parameter_list({"edgeWeightType": "double; DROP"})
 
     def test_enum_param_accepts_valid_value(self):
-        assert _to_parameter_list({"traversalDirection": "inbound"}) == 'traversalDirection:"inbound"'
-        assert _to_parameter_list({"edgeWeightType": "double"}) == 'edgeWeightType:"double"'
+        assert (
+            _to_parameter_list({"traversalDirection": "inbound"})
+            == 'traversalDirection:"inbound"'
+        )
+        assert (
+            _to_parameter_list({"edgeWeightType": "double"})
+            == 'edgeWeightType:"double"'
+        )
 
     def test_numeric_param_rejects_string_payload(self):
         """A numeric param cannot carry a string payload."""
@@ -80,10 +87,31 @@ class TestParameterValueInjection:
 
     def test_list_param_escapes_string_elements(self):
         """List elements are individually string-escaped, not rendered via repr."""
-        rendered = _to_parameter_list({"edgeLabels": ['route", }) MATCH (m) DELETE m //']})
+        rendered = _to_parameter_list(
+            {"edgeLabels": ['route", }) MATCH (m) DELETE m //']}
+        )
         # element is a quoted string literal with the double-quote escaped
         assert rendered.startswith("edgeLabels:[")
         assert '\\"' in rendered  # the embedded double quote was escaped
+
+    def test_empty_list_param_renders_empty_brackets(self):
+        """An empty list-valued param renders as [] and does not error."""
+        assert _to_parameter_list({"edgeLabels": []}) == "edgeLabels:[]"
+
+    def test_trailing_backslash_cannot_escape_closing_quote(self):
+        """A value ending in a backslash must not escape the literal's closing
+        quote. The backslash is doubled (escaped first) so the closing quote
+        stays intact."""
+        rendered = _to_parameter_list({"writeProperty": "X\\"})
+        assert rendered == r'writeProperty:"X\\"'
+
+    def test_trailing_backslash_then_quote_breakout_neutralized(self):
+        """A backslash-then-quote payload can't break out: the backslash is
+        doubled and the quote is independently escaped, so neither terminates
+        the string literal."""
+        payload = 'X\\") MATCH (m) DETACH DELETE m //'
+        rendered = _to_parameter_list({"writeProperty": payload})
+        assert rendered == r'writeProperty:"X\\\") MATCH (m) DETACH DELETE m //"'
 
     def test_pagerank_query_injection_is_neutralized(self):
         """End-to-end: a vertexLabel payload cannot inject into pagerank_query.
@@ -107,7 +135,10 @@ class TestLabelInjection:
         src = Node(id="a", labels=["Person"], properties={})
         dest = Node(id="b", labels=["Person"], properties={})
         edge = Edge(
-            label=IDENTIFIER_INJECTION_PAYLOAD, properties={}, node_src=src, node_dest=dest
+            label=IDENTIFIER_INJECTION_PAYLOAD,
+            properties={},
+            node_src=src,
+            node_dest=dest,
         )
         query, _ = insert_edge(edge)
         assert "`X``}) MATCH (m) DETACH DELETE m //`" in query

--- a/tests/clients/test_opencypher_injection.py
+++ b/tests/clients/test_opencypher_injection.py
@@ -113,6 +113,27 @@ class TestParameterValueInjection:
         rendered = _to_parameter_list({"writeProperty": payload})
         assert rendered == r'writeProperty:"X\\\") MATCH (m) DETACH DELETE m //"'
 
+    def test_unicode_escape_sequence_is_not_interpreted(self):
+        """A payload containing the literal characters ``\\u0022`` (an attempt
+        to smuggle a double-quote via a unicode escape) is neutralized: the
+        backslash is doubled first, so it renders as a literal backslash
+        followed by the text ``u0022`` and can never decode to a quote that
+        terminates the literal."""
+        payload = "X\\u0022 ) MATCH (m) DETACH DELETE m //"
+        rendered = _to_parameter_list({"writeProperty": payload})
+        assert rendered == r'writeProperty:"X\\u0022 ) MATCH (m) DETACH DELETE m //"'
+
+    def test_error_message_truncates_long_payload(self):
+        """A rejected value is not echoed verbatim into the error message; a
+        long attacker payload is truncated so it can't flood exceptions/logs."""
+        payload = "A" * 500 + '") MATCH (m) DETACH DELETE m //'
+        with pytest.raises(ValueError) as exc_info:
+            _to_parameter_list({"numOfIterations": payload})
+        msg = str(exc_info.value)
+        assert payload not in msg  # full payload not reflected
+        assert "…" in msg  # truncated
+        assert len(msg) < 120  # message stays bounded
+
     def test_pagerank_query_injection_is_neutralized(self):
         """End-to-end: a vertexLabel payload cannot inject into pagerank_query.
         It is confined inside an escaped double-quoted string literal."""

--- a/tests/clients/test_opencypher_injection.py
+++ b/tests/clients/test_opencypher_injection.py
@@ -1,0 +1,130 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Unit tests proving labels, property keys, and algorithm parameter values
+cannot inject openCypher syntax.
+
+These run in CI (no live Neptune needed), complementing the integration test in
+integ_test/graph_operations/test_security_injection.py which covers node IDs and
+property values against a real graph.
+"""
+import pytest
+
+from nx_neptune.clients import Edge, Node
+from nx_neptune.clients.opencypher_builder import (
+    _escape_identifier,
+    _to_parameter_list,
+    insert_edge,
+    insert_node,
+    pagerank_query,
+    update_node,
+    wcc_query,
+)
+
+# The PoC payload from the finding, plus variants that try to break out of a
+# string literal, an identifier, or a list.
+PARAM_INJECTION_PAYLOAD = 'X"}) MATCH (m) DETACH DELETE m //'
+IDENTIFIER_INJECTION_PAYLOAD = "X`}) MATCH (m) DETACH DELETE m //"
+
+
+class TestParameterValueInjection:
+    def test_identifier_param_quoted_string_escaped(self):
+        """An identifier-valued param (writeProperty) is emitted as a quoted
+        string literal with the payload's quote/backslash escaped, so it cannot
+        terminate the literal. (Inside a neptune.algo.* config map these are
+        string values, not backtick identifiers.)"""
+        rendered = _to_parameter_list({"writeProperty": PARAM_INJECTION_PAYLOAD})
+        # value wrapped in double quotes; the embedded double-quote is escaped
+        assert rendered == 'writeProperty:"X\\"}) MATCH (m) DETACH DELETE m //"'
+        assert '\\"' in rendered  # the quote that would break out is escaped
+
+    def test_enum_param_rejects_bad_value(self):
+        """A closed-domain enum param rejects anything outside the documented set."""
+        with pytest.raises(ValueError):
+            _to_parameter_list({"traversalDirection": PARAM_INJECTION_PAYLOAD})
+        with pytest.raises(ValueError):
+            _to_parameter_list({"edgeWeightType": "double; DROP"})
+
+    def test_enum_param_accepts_valid_value(self):
+        assert _to_parameter_list({"traversalDirection": "inbound"}) == 'traversalDirection:"inbound"'
+        assert _to_parameter_list({"edgeWeightType": "double"}) == 'edgeWeightType:"double"'
+
+    def test_numeric_param_rejects_string_payload(self):
+        """A numeric param cannot carry a string payload."""
+        with pytest.raises(ValueError):
+            _to_parameter_list({"numOfIterations": PARAM_INJECTION_PAYLOAD})
+        with pytest.raises(ValueError):
+            _to_parameter_list({"dampingFactor": "0.9}) MATCH (m) DETACH DELETE m //"})
+
+    def test_numeric_param_accepts_numbers(self):
+        assert _to_parameter_list({"dampingFactor": 0.9, "numOfIterations": 50}) == (
+            "dampingFactor:0.9, numOfIterations:50"
+        )
+
+    def test_unknown_param_key_rejected(self):
+        """A parameter key outside the allowlist fails closed."""
+        with pytest.raises(ValueError):
+            _to_parameter_list({"maliciousKey": 1})
+        # A payload used AS a key is also rejected.
+        with pytest.raises(ValueError):
+            _to_parameter_list({PARAM_INJECTION_PAYLOAD: 1})
+
+    def test_list_param_escapes_string_elements(self):
+        """List elements are individually string-escaped, not rendered via repr."""
+        rendered = _to_parameter_list({"edgeLabels": ['route", }) MATCH (m) DELETE m //']})
+        # element is a quoted string literal with the double-quote escaped
+        assert rendered.startswith("edgeLabels:[")
+        assert '\\"' in rendered  # the embedded double quote was escaped
+
+    def test_pagerank_query_injection_is_neutralized(self):
+        """End-to-end: a vertexLabel payload cannot inject into pagerank_query.
+        It is confined inside an escaped double-quoted string literal."""
+        query, _ = pagerank_query({"vertexLabel": PARAM_INJECTION_PAYLOAD})
+        assert 'vertexLabel:"X\\"}) MATCH (m) DETACH DELETE m //"' in query
+
+    def test_wcc_query_rejects_bad_enum(self):
+        with pytest.raises(ValueError):
+            wcc_query({"traversalDirection": PARAM_INJECTION_PAYLOAD})
+
+
+class TestLabelInjection:
+    def test_insert_node_label_backtick_escaped(self):
+        node = Node(id="a", labels=[IDENTIFIER_INJECTION_PAYLOAD], properties={})
+        query, _ = insert_node(node)
+        # Label is wrapped in backticks with the embedded backtick doubled.
+        assert "`X``}) MATCH (m) DETACH DELETE m //`" in query
+
+    def test_insert_edge_label_backtick_escaped(self):
+        src = Node(id="a", labels=["Person"], properties={})
+        dest = Node(id="b", labels=["Person"], properties={})
+        edge = Edge(
+            label=IDENTIFIER_INJECTION_PAYLOAD, properties={}, node_src=src, node_dest=dest
+        )
+        query, _ = insert_edge(edge)
+        assert "`X``}) MATCH (m) DETACH DELETE m //`" in query
+        # Legit labels still present, backticked.
+        assert "`Person`" in query
+
+    def test_update_node_match_label_escaped(self):
+        node = Node(id="a", labels=[], properties={})
+        query, _ = update_node(IDENTIFIER_INJECTION_PAYLOAD, "a", ["a"], {"a.x": "1"})
+        assert "`X``}) MATCH (m) DETACH DELETE m //`" in query
+
+
+class TestEscapeIdentifierHelper:
+    def test_wraps_and_doubles_backticks(self):
+        assert _escape_identifier("pageRank") == "`pageRank`"
+        assert _escape_identifier("a`b") == "`a``b`"
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValueError):
+            _escape_identifier(123)


### PR DESCRIPTION
## Summary

Algorithm parameters and labels were string-interpolated into openCypher without validation or escaping.
This constrains what the library emits into an algorithm CALL to an allowlisted vocabulary, and escapes labels — so generated queries are predictable and well-formed. (Property values and node IDs were already parameterized; this covers the remaining identifiers and algorithm parameters.)

## Allowlist / fail-closed model

Algorithm config is an inline map literal in the CALL clause, so its parts can't be bound as query parameters ($n).
Each is now validated positively — only known values pass, everything else is rejected (fail-closed, ValueError):

- Keys allowlisted against the known parameter names (ALLOWED_ALGO_PARAM_KEYS).
- Enum values (traversalDirection, edge/vertexWeightType) checked against their documented value sets.
- Numeric params must be int/float.
- Identifier params (vertexLabel, writeProperty, edge/vertexWeightProperty) are emitted as escaped double-quoted string literals.
- List values (edgeLabels, sourceNodes, sourceWeights) escape each element.

Node/edge labels and relationship types are backtick-escaped where interpolated.

## Scope

Library-only: opencypher_builder.py + allowlists/enum sets in neptune_constants.py.

## Testing

- Unit (CI): tests/clients/test_opencypher_injection.py, plus updated test_opencypher_builder.py expectations.
- Live graph: all 75 algorithm integ tests pass (label filtering, enum params, write-property mutations all still correct — no regression).

