### PR TITLE
Fix: Disable Swagger/ReDoc docs by default

### DIFF
--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -41,7 +41,7 @@ logger = logging.getLogger("nx_neptune_proxy")
 
 # --- App ---
 
-app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url="/docs", redoc_url=None)
+app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_url=None)
 
 app.add_middleware(
     CORSMiddleware,

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -165,6 +165,11 @@ if UI_DIR.exists():
         if path.startswith("api/"):
             raise HTTPException(status_code=404)
 
+        # docs_url/redoc_url are disabled above; also block the SPA
+        # fallback from serving index.html at these paths instead.
+        if path in ("docs", "redoc"):
+            raise HTTPException(status_code=404)
+
         # Control 1: Input sanitization — reject any path containing traversal
         if ".." in path:
             raise HTTPException(status_code=403)

--- a/proxy/tests/test_app.py
+++ b/proxy/tests/test_app.py
@@ -4,13 +4,17 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from nx_neptune_proxy.app import app
+from nx_neptune_proxy.app import app, UI_DIR
 
 
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
 
 
 @pytest.mark.asyncio
@@ -48,3 +52,36 @@ async def test_docs_disabled(client):
 async def test_redoc_disabled(client):
     resp = await client.get("/redoc")
     assert resp.status_code == 404
+
+
+@pytest.mark.skipif(
+    not UI_DIR.exists(),
+    reason="ui/ directory not built — run 'make ui' first",
+)
+class TestDocsDisabledWithUiBuilt:
+    """With docs_url=None, /docs and /redoc would otherwise fall through to
+    the SPA catch-all and be served as index.html (200). Only meaningful
+    once the SPA fallback route actually exists, i.e. ui/ is built — the
+    two tests above run with no SPA build present, where FastAPI's own
+    router already 404s these paths regardless of this control."""
+
+    @pytest.mark.asyncio
+    async def test_docs_still_404_via_spa_fallback(self, client):
+        resp = await client.get("/docs")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_redoc_still_404_via_spa_fallback(self, client):
+        resp = await client.get("/redoc")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_root_still_served_by_spa_fallback(self, client):
+        """Sanity check: the fix doesn't collateral-damage real SPA routes."""
+        resp = await client.get("/")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_client_side_route_still_served_by_spa_fallback(self, client):
+        resp = await client.get("/projects/abc")
+        assert resp.status_code == 200

--- a/proxy/tests/test_app.py
+++ b/proxy/tests/test_app.py
@@ -39,6 +39,12 @@ async def test_not_found_returns_404(client):
 
 
 @pytest.mark.asyncio
-async def test_openapi_docs_available(client):
+async def test_docs_disabled(client):
     resp = await client.get("/docs")
-    assert resp.status_code == 200
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_redoc_disabled(client):
+    resp = await client.get("/redoc")
+    assert resp.status_code == 404


### PR DESCRIPTION
**Summary**

The proxy currently sets `docs_url="/docs"`, exposing the OpenAPI Swagger UI and schema to anyone who can reach it.
This disables that, and also makes the SPA fallback reject `/docs`/`/redoc` so they don't fall through and get served as `index.html` instead.

**Changes**

`app.py`: disables Swagger/ReDoc, and blocks those two paths from the SPA fallback too.
`test_app.py`: tests covering both the no-UI-build and UI-built cases.

**Scope**

Proxy only.
