### PR TITLE
Feat:  Add server-side Origin validation for non-browser callers

### DIFF
--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -6,6 +6,7 @@ import logging
 import time
 import uuid
 from pathlib import Path
+from urllib.parse import urlparse
 
 from botocore.exceptions import ClientError
 from fastapi import FastAPI, HTTPException, Request
@@ -41,7 +42,9 @@ logger = logging.getLogger("nx_neptune_proxy")
 
 # --- App ---
 
-app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_url=None)
+app = FastAPI(
+    title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_url=None
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -49,6 +52,36 @@ app.add_middleware(
     allow_methods=["GET", "POST", "PUT", "DELETE"],
     allow_headers=["Content-Type", "Authorization", "X-Requested-With"],
 )
+
+
+# --- Origin validation middleware (server-side, defense-in-depth) ---
+
+
+@app.middleware("http")
+async def origin_validation(request: Request, call_next):
+    """Reject requests with an Origin header not on the allowlist.
+
+    Browsers always send a truthful Origin header on cross-origin requests.
+    This enforces the allowlist server-side, rather than relying on the
+    browser to respect CORS.
+    """
+    origin = request.headers.get("origin")
+    if origin:
+        # Parse origin to extract host (e.g. "http://localhost:8080" -> "localhost")
+        try:
+            parsed = urlparse(origin)
+            host = parsed.hostname or ""
+        except Exception:
+            host = ""
+        if host not in settings.trusted_hosts:
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": "origin_rejected",
+                    "message": f"Origin '{origin}' is not allowed",
+                },
+            )
+    return await call_next(request)
 
 
 # --- CSRF protection middleware ---
@@ -67,7 +100,10 @@ async def csrf_protection(request: Request, call_next):
         if not request.headers.get("x-requested-with"):
             return JSONResponse(
                 status_code=403,
-                content={"error": "csrf_rejected", "message": "Missing required X-Requested-With header"},
+                content={
+                    "error": "csrf_rejected",
+                    "message": "Missing required X-Requested-With header",
+                },
             )
     return await call_next(request)
 
@@ -117,7 +153,10 @@ async def global_exception_handler(request: Request, exc: Exception):
     logger.exception(f"Unhandled error on {request.method} {request.url.path}")
     return JSONResponse(
         status_code=500,
-        content={"error": "internal_server_error", "message": "An unexpected error occurred"},
+        content={
+            "error": "internal_server_error",
+            "message": "An unexpected error occurred",
+        },
     )
 
 
@@ -143,6 +182,7 @@ app.include_router(graph_router)
 
 
 # --- Startup: resume stuck deletions ---
+
 
 @app.on_event("startup")
 async def resume_pending_deletions():

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+# Always trusted, regardless of TRUSTED_HOSTS: requests claiming to be from
+# here never leave the local machine.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
 @dataclass(frozen=True)
@@ -12,6 +16,7 @@ class Settings:
     log_level: str = "INFO"
     allowed_origins: list[str] = None  # type: ignore[assignment]
     port: int = 8080
+    extra_trusted_hosts: frozenset[str] = field(default_factory=frozenset)
     region: str = ""
     graph_prefix: str = "nxp-"
 
@@ -19,14 +24,37 @@ class Settings:
         if self.allowed_origins is None:
             object.__setattr__(self, "allowed_origins", [])
 
+    @property
+    def trusted_hosts(self) -> frozenset[str]:
+        """Hostnames this process accepts in a request's Host or Origin.
+
+        Used by the origin_validation middleware to check the Origin header.
+        Independent of allowed_origins/CORS — that list controls browser
+        CORS response headers; this one controls whether the server accepts
+        the request at all. TRUSTED_HOSTS (comma-separated) adds to the
+        fixed loopback set; it's never removed or replaced.
+        """
+        return _LOOPBACK_HOSTS | self.extra_trusted_hosts
+
     @classmethod
     def from_env(cls) -> "Settings":
         origins_raw = os.environ.get("CORS_ALLOWED_ORIGINS", "")
-        origins = [o.strip() for o in origins_raw.split(",") if o.strip()] if origins_raw else []
+        origins = (
+            [o.strip() for o in origins_raw.split(",") if o.strip()]
+            if origins_raw
+            else []
+        )
+        trusted_hosts_raw = os.environ.get("TRUSTED_HOSTS", "")
+        extra_trusted = frozenset(
+            h.strip() for h in trusted_hosts_raw.split(",") if h.strip()
+        )
         return cls(
             log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
             allowed_origins=origins,
             port=int(os.environ.get("PORT", "8080")),
-            region=os.environ.get("AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")),
+            extra_trusted_hosts=extra_trusted,
+            region=os.environ.get(
+                "AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")
+            ),
             graph_prefix=os.environ.get("GRAPH_PREFIX", "nxp-"),
         )

--- a/proxy/tests/test_origin_validation.py
+++ b/proxy/tests/test_origin_validation.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-side Origin header validation (origin_validation middleware)."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
+
+
+class TestOriginValidation:
+    @pytest.mark.asyncio
+    async def test_evil_origin_rejected(self, client):
+        resp = await client.get("/health", headers={"Origin": "http://evil.com"})
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "origin_rejected"
+
+    @pytest.mark.asyncio
+    async def test_localhost_origin_allowed(self, client):
+        resp = await client.get("/health", headers={"Origin": "http://localhost:8080"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_127_0_0_1_origin_allowed(self, client):
+        resp = await client.get("/health", headers={"Origin": "http://127.0.0.1:8080"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_ipv6_loopback_origin_allowed(self, client):
+        """urlparse correctly strips IPv6 brackets before comparison, unlike
+        Starlette's TrustedHostMiddleware, which cannot parse them at all."""
+        resp = await client.get("/health", headers={"Origin": "http://[::1]:8080"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_no_origin_allowed(self, client):
+        """Requests without an Origin header (e.g. non-browser callers) are
+        not subject to this check."""
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_malformed_origin_rejected(self, client):
+        resp = await client.get("/health", headers={"Origin": "not-a-valid-url"})
+        assert resp.status_code == 403

--- a/proxy/tests/test_trusted_hosts.py
+++ b/proxy/tests/test_trusted_hosts.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Settings.trusted_hosts — independent of allowed_origins/CORS."""
+
+from nx_neptune_proxy.config import Settings
+
+
+class TestTrustedHosts:
+    def test_defaults_to_loopback_only(self):
+        settings = Settings()
+        assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
+
+    def test_extra_trusted_hosts_is_additive(self):
+        settings = Settings(extra_trusted_hosts=frozenset({"example.com"}))
+        assert settings.trusted_hosts == {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+            "example.com",
+        }
+
+    def test_from_env_reads_trusted_hosts(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_HOSTS", "example.com, foo.local")
+        settings = Settings.from_env()
+        assert settings.extra_trusted_hosts == {"example.com", "foo.local"}
+        assert "example.com" in settings.trusted_hosts
+        assert "foo.local" in settings.trusted_hosts
+
+    def test_independent_of_cors_allowed_origins(self, monkeypatch):
+        """trusted_hosts must not be affected by CORS_ALLOWED_ORIGINS in
+        either direction — the two lists are unrelated."""
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://example.com:888")
+        settings = Settings.from_env()
+        assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
+        assert settings.allowed_origins == ["https://example.com:888"]
+
+    def test_allowed_origins_still_defaults_to_empty(self):
+        """Unchanged pre-existing behaviour: no fallback/derivation."""
+        settings = Settings()
+        assert settings.allowed_origins == []


### PR DESCRIPTION
**Summary**

CORS is a browser-only convention — it doesn't stop a non-browser caller (script, curl, another local process) from hitting the proxy with any `Origin` it likes.
This adds `origin_validation`, a middleware that checks the `Origin` header server-side and rejects anything not recognized, so the check holds regardless of what kind of client is making the request.

**Changes**

`config.py`: new `trusted_hosts` (loopback by default, `TRUSTED_HOSTS` env var adds more).
`app.py`: `origin_validation` middleware, checks `Origin` against `trusted_hosts`, rejects with 403 if unrecognized.
Tests for both.
