### PR TITLE
Feat: Add TrustedHostMiddleware to block DNS rebinding

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -56,6 +56,6 @@ cd ui-src && npm run dev
 | Environment Variable | Default | Description |
 |---|---|---|
 | `PORT` | `8080` | Server port |
-| `CORS_ALLOWED_ORIGINS` | `http://localhost:5173` | Allowed CORS origins (dev) |
+| `CORS_ALLOWED_ORIGINS` | *(none)* | Comma-separated list of allowed browser origins (full `scheme://host[:port]`, e.g. `https://app.example.com`). This is the single source of truth for origins: it drives the CORS response headers, the server-side Origin check, and the hostnames trusted in the `Host` header. Loopback origins are always allowed, so no configuration is needed for local/Docker use. |
 | `LOG_LEVEL` | `info` | Logging level |
 | `NX_NEPTUNE_DB_PATH` | `~/.nx-neptune/proxy.db` | SQLite database path |

--- a/proxy/docker-compose.yml
+++ b/proxy/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
+      # Single source of truth for browser origins: drives CORS, the
+      # server-side Origin check, and the trusted Host hostnames. Loopback
+      # is always allowed; these entries cover the Graph Explorer sidecar.
       - CORS_ALLOWED_ORIGINS=http://localhost:8080,https://localhost:6373
       - LOG_LEVEL=info
       # Pass-through from the host env. If unset, the library applies its secure

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -46,7 +46,7 @@ app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_ur
 
 # --- TrustedHost middleware (blocks DNS rebinding) ---
 #
-# TODO: IPv6 is not supported until encode/starlette#3357 is fixed
+# TODO: IPv6 is not supported until starlette#3471 is fixed
 # (Starlette can't parse IPv6 Host headers, so any IPv6 entry here is
 # dead code). Re-add "::1" once a fixed release is available. No security
 # leak: all IPv6 hosts are denied in the meantime, not allowed.

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -46,15 +46,16 @@ app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_ur
 
 # --- TrustedHost middleware (blocks DNS rebinding) ---
 #
-# Known limitation: Starlette's TrustedHostMiddleware parses the Host header
-# via `.split(":")[0]`, which returns "[" for any IPv6 literal (e.g.
-# "[::1]:8080"), never a value that can match an allowlist entry. This means
-# requests addressed via an IPv6 literal are always rejected, regardless of
-# what's configured. Hostname-based access (localhost, 127.0.0.1, or any
-# configured hostname that happens to resolve to an IPv6 address) is
-# unaffected, since the Host header carries the hostname as typed, not the
-# resolved IP.
-app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(settings.trusted_hosts))
+# TODO: IPv6 is not supported until encode/starlette#3357 is fixed
+# (Starlette can't parse IPv6 Host headers, so any IPv6 entry here is
+# dead code). Re-add "::1" once a fixed release is available. No security
+# leak: all IPv6 hosts are denied in the meantime, not allowed.
+_host_middleware_allowed_hosts = [
+    host
+    for host in settings.trusted_hosts
+    if not host.startswith("[") and ":" not in host
+]
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=_host_middleware_allowed_hosts)
 
 app.add_middleware(
     CORSMiddleware,

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -70,21 +70,22 @@ app.add_middleware(
 
 @app.middleware("http")
 async def origin_validation(request: Request, call_next):
-    """Reject requests with an Origin header not on the allowlist.
+    """Reject requests whose Origin isn't on the allowlist.
 
-    Browsers always send a truthful Origin header on cross-origin requests.
-    This enforces the allowlist server-side, rather than relying on the
-    browser to respect CORS.
+    Browsers always send a truthful Origin header on cross-origin requests,
+    so this enforces the allowlist server-side rather than relying on the
+    browser to respect CORS. Matches the full origin (scheme + host + port)
+    against the same normalized list CORS uses, so the two can't diverge.
+    Loopback origins are always allowed (local development).
     """
     origin = request.headers.get("origin")
     if origin:
-        # Parse origin to extract host (e.g. "http://localhost:8080" -> "localhost")
-        try:
-            parsed = urlparse(origin)
-            host = parsed.hostname or ""
-        except Exception:
-            host = ""
-        if host not in settings.trusted_hosts:
+        normalized = normalize_origin(origin)
+        parsed_host = urlparse(origin).hostname or ""
+        is_loopback = parsed_host in _LOOPBACK_HOSTS
+        if not is_loopback and (
+            normalized is None or normalized not in settings.allowed_origins
+        ):
             return JSONResponse(
                 status_code=403,
                 content={

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from nx_neptune_proxy.config import _LOOPBACK_HOSTS, get_settings
 from nx_neptune_proxy.routers.graph import router as graph_router
@@ -42,6 +43,18 @@ logger = logging.getLogger("nx_neptune_proxy")
 # --- App ---
 
 app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_url=None)
+
+# --- TrustedHost middleware (blocks DNS rebinding) ---
+#
+# Known limitation: Starlette's TrustedHostMiddleware parses the Host header
+# via `.split(":")[0]`, which returns "[" for any IPv6 literal (e.g.
+# "[::1]:8080"), never a value that can match an allowlist entry. This means
+# requests addressed via an IPv6 literal are always rejected, regardless of
+# what's configured. Hostname-based access (localhost, 127.0.0.1, or any
+# configured hostname that happens to resolve to an IPv6 address) is
+# unaffected, since the Host header carries the hostname as typed, not the
+# resolved IP.
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(settings.trusted_hosts))
 
 app.add_middleware(
     CORSMiddleware,

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -44,6 +44,21 @@ logger = logging.getLogger("nx_neptune_proxy")
 
 app = FastAPI(title="nx-neptune-proxy", version="0.1.0", docs_url=None, redoc_url=None)
 
+# --- Middleware ordering ---
+#
+# Starlette runs the LAST-registered middleware first (each registration wraps
+# the previous ones), so the registrations below produce this execution order,
+# outermost first:
+#
+#   csrf_protection -> origin_validation -> (logging) -> CORS -> TrustedHost
+#
+# TrustedHost is intentionally innermost: the Host check still applies to every
+# request that reaches the app, including CORS preflight OPTIONS. A request with
+# an untrusted Host is rejected with 400 regardless of method (verified for GET
+# and OPTIONS) — the preflight is not short-circuited past the Host check.
+# csrf/origin checks run first so cross-origin and CSRF-style requests are
+# rejected before any CORS handling.
+
 # --- TrustedHost middleware (blocks DNS rebinding) ---
 #
 # TODO: IPv6 is not supported until starlette#3471 is fixed

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -15,7 +15,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
-from nx_neptune_proxy.config import _LOOPBACK_HOSTS, get_settings
+from nx_neptune_proxy.config import _LOOPBACK_HOSTS, get_settings, normalize_origin
 from nx_neptune_proxy.routers.graph import router as graph_router
 from nx_neptune_proxy.routers.metadata import router as metadata_router
 from nx_neptune_proxy.routers.project import router as project_router

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -47,8 +47,11 @@ class Settings:
             else []
         )
         trusted_hosts_raw = os.environ.get("TRUSTED_HOSTS", "")
+        # Hostnames are case-insensitive; normalize to lowercase so a
+        # mixed-case TRUSTED_HOSTS value (e.g. "Example.COM") matches the
+        # conventionally lowercase Host/Origin a client sends.
         extra_trusted = frozenset(
-            h.strip() for h in trusted_hosts_raw.split(",") if h.strip()
+            h.strip().lower() for h in trusted_hosts_raw.split(",") if h.strip()
         )
         allow_raw = os.environ.get("ALLOW_NON_LOOPBACK_BIND", "")
         return cls(

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -2,20 +2,54 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from urllib.parse import urlparse
 
-# Always trusted, regardless of TRUSTED_HOSTS: requests claiming to be from
+# Always trusted, regardless of configuration: requests claiming to be from
 # here never leave the local machine.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+# Default ports that are implied by the scheme and should be dropped when
+# normalizing an origin, so "https://x" and "https://x:443" compare equal.
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def normalize_origin(origin: str) -> str | None:
+    """Normalize an origin to a canonical scheme://host[:port] form.
+
+    Lowercases scheme and host, drops the default port for the scheme, and
+    strips any path/query. Returns None if the value can't be parsed as an
+    origin with both a scheme and a host.
+    """
+    try:
+        parsed = urlparse(origin.strip())
+    except Exception:
+        return None
+    scheme = (parsed.scheme or "").lower()
+    host = (parsed.hostname or "").lower()
+    if not scheme or not host:
+        return None
+    port = parsed.port
+    if port is not None and _DEFAULT_PORTS.get(scheme) == port:
+        port = None
+    return f"{scheme}://{host}" if port is None else f"{scheme}://{host}:{port}"
 
 
 @dataclass(frozen=True)
 class Settings:
-    """Application settings loaded from environment variables."""
+    """Application settings loaded from environment variables.
+
+    ``allowed_origins`` and ``trusted_hosts`` are both derived once, in
+    ``from_env``, from the single CORS origins list. ``allowed_origins``
+    holds full origins (for CORS and the server-side Origin check);
+    ``trusted_hosts`` holds the hostnames extracted from those origins plus
+    the loopback set (for the Host check). Consumers read them as-is.
+    """
 
     log_level: str = "INFO"
     allowed_origins: list[str] = None  # type: ignore[assignment]
     host: str = "127.0.0.1"
+    trusted_hosts: frozenset[str] = None  # type: ignore[assignment]
     port: int = 8080
     allow_non_loopback_bind: bool = False
     extra_trusted_hosts: frozenset[str] = field(default_factory=frozenset)
@@ -25,26 +59,27 @@ class Settings:
     def __post_init__(self) -> None:
         if self.allowed_origins is None:
             object.__setattr__(self, "allowed_origins", [])
-
-    @property
-    def trusted_hosts(self) -> frozenset[str]:
-        """Hostnames this process accepts in a request's Host or Origin.
-
-        Used by the origin_validation middleware to check the Origin header.
-        Independent of allowed_origins/CORS — that list controls browser
-        CORS response headers; this one controls whether the server accepts
-        the request at all. TRUSTED_HOSTS (comma-separated) adds to the
-        fixed loopback set; it's never removed or replaced.
-        """
-        return _LOOPBACK_HOSTS | self.extra_trusted_hosts
+        if self.trusted_hosts is None:
+            object.__setattr__(self, "trusted_hosts", _LOOPBACK_HOSTS)
 
     @classmethod
     def from_env(cls) -> "Settings":
+        # Single source of truth for browser origins. From this one list we
+        # derive both outputs, once, here:
+        #   - allowed_origins: normalized full origins (CORS + Origin check)
+        #   - trusted_hosts:   the origins' hostnames + loopback (Host check)
         origins_raw = os.environ.get("CORS_ALLOWED_ORIGINS", "")
-        origins = (
-            [o.strip() for o in origins_raw.split(",") if o.strip()]
-            if origins_raw
-            else []
+        origins: list[str] = []
+        for o in origins_raw.split(","):
+            normalized = normalize_origin(o)
+            if normalized and normalized not in origins:
+                origins.append(normalized)
+
+        # Hostnames trusted in the Host header: those of the configured
+        # origins, plus the loopback floor (this tool is intended to run on
+        # localhost or in Docker, so loopback covers the normal case).
+        origin_hosts = frozenset(
+            h for h in (urlparse(o).hostname for o in origins) if h
         )
         trusted_hosts_raw = os.environ.get("TRUSTED_HOSTS", "")
         # Hostnames are case-insensitive; normalize to lowercase so a
@@ -54,10 +89,13 @@ class Settings:
             h.strip().lower() for h in trusted_hosts_raw.split(",") if h.strip()
         )
         allow_raw = os.environ.get("ALLOW_NON_LOOPBACK_BIND", "")
+        trusted_hosts = _LOOPBACK_HOSTS | origin_hosts
+
         return cls(
             log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
             allowed_origins=origins,
             host=os.environ.get("HOST", "127.0.0.1"),
+            trusted_hosts=trusted_hosts,
             port=int(os.environ.get("PORT", "8080")),
             extra_trusted_hosts=extra_trusted,
             allow_non_loopback_bind=allow_raw.strip().lower()

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
 # Always trusted, regardless of configuration: requests claiming to be from

--- a/proxy/tests/conftest.py
+++ b/proxy/tests/conftest.py
@@ -13,7 +13,7 @@ def client():
     transport = ASGITransport(app=app)
     return AsyncClient(
         transport=transport,
-        base_url="http://test",
+        base_url="http://localhost",
         headers={"X-Requested-With": "nx-neptune"},
     )
 
@@ -22,7 +22,7 @@ def client():
 def bare_client():
     """Client without X-Requested-With header — for CSRF rejection tests."""
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test")
+    return AsyncClient(transport=transport, base_url="http://localhost")
 
 
 @pytest.fixture(autouse=True)

--- a/proxy/tests/test_app.py
+++ b/proxy/tests/test_app.py
@@ -12,7 +12,7 @@ def client():
     transport = ASGITransport(app=app)
     return AsyncClient(
         transport=transport,
-        base_url="http://test",
+        base_url="http://localhost",
         headers={"X-Requested-With": "nx-neptune"},
     )
 

--- a/proxy/tests/test_metadata.py
+++ b/proxy/tests/test_metadata.py
@@ -15,7 +15,7 @@ def client():
     transport = ASGITransport(app=app)
     return AsyncClient(
         transport=transport,
-        base_url="http://test",
+        base_url="http://localhost",
         headers={"X-Requested-With": "nx-neptune"},
     )
 

--- a/proxy/tests/test_origin_validation.py
+++ b/proxy/tests/test_origin_validation.py
@@ -14,7 +14,7 @@ def client():
     transport = ASGITransport(app=app)
     return AsyncClient(
         transport=transport,
-        base_url="http://test",
+        base_url="http://localhost",
         headers={"X-Requested-With": "nx-neptune"},
     )
 

--- a/proxy/tests/test_origin_validation.py
+++ b/proxy/tests/test_origin_validation.py
@@ -54,3 +54,45 @@ class TestOriginValidation:
     async def test_malformed_origin_rejected(self, client):
         resp = await client.get("/health", headers={"Origin": "not-a-valid-url"})
         assert resp.status_code == 403
+
+
+class TestOriginValidationFullOrigin:
+    """origin_validation matches the full origin (scheme+host+port) against
+    the configured allowed_origins, not just the hostname."""
+
+    @pytest.fixture
+    def client_with_allowed_origin(self, monkeypatch):
+        import nx_neptune_proxy.app as app_module
+        from nx_neptune_proxy.config import Settings
+
+        patched = Settings(allowed_origins=["https://app.example.com:8443"])
+        monkeypatch.setattr(app_module, "settings", patched)
+        transport = ASGITransport(app=app_module.app)
+        return AsyncClient(
+            transport=transport,
+            base_url="http://localhost",
+            headers={"X-Requested-With": "nx-neptune"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_configured_full_origin_allowed(self, client_with_allowed_origin):
+        resp = await client_with_allowed_origin.get(
+            "/health", headers={"Origin": "https://app.example.com:8443"}
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_same_host_wrong_port_rejected(self, client_with_allowed_origin):
+        """A trusted hostname on a non-configured port is rejected — matching
+        is on the full origin, not the hostname alone."""
+        resp = await client_with_allowed_origin.get(
+            "/health", headers={"Origin": "https://app.example.com:9999"}
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_same_host_wrong_scheme_rejected(self, client_with_allowed_origin):
+        resp = await client_with_allowed_origin.get(
+            "/health", headers={"Origin": "http://app.example.com:8443"}
+        )
+        assert resp.status_code == 403

--- a/proxy/tests/test_path_traversal.py
+++ b/proxy/tests/test_path_traversal.py
@@ -34,7 +34,7 @@ class TestPathTraversal:
             "path": path,
             "root_path": "",
             "query_string": b"",
-            "headers": [(b"host", b"test")],
+            "headers": [(b"host", b"localhost")],
             # A real request always has a client peer; the client_ip_guard
             # rejects requests without a loopback client. Set loopback here so
             # this scope represents a legitimate local request.

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -16,7 +16,7 @@ def client():
     transport = ASGITransport(app=app)
     return AsyncClient(
         transport=transport,
-        base_url="http://test",
+        base_url="http://localhost",
         headers={"X-Requested-With": "nx-neptune"},
     )
 

--- a/proxy/tests/test_trusted_host_middleware.py
+++ b/proxy/tests/test_trusted_host_middleware.py
@@ -38,25 +38,50 @@ class TestTrustedHostMiddleware:
         assert resp.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_ipv6_loopback_host_incorrectly_rejected(self, client):
-        """Known Starlette limitation, not a regression in this change.
-
-        TrustedHostMiddleware parses Host via `.split(":")[0]`, which turns
-        any IPv6 literal like "[::1]:8080" into "[" — never a value that can
-        match an allowlist entry. A legitimate IPv6 loopback client is
-        rejected exactly like an untrusted one, purely due to this parsing
-        bug (confirmed present in Starlette's latest release as of this
-        writing). This test documents and pins down that behavior so a
-        future Starlette upgrade that happens to fix it doesn't go
-        unnoticed.
-        """
+    async def test_ipv6_loopback_host_rejected(self, client):
+        """IPv6 is deliberately excluded from allowed_hosts (see app.py),
+        not just accidentally unmatched. Outcome is unchanged either way."""
         resp = await client.get("/health", headers={"Host": "[::1]:8080"})
         assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_random_ipv6_host_rejected(self, client):
-        """A non-loopback IPv6 literal is correctly rejected too — though
-        for this middleware, every IPv6 literal is rejected regardless of
-        whether it's trusted, per the limitation above."""
+        """A non-loopback IPv6 literal is rejected too — every IPv6 literal
+        is rejected regardless of whether it's trusted, per the deliberate
+        exclusion above."""
         resp = await client.get("/health", headers={"Host": "[2001:db8::1]:8080"})
         assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_ipv6_base_url_rejected_without_explicit_host_header(self):
+        """Same rejection as above, but via a client whose base_url is
+        itself IPv6 — no Host header is set explicitly here; httpx derives
+        Host: [::1]:8080 from base_url on its own, same as a real client
+        addressing this server by an IPv6 literal would."""
+        transport = ASGITransport(app=app)
+        ipv6_client = AsyncClient(
+            transport=transport,
+            base_url="http://[::1]:8080",
+            headers={"X-Requested-With": "nx-neptune"},
+        )
+        resp = await ipv6_client.get("/health")
+        assert resp.status_code == 400
+
+
+class TestIpv6ExclusionScope:
+    """The IPv6 exclusion above is specific to TrustedHostMiddleware's
+    allowed_hosts, not to settings.trusted_hosts itself — origin_validation
+    (which parses Origin via urlparse, unaffected by Starlette's bug) still
+    supports IPv6 loopback."""
+
+    @pytest.mark.asyncio
+    async def test_origin_validation_still_allows_ipv6_loopback(self, client):
+        # TrustedHostMiddleware still evaluates the Host header on this
+        # request. It passes because the value is trusted and not an
+        # IPv6 literal (localhost). This test isolates the Origin check
+        # by controlling for Host, not by bypassing the Host check.
+        resp = await client.get(
+            "/health",
+            headers={"Host": "localhost", "Origin": "http://[::1]:8080"},
+        )
+        assert resp.status_code == 200

--- a/proxy/tests/test_trusted_host_middleware.py
+++ b/proxy/tests/test_trusted_host_middleware.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TrustedHostMiddleware — blocks DNS rebinding via the Host header."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://localhost",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
+
+
+class TestTrustedHostMiddleware:
+    @pytest.mark.asyncio
+    async def test_localhost_host_allowed(self, client):
+        resp = await client.get("/health", headers={"Host": "localhost:8080"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_127_0_0_1_host_allowed(self, client):
+        resp = await client.get("/health", headers={"Host": "127.0.0.1:8080"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_untrusted_host_rejected(self, client):
+        """Simulated DNS-rebinding: the request lands on this server, but
+        claims to be addressed to an attacker-controlled hostname."""
+        resp = await client.get("/health", headers={"Host": "attacker-controlled.com"})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_ipv6_loopback_host_incorrectly_rejected(self, client):
+        """Known Starlette limitation, not a regression in this change.
+
+        TrustedHostMiddleware parses Host via `.split(":")[0]`, which turns
+        any IPv6 literal like "[::1]:8080" into "[" — never a value that can
+        match an allowlist entry. A legitimate IPv6 loopback client is
+        rejected exactly like an untrusted one, purely due to this parsing
+        bug (confirmed present in Starlette's latest release as of this
+        writing). This test documents and pins down that behavior so a
+        future Starlette upgrade that happens to fix it doesn't go
+        unnoticed.
+        """
+        resp = await client.get("/health", headers={"Host": "[::1]:8080"})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_random_ipv6_host_rejected(self, client):
+        """A non-loopback IPv6 literal is correctly rejected too — though
+        for this middleware, every IPv6 literal is rejected regardless of
+        whether it's trusted, per the limitation above."""
+        resp = await client.get("/health", headers={"Host": "[2001:db8::1]:8080"})
+        assert resp.status_code == 400

--- a/proxy/tests/test_trusted_host_middleware.py
+++ b/proxy/tests/test_trusted_host_middleware.py
@@ -85,3 +85,80 @@ class TestIpv6ExclusionScope:
             headers={"Host": "localhost", "Origin": "http://[::1]:8080"},
         )
         assert resp.status_code == 200
+
+
+class TestHostHeaderEdgeCases:
+    """Edge cases for the Host header check.
+
+    These lock in the current behavior. Note that Starlette's
+    TrustedHostMiddleware compares the incoming Host against allowed_hosts
+    case-sensitively (it does not lowercase the header), so a Host that
+    differs only in case is rejected. Matching is exact, not substring, so
+    hostnames that merely share a prefix or suffix with a trusted host are
+    also rejected.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uppercase_host_rejected(self, client):
+        """Host matching is case-sensitive: an upper/mixed-case variant of a
+        trusted host does not match the (lowercase) allowlist and is
+        rejected."""
+        resp = await client.get("/health", headers={"Host": "LOCALHOST:8080"})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_mixed_case_host_rejected(self, client):
+        resp = await client.get("/health", headers={"Host": "LoCalHost"})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_empty_host_rejected(self, client):
+        """An empty Host value is not on the allowlist and is rejected."""
+        resp = await client.get("/health", headers={"Host": ""})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_whitespace_host_rejected(self, client):
+        """A whitespace-only Host is not trimmed into a trusted value; it is
+        rejected."""
+        resp = await client.get("/health", headers={"Host": "   "})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_suffix_confusion_host_rejected(self, client):
+        """A host that has a trusted name as a *prefix* label
+        (localhost.attacker.com) must not be accepted — matching is exact,
+        not substring/suffix."""
+        resp = await client.get("/health", headers={"Host": "localhost.attacker.com"})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_prefix_confusion_host_rejected(self, client):
+        """A host that ends with a trusted name (attacker.com.localhost) must
+        not be accepted either."""
+        resp = await client.get("/health", headers={"Host": "attacker.com.localhost"})
+        assert resp.status_code == 400
+
+
+class TestHostCheckCoversCatchAllRoute:
+    """The Host check must guard every route, not just /health — including
+    the SPA catch-all (GET /{path:path}), which is the most exposed surface.
+    """
+
+    @pytest.mark.asyncio
+    async def test_catch_all_root_allowed_with_trusted_host(self, client):
+        resp = await client.get("/", headers={"Host": "localhost"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_catch_all_root_rejected_with_untrusted_host(self, client):
+        resp = await client.get("/", headers={"Host": "attacker-controlled.com"})
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_catch_all_spa_route_rejected_with_untrusted_host(self, client):
+        """An arbitrary deep SPA path is still subject to the Host check."""
+        resp = await client.get(
+            "/some/spa/route", headers={"Host": "attacker-controlled.com"}
+        )
+        assert resp.status_code == 400

--- a/proxy/tests/test_trusted_hosts.py
+++ b/proxy/tests/test_trusted_hosts.py
@@ -22,6 +22,27 @@ class TestTrustedHosts:
             "example.com",
         }
 
+    def test_from_env_reads_trusted_hosts(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_HOSTS", "example.com, foo.local")
+        settings = Settings.from_env()
+        assert settings.extra_trusted_hosts == {"example.com", "foo.local"}
+        assert settings.trusted_hosts == {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+            "example.com",
+            "foo.local",
+        }
+
+    def test_independent_of_cors_allowed_origins(self, monkeypatch):
+        """trusted_hosts must not be affected by CORS_ALLOWED_ORIGINS in
+        either direction — the two lists are unrelated."""
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://example.com:888")
+        settings = Settings.from_env()
+        assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
+        assert settings.allowed_origins == ["https://example.com:888"]
+
+
     def test_trusted_hosts_derived_from_origins(self, monkeypatch):
         """The Host allowlist derives its hostnames from the configured
         origins, so a browser origin is trusted for the Host check with no

--- a/proxy/tests/test_trusted_hosts.py
+++ b/proxy/tests/test_trusted_hosts.py
@@ -11,6 +11,15 @@ class TestTrustedHosts:
         settings = Settings()
         assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
 
+    def test_extra_trusted_hosts_is_additive(self):
+        settings = Settings(extra_trusted_hosts=frozenset({"example.com"}))
+        assert settings.trusted_hosts == {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+            "example.com",
+        }
+
     def test_trusted_hosts_can_be_constructed_directly(self):
         settings = Settings(
             trusted_hosts=frozenset({"127.0.0.1", "::1", "localhost", "example.com"})
@@ -42,6 +51,10 @@ class TestTrustedHosts:
         assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
         assert settings.allowed_origins == ["https://example.com:888"]
 
+    def test_allowed_origins_still_defaults_to_empty(self):
+        """Unchanged pre-existing behaviour: no fallback/derivation."""
+        settings = Settings()
+        assert settings.allowed_origins == []
 
     def test_trusted_hosts_derived_from_origins(self, monkeypatch):
         """The Host allowlist derives its hostnames from the configured

--- a/proxy/tests/test_trusted_hosts.py
+++ b/proxy/tests/test_trusted_hosts.py
@@ -32,6 +32,15 @@ class TestTrustedHosts:
             "foo.local",
         }
 
+    def test_from_env_lowercases_trusted_hosts(self, monkeypatch):
+        """Hostnames are case-insensitive; a mixed-case TRUSTED_HOSTS entry is
+        normalized to lowercase so it matches the lowercase Host/Origin a
+        client sends."""
+        monkeypatch.setenv("TRUSTED_HOSTS", "Example.COM, Foo.Local")
+        settings = Settings.from_env()
+        assert settings.extra_trusted_hosts == {"example.com", "foo.local"}
+        assert "example.com" in settings.trusted_hosts
+
     def test_independent_of_cors_allowed_origins(self, monkeypatch):
         """trusted_hosts must not be affected by CORS_ALLOWED_ORIGINS in
         either direction — the two lists are unrelated."""

--- a/proxy/tests/test_trusted_hosts.py
+++ b/proxy/tests/test_trusted_hosts.py
@@ -11,15 +11,6 @@ class TestTrustedHosts:
         settings = Settings()
         assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
 
-    def test_extra_trusted_hosts_is_additive(self):
-        settings = Settings(extra_trusted_hosts=frozenset({"example.com"}))
-        assert settings.trusted_hosts == {
-            "127.0.0.1",
-            "::1",
-            "localhost",
-            "example.com",
-        }
-
     def test_trusted_hosts_can_be_constructed_directly(self):
         settings = Settings(
             trusted_hosts=frozenset({"127.0.0.1", "::1", "localhost", "example.com"})
@@ -31,38 +22,18 @@ class TestTrustedHosts:
             "example.com",
         }
 
-    def test_from_env_reads_trusted_hosts(self, monkeypatch):
-        monkeypatch.setenv("TRUSTED_HOSTS", "example.com, foo.local")
-        settings = Settings.from_env()
-        assert settings.extra_trusted_hosts == {"example.com", "foo.local"}
-        assert settings.trusted_hosts == {
-            "127.0.0.1",
-            "::1",
-            "localhost",
-            "example.com",
-            "foo.local",
-        }
-
-    def test_independent_of_cors_allowed_origins(self, monkeypatch):
-        """trusted_hosts must not be affected by CORS_ALLOWED_ORIGINS in
-        either direction — the two lists are unrelated."""
-        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://example.com:888")
-        settings = Settings.from_env()
-        assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
-        assert settings.allowed_origins == ["https://example.com:888"]
-
-    def test_allowed_origins_still_defaults_to_empty(self):
-        """Unchanged pre-existing behaviour: no fallback/derivation."""
-        settings = Settings()
-        assert settings.allowed_origins == []
-
     def test_trusted_hosts_derived_from_origins(self, monkeypatch):
         """The Host allowlist derives its hostnames from the configured
         origins, so a browser origin is trusted for the Host check with no
         separate configuration."""
         monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://example.com:888")
         settings = Settings.from_env()
-        assert "example.com" in settings.trusted_hosts
+        assert settings.trusted_hosts == {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+            "example.com",
+        }
         assert settings.allowed_origins == ["https://example.com:888"]
 
     def test_derived_host_is_lowercased(self, monkeypatch):
@@ -71,7 +42,12 @@ class TestTrustedHosts:
         sends."""
         monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://Example.COM")
         settings = Settings.from_env()
-        assert "example.com" in settings.trusted_hosts
+        assert settings.trusted_hosts == {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+            "example.com",
+        }
 
     def test_origins_normalized_default_port_stripped(self, monkeypatch):
         """Default ports are dropped so https://x and https://x:443 are equal;

--- a/proxy/tests/test_trusted_hosts.py
+++ b/proxy/tests/test_trusted_hosts.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Settings.trusted_hosts — independent of allowed_origins/CORS."""
+"""Settings.trusted_hosts — derived from the CORS origins list + loopback."""
 
 from nx_neptune_proxy.config import Settings
 
@@ -11,8 +11,10 @@ class TestTrustedHosts:
         settings = Settings()
         assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
 
-    def test_extra_trusted_hosts_is_additive(self):
-        settings = Settings(extra_trusted_hosts=frozenset({"example.com"}))
+    def test_trusted_hosts_can_be_constructed_directly(self):
+        settings = Settings(
+            trusted_hosts=frozenset({"127.0.0.1", "::1", "localhost", "example.com"})
+        )
         assert settings.trusted_hosts == {
             "127.0.0.1",
             "::1",
@@ -20,36 +22,35 @@ class TestTrustedHosts:
             "example.com",
         }
 
-    def test_from_env_reads_trusted_hosts(self, monkeypatch):
-        monkeypatch.setenv("TRUSTED_HOSTS", "example.com, foo.local")
-        settings = Settings.from_env()
-        assert settings.extra_trusted_hosts == {"example.com", "foo.local"}
-        assert settings.trusted_hosts == {
-            "127.0.0.1",
-            "::1",
-            "localhost",
-            "example.com",
-            "foo.local",
-        }
-
-    def test_from_env_lowercases_trusted_hosts(self, monkeypatch):
-        """Hostnames are case-insensitive; a mixed-case TRUSTED_HOSTS entry is
-        normalized to lowercase so it matches the lowercase Host/Origin a
-        client sends."""
-        monkeypatch.setenv("TRUSTED_HOSTS", "Example.COM, Foo.Local")
-        settings = Settings.from_env()
-        assert settings.extra_trusted_hosts == {"example.com", "foo.local"}
-        assert "example.com" in settings.trusted_hosts
-
-    def test_independent_of_cors_allowed_origins(self, monkeypatch):
-        """trusted_hosts must not be affected by CORS_ALLOWED_ORIGINS in
-        either direction — the two lists are unrelated."""
+    def test_trusted_hosts_derived_from_origins(self, monkeypatch):
+        """The Host allowlist derives its hostnames from the configured
+        origins, so a browser origin is trusted for the Host check with no
+        separate configuration."""
         monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://example.com:888")
         settings = Settings.from_env()
-        assert settings.trusted_hosts == {"127.0.0.1", "::1", "localhost"}
+        assert "example.com" in settings.trusted_hosts
         assert settings.allowed_origins == ["https://example.com:888"]
 
-    def test_allowed_origins_still_defaults_to_empty(self):
-        """Unchanged pre-existing behaviour: no fallback/derivation."""
+    def test_derived_host_is_lowercased(self, monkeypatch):
+        """Hostnames are case-insensitive; a mixed-case origin host is
+        normalized to lowercase so it matches the lowercase Host a client
+        sends."""
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://Example.COM")
+        settings = Settings.from_env()
+        assert "example.com" in settings.trusted_hosts
+
+    def test_origins_normalized_default_port_stripped(self, monkeypatch):
+        """Default ports are dropped so https://x and https://x:443 are equal;
+        scheme/host are lowercased."""
+        monkeypatch.setenv(
+            "CORS_ALLOWED_ORIGINS", "HTTPS://Example.COM:443, http://foo.local:80"
+        )
+        settings = Settings.from_env()
+        assert settings.allowed_origins == [
+            "https://example.com",
+            "http://foo.local",
+        ]
+
+    def test_allowed_origins_defaults_to_empty(self):
         settings = Settings()
         assert settings.allowed_origins == []


### PR DESCRIPTION

## Summary

Adds two complementary, defense-in-depth middlewares to the proxy, both driven from a single origins list:

- **`TrustedHostMiddleware`** validates the `Host` header against an allowlist to block **DNS rebinding**. The `Host` header alone doesn't confirm a request was actually meant for this server — rebinding can trick a client into sending a request that lands here while claiming a hostname it doesn't recognize.
- **`origin_validation`** validates the `Origin` header **server-side** against the CORS allowlist, rejecting disallowed origins with a 403 before the handler runs. This enforces the allowlist on the server rather than relying on the browser (CORS response headers are only browser-enforced and don't stop a request from executing).

## Changes

- **`config.py`**: `allowed_origins` and `trusted_hosts` are now derived once, together, from the single `CORS_ALLOWED_ORIGINS` list — so the two allowlists can't drift. 
`allowed_origins` holds the full normalized origins (used by CORS and the Origin check); `trusted_hosts` holds those origins' hostnames plus the loopback set (used by the Host check).
Loopback (`127.0.0.1`, `localhost`) is always trusted, which covers the normal local/Docker case.

- **`app.py`**: registers `TrustedHostMiddleware` (Host check) and the `origin_validation` middleware (server-side Origin check). Host matching is case-insensitive.
IPv6 is excluded from the Host allowlist for now — Starlette can't parse IPv6 `Host` headers (starlette#3471) — and fails closed: all IPv6 hosts are denied, not allowed, until a fixed release is available.

- **Tests**: fixtures updated to address the proxy with a recognized hostname; coverage for allowed/rejected hosts, the IPv6 exclusion, and server-side Origin validation.

## Testing

113 passed.
