### PR TITLE
Misc: Add proxy-fmt / proxy-lint make targets and CI lint job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,3 +140,20 @@ jobs:
       - name: Run proxy tests
         run: pytest tests/ -v
         working-directory: proxy
+
+  proxy_lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.11]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install project for developers
+        run: make install-dev
+      - name: Run proxy linter
+        run: make proxy-lint

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,17 @@ lint:             ## Run flake8, black, mypy linters.
 	$(ENV_PREFIX)black --check tests/
 	$(ENV_PREFIX)mypy --ignore-missing-imports nx_neptune/ nx_plugin/
 
+.PHONY: proxy-fmt
+proxy-fmt:        ## Format proxy module using black & isort.
+	$(ENV_PREFIX)isort proxy/src/ proxy/tests/
+	$(ENV_PREFIX)black proxy/src/ proxy/tests/
+
+.PHONY: proxy-lint
+proxy-lint:       ## Run flake8, black, mypy linters on the proxy module.
+	$(ENV_PREFIX)flake8 proxy/src/ proxy/tests/
+	$(ENV_PREFIX)black --check proxy/src/ proxy/tests/
+	$(ENV_PREFIX)mypy --ignore-missing-imports proxy/src/
+
 .PHONY: test
 test: lint        ## Run tests and generate coverage report.
 	$(ENV_PREFIX)pytest -v --cov-config=.coveragerc --cov=nx_neptune -l --tb=short --maxfail=1 --cov-fail-under=80 tests/


### PR DESCRIPTION
### Summary :memo:

Adds format/lint tooling for the `proxy/` module, which had no lint coverage before.

- `Makefile`: `proxy-fmt` (isort + black) and `proxy-lint` (flake8 + black --check + mypy) over `proxy/src/ proxy/tests/`, mirroring the root `fmt`/`lint`.

- `.github/workflows/main.yml`: new `proxy_lint` job running `make install-dev` then `make proxy-lint`.
