### PR TITLE
Fix: Read NETWORKX_GRAPH_ID and NETWORKX_S3_IAM_ROLE_ARN from environment at call time

### DIFF
--- a/nx_neptune/na_graph.py
+++ b/nx_neptune/na_graph.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
+import os
 from asyncio import Task
 from typing import Any, List, Optional
 
@@ -304,16 +305,23 @@ def get_config() -> NeptuneConfig:
     """
     Helper method to retrieve the Neptune configuration with global variable overrides.
 
+    Reads NETWORKX_GRAPH_ID and NETWORKX_S3_IAM_ROLE_ARN from the environment at call
+    time rather than relying on the module-level constants exported from
+    nx_plugin.config, which are captured once at import time and would otherwise miss
+    values set afterward (for example via load_dotenv() called after import).
+
     Returns:
         dict: The Neptune configuration.
     """
     config = networkx.config.backends.neptune
 
-    if NETWORKX_GRAPH_ID is not None:
-        config.graph_id = NETWORKX_GRAPH_ID
+    graph_id = os.environ.get("NETWORKX_GRAPH_ID")
+    if graph_id is not None:
+        config.graph_id = graph_id
 
-    if NETWORKX_S3_IAM_ROLE_ARN is not None:
-        config.role_arn = NETWORKX_S3_IAM_ROLE_ARN
+    s3_iam_role_arn = os.environ.get("NETWORKX_S3_IAM_ROLE_ARN")
+    if s3_iam_role_arn is not None:
+        config.s3_iam_role = s3_iam_role_arn
 
     return config
 

--- a/tests/test_na_graph.py
+++ b/tests/test_na_graph.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import pytest
 from unittest.mock import MagicMock, patch
 import logging
@@ -20,7 +21,7 @@ from nx_neptune.clients import (
     PARAM_TRAVERSAL_DIRECTION_INBOUND,
     PARAM_TRAVERSAL_DIRECTION_OUTBOUND,
 )
-from nx_neptune.na_graph import NeptuneGraph
+from nx_neptune.na_graph import NeptuneGraph, get_config
 from nx_neptune.clients import (
     NeptuneAnalyticsClient,
     insert_node,
@@ -262,3 +263,53 @@ class TestNeptuneGraph:
         expected_query = match_all_edges()
         mock_client.execute_generic_query.assert_called_once_with(expected_query)
         assert result == ["relationship1", "relationship1"]
+
+
+class TestGetConfig:
+    @pytest.fixture(autouse=True)
+    def reset_neptune_config(self):
+        """Reset the global neptune backend config before and after each test.
+
+        get_config() mutates a process-wide singleton (networkx.config.backends.neptune),
+        so tests must not leak overrides into each other.
+        """
+        config = nx.config.backends.neptune
+        original_graph_id = config.graph_id
+        original_s3_iam_role = config.s3_iam_role
+        config.graph_id = None
+        config.s3_iam_role = None
+        yield
+        config.graph_id = original_graph_id
+        config.s3_iam_role = original_s3_iam_role
+
+    def test_get_config_reads_graph_id_set_after_import(self):
+        """Regression test for #16: NETWORKX_GRAPH_ID must be read live, not cached
+        at import time, so it is picked up even if set (e.g. via load_dotenv())
+        after nx_neptune has already been imported."""
+        with patch.dict(os.environ, {"NETWORKX_GRAPH_ID": "graph-set-after-import"}):
+            config = get_config()
+
+        assert config.graph_id == "graph-set-after-import"
+
+    def test_get_config_reads_s3_iam_role_set_after_import(self):
+        """Regression test for #16, and for the config.role_arn typo (the
+        NeptuneConfig field is s3_iam_role, not role_arn) which meant this branch
+        raised AttributeError whenever NETWORKX_S3_IAM_ROLE_ARN was set."""
+        with patch.dict(
+            os.environ,
+            {"NETWORKX_S3_IAM_ROLE_ARN": "arn:aws:iam::123456789012:role/my-role"},
+        ):
+            config = get_config()
+
+        assert config.s3_iam_role == "arn:aws:iam::123456789012:role/my-role"
+
+    def test_get_config_leaves_defaults_untouched_when_env_vars_unset(self):
+        """When neither env var is set, get_config() must not overwrite existing
+        configuration values."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NETWORKX_GRAPH_ID", None)
+            os.environ.pop("NETWORKX_S3_IAM_ROLE_ARN", None)
+            config = get_config()
+
+        assert config.graph_id is None
+        assert config.s3_iam_role is None


### PR DESCRIPTION
## What
`get_config()` now reads `NETWORKX_GRAPH_ID` and `NETWORKX_S3_IAM_ROLE_ARN` from the environment at call time instead of relying on the module-level constants exported from `nx_plugin.config`, which are captured once at import time.

Also fixes `config.role_arn`, which is not a valid `NeptuneConfig` field (the actual field is `s3_iam_role`). This meant the `NETWORKX_S3_IAM_ROLE_ARN` branch raised `AttributeError` any time that variable was set, so it likely never worked in practice.

## Why
Hi @acarbonetto, since you filed this one. The constants in `nx_plugin/config.py` are set with `os.environ.get(...)` at module import time. Because `nx_neptune/na_graph.py` (and `interface.py`, `__init__.py`) do `from nx_plugin.config import NETWORKX_GRAPH_ID, NETWORKX_S3_IAM_ROLE_ARN`, that value gets frozen into their own namespace at their own import time too. Calling `load_dotenv()` after `import nx_neptune`, as in the issue's repro, updates `os.environ` but has no effect on the already-bound name. Since `get_config()` is called fresh on every algorithm invocation, reading the environment directly inside it is the correct place to fix this.

While testing, I found the `config.role_arn` typo in the same function. `NeptuneConfig` only has `s3_iam_role`, so that branch would raise `AttributeError` whenever `NETWORKX_S3_IAM_ROLE_ARN` was set, independent of this bug.

## How I verified this
- Reproduced the exact bug locally with a standalone script simulating the issue's repro (import, then set env var, then call `load_dotenv()`), confirmed both `nx_plugin.config.NETWORKX_GRAPH_ID` and `nx_neptune.interface.NETWORKX_GRAPH_ID` stayed `None`.
- Re-ran the same reproduction against `get_config()` directly after the fix, confirmed both values now resolve correctly.
- Added 3 new unit tests to `tests/test_na_graph.py`, following the existing `patch.dict(os.environ, ...)` convention already used elsewhere in the test suite.
- Ran the full test suite: 399 passed, no regressions.
- Checked against black, isort, and flake8. Clean except one pre-existing isort ordering issue on `main` that predates this change; left untouched to keep the diff scoped to the actual fix.

Fixes #16