### PR TITLE
Feat: Introduce a startup check for the proxy bind address

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,6 +7,12 @@ COPY proxy/ ./proxy/
 RUN pip install --no-cache-dir ./nx_neptune_src ./proxy && useradd --create-home appuser
 USER appuser
 EXPOSE 8080
+# The container must bind 0.0.0.0 so Docker's published-port forwarding can
+# reach it (container-internal 127.0.0.1 is unreachable from the host). Real
+# network exposure is controlled by how the port is published (see the run
+# target's -p 127.0.0.1:8080:8080). ALLOW_NON_LOOPBACK_BIND acknowledges this
+# deliberate bind so the startup guard permits it.
+ENV HOST=0.0.0.0 ALLOW_NON_LOOPBACK_BIND=1
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 \
     CMD wget -qO /dev/null http://localhost:8080/health
-CMD ["uvicorn", "nx_neptune_proxy.app:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["python", "-m", "nx_neptune_proxy"]

--- a/proxy/src/nx_neptune_proxy/__main__.py
+++ b/proxy/src/nx_neptune_proxy/__main__.py
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process entrypoint: validate the bind address, then launch uvicorn.
+
+Run as ``python -m nx_neptune_proxy``. This wraps the uvicorn launch so the
+bind address is validated *before* the socket is opened. Because the same
+value is both checked here and passed to ``uvicorn.run``, the address that
+gets validated is guaranteed to be the address that gets bound.
+
+"""
+
+import sys
+
+import uvicorn
+
+from nx_neptune_proxy.config import Settings
+
+# A request addressed to any of these never leaves the local machine.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def check_bind_allowed(host: str, allow_non_loopback: bool) -> str | None:
+    """Return an error message if binding to ``host`` is not allowed, else None.
+
+    Binding to loopback is always allowed. Binding to any other address is
+    allowed only when explicitly acknowledged via ``allow_non_loopback``.
+    """
+    if host in _LOOPBACK_HOSTS:
+        return None
+    if allow_non_loopback:
+        return None
+    return (
+        f"Refusing to start: HOST={host!r} is not a loopback address and "
+        "ALLOW_NON_LOOPBACK_BIND is not set. This would expose the proxy on "
+        "the network. Bind to 127.0.0.1, or set ALLOW_NON_LOOPBACK_BIND=1 to "
+        "expose it deliberately (e.g. inside a container whose published "
+        "ports are restricted)."
+    )
+
+
+def main() -> None:
+    settings = Settings.from_env()
+    error = check_bind_allowed(settings.host, settings.allow_non_loopback_bind)
+    if error:
+        sys.exit(error)
+    uvicorn.run(
+        "nx_neptune_proxy.app:app",
+        host=settings.host,
+        port=settings.port,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -14,7 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from nx_neptune_proxy.config import get_settings
+from nx_neptune_proxy.config import _LOOPBACK_HOSTS, get_settings
 from nx_neptune_proxy.routers.graph import router as graph_router
 from nx_neptune_proxy.routers.metadata import router as metadata_router
 from nx_neptune_proxy.routers.project import router as project_router
@@ -119,6 +119,27 @@ async def request_logging(request: Request, call_next):
     )
     response.headers["x-request-id"] = request_id
     return response
+
+
+# --- Client IP guard (network-level, defense-in-depth) ---
+#
+# Checks the TCP peer address (request.client.host), which a remote client
+# can't forge — unlike the Host/Origin/CORS header checks. Rejects non-loopback
+# clients unless ALLOW_NON_LOOPBACK_BIND is set. Enforced per-request, so it
+# holds however the app was launched (not just via the startup bind guard).
+@app.middleware("http")
+async def client_ip_guard(request: Request, call_next):
+    if not settings.allow_non_loopback_bind:
+        client = request.client.host if request.client else ""
+        if client not in _LOOPBACK_HOSTS:
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": "non_loopback_client",
+                    "message": "Client address is not loopback",
+                },
+            )
+    return await call_next(request)
 
 
 # --- Error handlers ---

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -41,14 +41,14 @@ class Settings:
     @classmethod
     def from_env(cls) -> "Settings":
         origins_raw = os.environ.get("CORS_ALLOWED_ORIGINS", "")
-        trusted_hosts_raw = os.environ.get("TRUSTED_HOSTS", "")
-        extra_trusted = frozenset(
-            h.strip() for h in trusted_hosts_raw.split(",") if h.strip()
-        )
         origins = (
             [o.strip() for o in origins_raw.split(",") if o.strip()]
             if origins_raw
             else []
+        )
+        trusted_hosts_raw = os.environ.get("TRUSTED_HOSTS", "")
+        extra_trusted = frozenset(
+            h.strip() for h in trusted_hosts_raw.split(",") if h.strip()
         )
         allow_raw = os.environ.get("ALLOW_NON_LOOPBACK_BIND", "")
         return cls(

--- a/proxy/src/nx_neptune_proxy/config.py
+++ b/proxy/src/nx_neptune_proxy/config.py
@@ -15,7 +15,9 @@ class Settings:
 
     log_level: str = "INFO"
     allowed_origins: list[str] = None  # type: ignore[assignment]
+    host: str = "127.0.0.1"
     port: int = 8080
+    allow_non_loopback_bind: bool = False
     extra_trusted_hosts: frozenset[str] = field(default_factory=frozenset)
     region: str = ""
     graph_prefix: str = "nxp-"
@@ -39,20 +41,24 @@ class Settings:
     @classmethod
     def from_env(cls) -> "Settings":
         origins_raw = os.environ.get("CORS_ALLOWED_ORIGINS", "")
+        trusted_hosts_raw = os.environ.get("TRUSTED_HOSTS", "")
+        extra_trusted = frozenset(
+            h.strip() for h in trusted_hosts_raw.split(",") if h.strip()
+        )
         origins = (
             [o.strip() for o in origins_raw.split(",") if o.strip()]
             if origins_raw
             else []
         )
-        trusted_hosts_raw = os.environ.get("TRUSTED_HOSTS", "")
-        extra_trusted = frozenset(
-            h.strip() for h in trusted_hosts_raw.split(",") if h.strip()
-        )
+        allow_raw = os.environ.get("ALLOW_NON_LOOPBACK_BIND", "")
         return cls(
             log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
             allowed_origins=origins,
+            host=os.environ.get("HOST", "127.0.0.1"),
             port=int(os.environ.get("PORT", "8080")),
             extra_trusted_hosts=extra_trusted,
+            allow_non_loopback_bind=allow_raw.strip().lower()
+            not in ("", "0", "false", "no"),
             region=os.environ.get(
                 "AWS_DEFAULT_REGION", os.environ.get("AWS_REGION", "")
             ),

--- a/proxy/tests/test_bind_guard.py
+++ b/proxy/tests/test_bind_guard.py
@@ -1,0 +1,84 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Startup bind guard — refuse a non-loopback bind unless acknowledged."""
+
+from unittest import mock
+
+import pytest
+
+from nx_neptune_proxy.__main__ import check_bind_allowed, main
+from nx_neptune_proxy.config import Settings
+
+
+class TestCheckBindAllowed:
+    @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+    def test_loopback_always_allowed(self, host):
+        assert check_bind_allowed(host, allow_non_loopback=False) is None
+
+    def test_non_loopback_refused_without_override(self):
+        error = check_bind_allowed("0.0.0.0", allow_non_loopback=False)
+        assert error is not None
+        assert "Refusing to start" in error
+        assert "ALLOW_NON_LOOPBACK_BIND" in error
+
+    def test_non_loopback_allowed_with_override(self):
+        assert check_bind_allowed("0.0.0.0", allow_non_loopback=True) is None
+
+    def test_specific_external_ip_refused_without_override(self):
+        assert check_bind_allowed("192.168.1.5", allow_non_loopback=False) is not None
+
+
+class TestMain:
+    def test_main_starts_uvicorn_on_loopback_default(self):
+        """Default (no HOST set) is loopback, so uvicorn is launched."""
+        with (
+            mock.patch.dict("os.environ", {}, clear=True),
+            mock.patch("nx_neptune_proxy.__main__.uvicorn.run") as run,
+        ):
+            main()
+            run.assert_called_once()
+            assert run.call_args.kwargs["host"] == "127.0.0.1"
+
+    def test_main_refuses_non_loopback_without_override(self):
+        with (
+            mock.patch.dict("os.environ", {"HOST": "0.0.0.0"}, clear=True),
+            mock.patch("nx_neptune_proxy.__main__.uvicorn.run") as run,
+        ):
+            with pytest.raises(SystemExit):
+                main()
+            run.assert_not_called()
+
+    def test_main_starts_non_loopback_with_override(self):
+        with (
+            mock.patch.dict(
+                "os.environ",
+                {"HOST": "0.0.0.0", "ALLOW_NON_LOOPBACK_BIND": "1"},
+                clear=True,
+            ),
+            mock.patch("nx_neptune_proxy.__main__.uvicorn.run") as run,
+        ):
+            main()
+            run.assert_called_once()
+            assert run.call_args.kwargs["host"] == "0.0.0.0"
+
+
+class TestConfigBindFields:
+    def test_defaults_to_loopback_no_override(self):
+        settings = Settings()
+        assert settings.host == "127.0.0.1"
+        assert settings.allow_non_loopback_bind is False
+
+    def test_from_env_reads_host(self, monkeypatch):
+        monkeypatch.setenv("HOST", "0.0.0.0")
+        assert Settings.from_env().host == "0.0.0.0"
+
+    @pytest.mark.parametrize("value", ["1", "true", "True", "yes", "on"])
+    def test_override_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv("ALLOW_NON_LOOPBACK_BIND", value)
+        assert Settings.from_env().allow_non_loopback_bind is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "False", "no"])
+    def test_override_falsy_values(self, monkeypatch, value):
+        monkeypatch.setenv("ALLOW_NON_LOOPBACK_BIND", value)
+        assert Settings.from_env().allow_non_loopback_bind is False

--- a/proxy/tests/test_client_ip_guard.py
+++ b/proxy/tests/test_client_ip_guard.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""client_ip_guard — reject non-loopback clients unless a non-loopback bind
+was explicitly acknowledged (ALLOW_NON_LOOPBACK_BIND).
+
+Unlike the Host/Origin/CORS checks (which inspect forgeable headers), this
+inspects the TCP peer address (request.client.host), which a remote client
+cannot forge. Tests drive it via ASGITransport's `client` argument, which
+sets request.client.host.
+"""
+
+import dataclasses
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from nx_neptune_proxy.app import app
+
+
+def _client(client_addr=("127.0.0.1", 12345)):
+    # ASGITransport(client=(host, port)) sets request.client.host.
+    transport = ASGITransport(app=app, client=client_addr)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://localhost",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
+
+
+class TestClientIpGuardDefault:
+    """Default settings (allow_non_loopback_bind=False)."""
+
+    @pytest.mark.asyncio
+    async def test_loopback_ipv4_allowed(self):
+        resp = await _client(("127.0.0.1", 12345)).get("/health")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_loopback_ipv6_allowed(self):
+        resp = await _client(("::1", 12345)).get("/health")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_client_rejected(self):
+        resp = await _client(("203.0.113.5", 40000)).get("/health")
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "non_loopback_client"
+
+    @pytest.mark.asyncio
+    async def test_private_lan_client_rejected(self):
+        resp = await _client(("192.168.1.20", 40000)).get("/health")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_missing_client_rejected_fails_closed(self):
+        # No client tuple -> request.client is None -> treated as non-loopback.
+        resp = await _client(client_addr=None).get("/health")
+        assert resp.status_code == 403
+
+
+class TestClientIpGuardOptIn:
+    """With allow_non_loopback_bind=True the guard is disabled (e.g. inside a
+    container whose published ports are restricted)."""
+
+    @pytest.fixture
+    def opted_in(self, monkeypatch):
+        # settings is a frozen dataclass, so swap in a modified copy.
+        import nx_neptune_proxy.app as app_module
+
+        patched = dataclasses.replace(app_module.settings, allow_non_loopback_bind=True)
+        monkeypatch.setattr(app_module, "settings", patched)
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_allowed_when_opted_in(self, opted_in):
+        resp = await _client(("203.0.113.5", 40000)).get("/health")
+        assert resp.status_code == 200

--- a/proxy/tests/test_path_traversal.py
+++ b/proxy/tests/test_path_traversal.py
@@ -35,6 +35,10 @@ class TestPathTraversal:
             "root_path": "",
             "query_string": b"",
             "headers": [(b"host", b"test")],
+            # A real request always has a client peer; the client_ip_guard
+            # rejects requests without a loopback client. Set loopback here so
+            # this scope represents a legitimate local request.
+            "client": ("127.0.0.1", 12345),
         }
         status = None
         body_parts = []


### PR DESCRIPTION
**Summary**

This introduces a startup check that runs before the proxy begins serving. The bind address is now a configurable setting that defaults to loopback, and the check confirms it before startup, asking for an explicit opt-in before binding to a non-loopback address. Local runs work out of the box, and binding elsewhere is always an intentional choice.

**Changes**

`__main__.py`: new startup entrypoint that runs the check and then starts the server. The proxy is now started through this entrypoint.
`config.py`: the bind address is now a setting (`HOST`, defaulting to loopback), with a companion opt-in (`ALLOW_NON_LOOPBACK_BIND`) for binding elsewhere.
`Dockerfile`: starts the proxy through the new entrypoint and sets the address and opt-in explicitly, since a container binds to all interfaces for its published port to be reachable, with a note explaining why.
Tests covering the startup check, the entrypoint behavior, and the new settings.

**Scope**

Proxy only. The development workflow (`make dev`) is unchanged.

**Testing**

* Make dev and docker-compose continue to work without issue.