### PR TITLE
Fix: Add missing link_prediction package to wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ packages = [
     'nx_neptune.algorithms.communities',
     'nx_neptune.algorithms.traversal',
     'nx_neptune.algorithms.link_analysis',
+    'nx_neptune.algorithms.link_prediction',
     'nx_neptune.algorithms.util',
     'nx_neptune.clients',
     'nx_neptune.utils',


### PR DESCRIPTION

**Summary**

`nx_neptune/algorithms/__init__.py` imports from `nx_neptune.algorithms.link_prediction.jaccard`, but that subpackage was never added to `[tool.setuptools].packages` in `pyproject.toml`.
The built wheel silently excludes it, so any install from a built package (e.g. via `pip install ./nx_neptune_src`, used by the proxy's Docker image) fails at import time.

**Problem**

```
ModuleNotFoundError: No module named 'nx_neptune.algorithms.link_prediction'
```


**Changes**

Adds `'nx_neptune.algorithms.link_prediction'` to `[tool.setuptools].packages`.

**Testing**

- Built a wheel and confirmed `link_prediction/__init__.py` and `jaccard.py` are now included (previously absent).
- Installed the built package into a clean venv and confirmed `import nx_neptune` succeeds (previously raised `ModuleNotFoundError`).