### PR TITLE
Misc: Make the proxy module pass `make proxy-lint`

### DIFF
--- a/nx_neptune/clients/opencypher_builder.py
+++ b/nx_neptune/clients/opencypher_builder.py
@@ -87,7 +87,7 @@ def _truncate_for_error(value: Any, limit: int = 40) -> str:
     return text
 
 
-def _escape_labels(labels) -> list:
+def _escape_labels(labels) -> list | str:
     """Backtick-escape a list of node/edge labels.
 
     Labels are interpolated into queries with escape=False (or directly into
@@ -451,7 +451,8 @@ def get_edge_batch_query_str(group_by_key: ImmutableEdgeGroupBy):
     else:
         return (
             f"UNWIND $relations AS rel MATCH (a{src_labels} {{`~id`: rel.from}}), (b{dest_labels} {{`~id`: rel.to}}) "
-            f"CREATE (a)-[r1:{_escape_identifier(group_by_key.label)}]->(b), (b)-[r2:{_escape_identifier(group_by_key.label)}]->(a)"
+            f"CREATE (a)-[r1:{_escape_identifier(group_by_key.label)}]->(b), "
+            f"(b)-[r2:{_escape_identifier(group_by_key.label)}]->(a) "
             f"SET r1 += rel.properties, r2 += rel.properties"
         )
 

--- a/proxy/src/nx_neptune_proxy/app.py
+++ b/proxy/src/nx_neptune_proxy/app.py
@@ -17,13 +17,12 @@ from fastapi.staticfiles import StaticFiles
 from nx_neptune_proxy.config import get_settings
 from nx_neptune_proxy.routers.graph import router as graph_router
 from nx_neptune_proxy.routers.metadata import router as metadata_router
-from nx_neptune_proxy.utils.sanitize import sanitize_error_message
-
-from nx_neptune_proxy.routers.projection import router as projection_router
 from nx_neptune_proxy.routers.project import router as project_router
+from nx_neptune_proxy.routers.projection import router as projection_router
 from nx_neptune_proxy.services.db import init_db
-from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.project_deletion import delete_project
+from nx_neptune_proxy.services.project_store import store as project_store
+from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
 settings = get_settings()
 

--- a/proxy/src/nx_neptune_proxy/routers/graph.py
+++ b/proxy/src/nx_neptune_proxy/routers/graph.py
@@ -9,18 +9,19 @@ import logging
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from nx_neptune.clients.client_factory import ClientFactory
+
+import nx_neptune_proxy.services.graph_ops  # noqa: F401 — registers transitions
+from nx_neptune_proxy.services.graph_state_machine import (
+    InvalidTransitionError,
+    available_actions,
+    clear_inflight,
+    execute_transition,
+    get_inflight,
+)
 from nx_neptune_proxy.utils.aws_helper import (
     assert_managed_graph,
     get_graph_or_exception,
 )
-from nx_neptune_proxy.services.graph_state_machine import (
-    InvalidTransitionError,
-    available_actions,
-    execute_transition,
-    get_inflight,
-    clear_inflight,
-)
-import nx_neptune_proxy.services.graph_ops  # noqa: F401 — registers transitions
 
 logger = logging.getLogger(__name__)
 

--- a/proxy/src/nx_neptune_proxy/routers/metadata.py
+++ b/proxy/src/nx_neptune_proxy/routers/metadata.py
@@ -2,13 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from fastapi import APIRouter, HTTPException, Query
-
 from nx_neptune.clients.client_factory import ClientFactory
+
 from nx_neptune_proxy.config import get_settings
-from nx_neptune_proxy.utils.aws_helper import (
-    assert_managed_graph,
-    get_graph_or_exception,
-)
 from nx_neptune_proxy.routers.schemas import (
     BucketsResponse,
     CatalogsResponse,
@@ -18,6 +14,10 @@ from nx_neptune_proxy.routers.schemas import (
     TablesResponse,
 )
 from nx_neptune_proxy.utils import paginate_aws
+from nx_neptune_proxy.utils.aws_helper import (
+    assert_managed_graph,
+    get_graph_or_exception,
+)
 
 router = APIRouter(prefix="/api/v0/metadata", tags=["metadata"])
 

--- a/proxy/src/nx_neptune_proxy/routers/project.py
+++ b/proxy/src/nx_neptune_proxy/routers/project.py
@@ -19,13 +19,17 @@ router = APIRouter(prefix="/api/v0/project", tags=["project"])
 class ProjectCreate(BaseModel):
     """Request body for creating a new project."""
 
-    name: str = Field(min_length=1, max_length=255, description="Display name for the project")
+    name: str = Field(
+        min_length=1, max_length=255, description="Display name for the project"
+    )
 
 
 class ProjectUpdate(BaseModel):
     """Request body for updating an existing project."""
 
-    name: Optional[str] = Field(default=None, min_length=1, max_length=255, description="New display name")
+    name: Optional[str] = Field(
+        default=None, min_length=1, max_length=255, description="New display name"
+    )
 
 
 class ProjectResponse(BaseModel):

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -3,18 +3,23 @@
 
 import asyncio
 import time
-
 from dataclasses import asdict
+
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
-
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune.clients.response_utils import get_query_failure_reason, get_query_state
-from nx_neptune.instance_management import _execute_athena_query, get_athena_query_results
+from nx_neptune.instance_management import (
+    _execute_athena_query,
+    get_athena_query_results,
+)
 from nx_neptune.utils.task_future import TaskType, wait_until_all_complete
-from nx_neptune.validators import check_athena_query, validate_resources, wrap_with_limit
-from nx_neptune_proxy.utils.aws_helper import assert_managed_graph, get_graph_or_exception
-from nx_neptune_proxy.utils.sanitize import sanitize_error_message
+from nx_neptune.validators import (
+    check_athena_query,
+    validate_resources,
+    wrap_with_limit,
+)
+
 from nx_neptune_proxy.routers.schemas import (
     PreviewResponse,
     ProjectionCreate,
@@ -26,6 +31,11 @@ from nx_neptune_proxy.routers.schemas import (
 from nx_neptune_proxy.services.pipeline import run_pipeline
 from nx_neptune_proxy.services.projection_store import store
 from nx_neptune_proxy.utils import unpack_query_results
+from nx_neptune_proxy.utils.aws_helper import (
+    assert_managed_graph,
+    get_graph_or_exception,
+)
+from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
 router = APIRouter(prefix="/api/v0/projection", tags=["projection"])
 
@@ -37,7 +47,12 @@ def _get_projection_or_404(projection_id: str):
     return projection
 
 
-@router.post("", summary="Create a new projection", response_model=ProjectionResponse, status_code=201)
+@router.post(
+    "",
+    summary="Create a new projection",
+    response_model=ProjectionResponse,
+    status_code=201,
+)
 def create_projection(body: ProjectionCreate):
     """Create a new projection in draft state."""
     projection = store.create(**body.model_dump())
@@ -50,20 +65,30 @@ def list_projections():
     return [asdict(p) for p in store.list()]
 
 
-@router.get("/{projection_id}", summary="Get projection state", response_model=ProjectionResponse)
+@router.get(
+    "/{projection_id}",
+    summary="Get projection state",
+    response_model=ProjectionResponse,
+)
 def get_projection(projection_id: str):
     """Get full projection state including progress."""
     return asdict(_get_projection_or_404(projection_id))
 
 
-@router.put("/{projection_id}", summary="Update projection", response_model=ProjectionResponse)
+@router.put(
+    "/{projection_id}", summary="Update projection", response_model=ProjectionResponse
+)
 def update_projection(projection_id: str, body: ProjectionUpdate):
     _get_projection_or_404(projection_id)
     projection = store.update(projection_id, **body.model_dump(exclude_unset=True))
-    return asdict(projection)
+    return asdict(projection)  # type: ignore[arg-type]
 
 
-@router.get("/{projection_id}/status", summary="Get pipeline progress", response_model=ProjectionStatus)
+@router.get(
+    "/{projection_id}/status",
+    summary="Get pipeline progress",
+    response_model=ProjectionStatus,
+)
 def get_projection_status(projection_id: str):
     """Get pipeline progress (subset of full state)."""
     p = _get_projection_or_404(projection_id)
@@ -78,19 +103,27 @@ def get_projection_status(projection_id: str):
     }
 
 
-@router.post("/{projection_id}/validate", summary="Validate all resources", response_model=ValidateResponse)
+@router.post(
+    "/{projection_id}/validate",
+    summary="Validate all resources",
+    response_model=ValidateResponse,
+)
 def validate_projection(projection_id: str):
     """Run all validators against the projection's configuration."""
     p = _get_projection_or_404(projection_id)
     checks = validate_resources(
         s3_staging_bucket=p.s3_staging_bucket,
         athena_catalog=p.catalog,
-        athena_database=p.database
+        athena_database=p.database,
     )
     return {"valid": all(c["passed"] for c in checks), "checks": checks}
 
 
-@router.post("/{projection_id}/validate-query", summary="Validate query only", response_model=ValidateResponse)
+@router.post(
+    "/{projection_id}/validate-query",
+    summary="Validate query only",
+    response_model=ValidateResponse,
+)
 def validate_query(projection_id: str):
     """Validate node and edge queries individually"""
     p = _get_projection_or_404(projection_id)
@@ -105,12 +138,18 @@ def validate_query(projection_id: str):
             output_location=p.s3_staging_bucket,
             query_type="edge" if label == "edge_query" else "node",
         )
-        checks.append({"check": label, "passed": result.passed, "message": result.message})
+        checks.append(
+            {"check": label, "passed": result.passed, "message": result.message}
+        )
     valid = all(c["passed"] for c in checks) if checks else False
     return {"valid": valid, "checks": checks}
 
 
-@router.post("/{projection_id}/preview", summary="Preview first N rows", response_model=PreviewResponse)
+@router.post(
+    "/{projection_id}/preview",
+    summary="Preview first N rows",
+    response_model=PreviewResponse,
+)
 async def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le=1000)):
     """Run the query with a LIMIT and return preview rows."""
     p = _get_projection_or_404(projection_id)
@@ -119,14 +158,18 @@ async def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le
     queries = [q for q in [p.node_query, p.edge_query] if q]
     if not queries and p.sql_query:
         queries = [q.strip() for q in p.sql_query.split(";") if q.strip()]
-    all_results = []
+    all_results: list = []
 
     for q in queries:
         limited = wrap_with_limit(q, limit)
 
-        exec_id = _execute_athena_query(client, limited, p.s3_staging_bucket, catalog=p.catalog, database=p.database)
+        exec_id = _execute_athena_query(
+            client, limited, p.s3_staging_bucket, catalog=p.catalog, database=p.database
+        )
 
-        await wait_until_all_complete([exec_id], TaskType.EXPORT_ATHENA_TABLE, client, polling_interval=5)
+        await wait_until_all_complete(
+            [exec_id], TaskType.EXPORT_ATHENA_TABLE, client, polling_interval=5
+        )
 
         resp = client.get_query_execution(QueryExecutionId=exec_id)
         state = get_query_state(resp)
@@ -139,7 +182,9 @@ async def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le
     return {"error": None, "results": all_results}
 
 
-@router.post("/{projection_id}/execute", summary="Start import pipeline", status_code=202)
+@router.post(
+    "/{projection_id}/execute", summary="Start import pipeline", status_code=202
+)
 def execute_projection(projection_id: str, background_tasks: BackgroundTasks):
     """Kick off the full import pipeline as a background task."""
     p = _get_projection_or_404(projection_id)
@@ -154,17 +199,25 @@ def delete_projection(projection_id: str):
     """Permanently remove the projection record from the database."""
     p = _get_projection_or_404(projection_id)
     if p.status == "deleting":
-        raise HTTPException(status_code=409, detail="Graph deletion in progress, cannot purge yet")
+        raise HTTPException(
+            status_code=409, detail="Graph deletion in progress, cannot purge yet"
+        )
     store.delete(projection_id)
     return {"id": p.id, "status": "deleted"}
 
 
-@router.post("/{projection_id}/delete-graph", summary="Delete associated graph and archive projection", status_code=202)
+@router.post(
+    "/{projection_id}/delete-graph",
+    summary="Delete associated graph and archive projection",
+    status_code=202,
+)
 def delete_projection_graph(projection_id: str, background_tasks: BackgroundTasks):
     """Delete the Neptune graph in background, then mark projection as archived."""
     p = _get_projection_or_404(projection_id)
     if not p.graph_id:
-        raise HTTPException(status_code=409, detail="No graph associated with this projection")
+        raise HTTPException(
+            status_code=409, detail="No graph associated with this projection"
+        )
     if p.status == "deleting":
         raise HTTPException(status_code=409, detail="Already deleting")
 
@@ -173,7 +226,12 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
     resp = get_graph_or_exception(client, p.graph_id)
     assert_managed_graph(resp.get("name"))
 
-    store.update(projection_id, status="deleting", step="graph_delete", step_label="Deleting graph")
+    store.update(
+        projection_id,
+        status="deleting",
+        step="graph_delete",
+        step_label="Deleting graph",
+    )
 
     async def _delete_graph():
         client = ClientFactory().neptune()
@@ -181,7 +239,9 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
             client.delete_graph(graphIdentifier=p.graph_id, skipSnapshot=True)
         except ClientError as e:
             if e.response["Error"]["Code"] != "ResourceNotFoundException":
-                store.update(projection_id, status="failed", error=sanitize_error_message(str(e)))
+                store.update(
+                    projection_id, status="failed", error=sanitize_error_message(str(e))
+                )
                 return
         # Poll until gone
         for _ in range(60):
@@ -191,10 +251,21 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
             except ClientError:
                 break
         else:
-            store.update(projection_id, status="failed", error="Timeout waiting for graph deletion")
+            store.update(
+                projection_id,
+                status="failed",
+                error="Timeout waiting for graph deletion",
+            )
             return
-        store.update(projection_id, status="archived", graph_id=None, graph_endpoint=None,
-                     step=None, step_label=None, progress=0)
+        store.update(
+            projection_id,
+            status="archived",
+            graph_id=None,
+            graph_endpoint=None,
+            step=None,
+            step_label=None,
+            progress=0,
+        )
 
     background_tasks.add_task(_delete_graph)
     return {"id": p.id, "status": "deleting"}

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-
 # --- graph_name validation ---
 
 # Neptune Analytics graph names in this tool are formed as `{prefix}{graph_name}`.

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -5,7 +5,9 @@ import os
 import sqlite3
 from pathlib import Path
 
-DB_PATH = os.environ.get("NX_NEPTUNE_DB_PATH", str(Path.home() / ".nx-neptune" / "proxy.db"))
+DB_PATH = os.environ.get(
+    "NX_NEPTUNE_DB_PATH", str(Path.home() / ".nx-neptune" / "proxy.db")
+)
 
 
 def get_connection() -> sqlite3.Connection:

--- a/proxy/src/nx_neptune_proxy/services/graph_ops.py
+++ b/proxy/src/nx_neptune_proxy/services/graph_ops.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 # --- Actions ---
 
+
 async def _stop_graph(graph_id: str) -> None:
     """Issue stop-graph API call."""
     client = ClientFactory().neptune()
@@ -39,6 +40,7 @@ async def _delete_graph(graph_id: str) -> None:
 
 
 # --- Probe ---
+
 
 async def _poll_graph_status(graph_id: str) -> str | None:
     """Check the current graph status. Returns None if graph is gone (deleted)."""

--- a/proxy/src/nx_neptune_proxy/services/graph_state_machine.py
+++ b/proxy/src/nx_neptune_proxy/services/graph_state_machine.py
@@ -43,9 +43,7 @@ def register_transition(action: str, transition: Transition) -> None:
 def available_actions(current_status: str) -> list[str]:
     """Return action names valid for the given graph status."""
     return [
-        action
-        for action, t in _TRANSITIONS.items()
-        if current_status in t.from_states
+        action for action, t in _TRANSITIONS.items() if current_status in t.from_states
     ]
 
 
@@ -76,9 +74,7 @@ async def execute_transition(
     if not transition:
         raise InvalidTransitionError(f"Unknown action: {action}")
     if current_status not in transition.from_states:
-        raise InvalidTransitionError(
-            f"Cannot {action} graph in {current_status} state"
-        )
+        raise InvalidTransitionError(f"Cannot {action} graph in {current_status} state")
 
     # Track in-flight
     _inflight[graph_id] = {"action": action, "error": None}
@@ -99,7 +95,10 @@ async def execute_transition(
                 logger.info(f"Graph {graph_id} transition {action} complete → {status}")
                 return
 
-            if status and status not in (transition.transient_state, *transition.from_states):
+            if status and status not in (
+                transition.transient_state,
+                *transition.from_states,
+            ):
                 raise TransitionFailed(
                     f"Graph entered unexpected state '{status}' during {action}"
                 )
@@ -116,9 +115,11 @@ async def execute_transition(
 
 class InvalidTransitionError(Exception):
     """Raised when an action is not valid for the current graph state."""
+
     pass
 
 
 class TransitionFailed(Exception):
     """Raised when a transition fails or times out."""
+
     pass

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -31,7 +31,7 @@ async def run_pipeline(projection: Projection) -> None:
     from nx_neptune.session_manager import SessionManager
 
     graph_name = f"{get_settings().graph_prefix}{projection.graph_name}"
-    s3_location = projection.s3_staging_bucket.rstrip("/") + f"/{projection.id}/"
+    s3_location = projection.s3_staging_bucket.rstrip("/") + f"/{projection.id}/"  # type: ignore[union-attr]  # noqa: E501
 
     try:
         store.update(projection.id, status="importing")

--- a/proxy/src/nx_neptune_proxy/services/project_deletion.py
+++ b/proxy/src/nx_neptune_proxy/services/project_deletion.py
@@ -9,8 +9,9 @@ import time
 
 from botocore.exceptions import ClientError
 from nx_neptune.clients.client_factory import ClientFactory
-from nx_neptune_proxy.services.projection_store import store as projection_store
+
 from nx_neptune_proxy.services.project_store import store as project_store
+from nx_neptune_proxy.services.projection_store import store as projection_store
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ async def delete_project(project_id: str) -> None:
     # Delete all graphs in parallel
     graphs_to_delete = [p for p in projections if p.graph_id]
     results = await asyncio.gather(
-        *[_delete_graph(p.graph_id) for p in graphs_to_delete],
+        *[_delete_graph(p.graph_id) for p in graphs_to_delete],  # type: ignore[arg-type]
         return_exceptions=True,
     )
 
@@ -33,7 +34,9 @@ async def delete_project(project_id: str) -> None:
     failed_ids = set()
     for p, result in zip(graphs_to_delete, results):
         if isinstance(result, Exception):
-            logger.warning(f"Failed to delete graph {p.graph_id} for projection {p.id}: {result}")
+            logger.warning(
+                f"Failed to delete graph {p.graph_id} for projection {p.id}: {result}"
+            )
             failed_ids.add(p.id)
 
     for p in projections:
@@ -42,7 +45,10 @@ async def delete_project(project_id: str) -> None:
 
     # Only delete the project if all graphs were cleaned up
     if failed_ids:
-        logger.warning(f"Project {project_id} has {len(failed_ids)} projection(s) with failed graph deletion, keeping project in deleting state")
+        logger.warning(
+            f"Project {project_id} has {len(failed_ids)} projection(s) "
+            "with failed graph deletion, keeping project in deleting state"
+        )
         return
 
     project_store.delete(project_id)

--- a/proxy/src/nx_neptune_proxy/services/project_store.py
+++ b/proxy/src/nx_neptune_proxy/services/project_store.py
@@ -33,7 +33,9 @@ class ProjectStore:
 
     def get(self, project_id: str) -> Optional[Project]:
         conn = get_connection()
-        row = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM projects WHERE id = ?", (project_id,)
+        ).fetchone()
         conn.close()
         return self._row_to_project(row) if row else None
 

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -9,9 +9,24 @@ from typing import Optional
 from .db import get_connection
 
 _FIELDS = [
-    "id", "status", "catalog", "database", "sql_query", "node_query", "edge_query",
-    "graph_name", "graph_memory_gb", "s3_staging_bucket", "graph_id", "graph_endpoint",
-    "project_id", "step", "step_label", "progress", "error", "created_at",
+    "id",
+    "status",
+    "catalog",
+    "database",
+    "sql_query",
+    "node_query",
+    "edge_query",
+    "graph_name",
+    "graph_memory_gb",
+    "s3_staging_bucket",
+    "graph_id",
+    "graph_endpoint",
+    "project_id",
+    "step",
+    "step_label",
+    "progress",
+    "error",
+    "created_at",
 ]
 
 
@@ -40,11 +55,18 @@ class Projection:
 
 
 class ProjectionStore:
-    def create(self, catalog: str = "AwsDataCatalog", database: str = None,
-               sql_query: str = None, node_query: str = None,
-               edge_query: str = None, graph_name: str = None,
-               graph_memory_gb: int = 16, s3_staging_bucket: str = None,
-               project_id: str = None) -> Projection:
+    def create(
+        self,
+        catalog: str = "AwsDataCatalog",
+        database: Optional[str] = None,
+        sql_query: Optional[str] = None,
+        node_query: Optional[str] = None,
+        edge_query: Optional[str] = None,
+        graph_name: Optional[str] = None,
+        graph_memory_gb: int = 16,
+        s3_staging_bucket: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> Projection:
         p = Projection(
             id=str(uuid.uuid4()),
             status="draft",
@@ -61,7 +83,10 @@ class ProjectionStore:
         conn = get_connection()
         conn.execute(
             f"INSERT INTO projections ({', '.join(_FIELDS)}) VALUES ({', '.join('?' for _ in _FIELDS)})",
-            [getattr(p, f) if f != "created_at" else p.created_at.isoformat() for f in _FIELDS],
+            [
+                getattr(p, f) if f != "created_at" else p.created_at.isoformat()
+                for f in _FIELDS
+            ],
         )
         conn.commit()
         conn.close()
@@ -69,20 +94,37 @@ class ProjectionStore:
 
     def get(self, projection_id: str) -> Optional[Projection]:
         conn = get_connection()
-        row = conn.execute("SELECT * FROM projections WHERE id = ?", (projection_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM projections WHERE id = ?", (projection_id,)
+        ).fetchone()
         conn.close()
         return self._row_to_projection(row) if row else None
 
     def list(self) -> list[Projection]:
         conn = get_connection()
-        rows = conn.execute("SELECT * FROM projections ORDER BY created_at DESC").fetchall()
+        rows = conn.execute(
+            "SELECT * FROM projections ORDER BY created_at DESC"
+        ).fetchall()
         conn.close()
         return [self._row_to_projection(r) for r in rows]
 
     _ALLOWED_UPDATE_COLUMNS = {
-        "status", "catalog", "database", "sql_query", "node_query", "edge_query",
-        "graph_name", "graph_memory_gb", "s3_staging_bucket", "graph_id", "graph_endpoint",
-        "project_id", "step", "step_label", "progress", "error",
+        "status",
+        "catalog",
+        "database",
+        "sql_query",
+        "node_query",
+        "edge_query",
+        "graph_name",
+        "graph_memory_gb",
+        "s3_staging_bucket",
+        "graph_id",
+        "graph_endpoint",
+        "project_id",
+        "step",
+        "step_label",
+        "progress",
+        "error",
     }
 
     def update(self, projection_id: str, **kwargs) -> Optional[Projection]:

--- a/proxy/tests/test_app.py
+++ b/proxy/tests/test_app.py
@@ -4,7 +4,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from nx_neptune_proxy.app import app, UI_DIR
+from nx_neptune_proxy.app import UI_DIR, app
 
 
 @pytest.fixture

--- a/proxy/tests/test_csrf.py
+++ b/proxy/tests/test_csrf.py
@@ -14,14 +14,18 @@ class TestCsrfProtection:
     @pytest.mark.asyncio
     async def test_post_without_header_rejected(self, bare_client):
         """POST without X-Requested-With must be rejected."""
-        resp = await bare_client.post("/api/v0/projection", json={"database": "test", "graph_name": "g"})
+        resp = await bare_client.post(
+            "/api/v0/projection", json={"database": "test", "graph_name": "g"}
+        )
         assert resp.status_code == 403
         assert resp.json()["error"] == "csrf_rejected"
 
     @pytest.mark.asyncio
     async def test_put_without_header_rejected(self, bare_client):
         """PUT without X-Requested-With must be rejected."""
-        resp = await bare_client.put("/api/v0/projection/fake-id", json={"status": "done"})
+        resp = await bare_client.put(
+            "/api/v0/projection/fake-id", json={"status": "done"}
+        )
         assert resp.status_code == 403
         assert resp.json()["error"] == "csrf_rejected"
 

--- a/proxy/tests/test_graph_name_collision.py
+++ b/proxy/tests/test_graph_name_collision.py
@@ -21,13 +21,14 @@ import pytest
 from nx_neptune_proxy.services.pipeline import run_pipeline
 from nx_neptune_proxy.services.projection_store import store
 
-
 # --- Schema validation (defense-in-depth) ---
 
 
 class TestGraphNameSchemaValidation:
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("bad_name", ["", "a", "ab", "-abc", "has space", "bad!char"])
+    @pytest.mark.parametrize(
+        "bad_name", ["", "a", "ab", "-abc", "has space", "bad!char"]
+    )
     async def test_rejects_invalid_graph_name(self, client, bad_name):
         """Empty, too-short, or illegal graph_name is rejected with 422."""
         resp = await client.post(
@@ -89,7 +90,9 @@ async def test_first_run_never_adopts_existing_graph(mock_sm_cls, mock_cf, clear
 @pytest.mark.asyncio
 @patch("nx_neptune.clients.client_factory.ClientFactory")
 @patch("nx_neptune.session_manager.SessionManager")
-async def test_retry_resets_only_the_recorded_graph_by_id(mock_sm_cls, mock_cf, clear_store):
+async def test_retry_resets_only_the_recorded_graph_by_id(
+    mock_sm_cls, mock_cf, clear_store
+):
     """With a recorded graph_id pointing at a managed AVAILABLE graph, the
     pipeline reuses that exact graph and resets it."""
     projection = _make_projection()
@@ -101,7 +104,9 @@ async def test_retry_resets_only_the_recorded_graph_by_id(mock_sm_cls, mock_cf, 
 
     sm = mock_sm_cls.return_value
     recorded = MagicMock(graph_id="g-mine")
-    recorded.name = "nxp-my-graph"  # .name must be set explicitly (reserved MagicMock kwarg)
+    recorded.name = (
+        "nxp-my-graph"  # .name must be set explicitly (reserved MagicMock kwarg)
+    )
     sm.get_graph.return_value = recorded
     sm.get_or_create_graph = AsyncMock()
     sm.reset_graph = AsyncMock()
@@ -119,7 +124,9 @@ async def test_retry_resets_only_the_recorded_graph_by_id(mock_sm_cls, mock_cf, 
 @pytest.mark.asyncio
 @patch("nx_neptune.clients.client_factory.ClientFactory")
 @patch("nx_neptune.session_manager.SessionManager")
-async def test_recorded_graph_not_managed_fails_without_reset(mock_sm_cls, mock_cf, clear_store):
+async def test_recorded_graph_not_managed_fails_without_reset(
+    mock_sm_cls, mock_cf, clear_store
+):
     """If the recorded graph does not carry the managed prefix, the pipeline
     refuses to reset it and marks the projection failed."""
     projection = _make_projection()

--- a/proxy/tests/test_no_secrets.py
+++ b/proxy/tests/test_no_secrets.py
@@ -53,9 +53,9 @@ class TestNoSecretsInDb:
         full_content = " ".join(all_values)
 
         for pattern in self.SENSITIVE_PATTERNS:
-            assert pattern.lower() not in full_content, (
-                f"Sensitive pattern '{pattern}' found in SQLite data"
-            )
+            assert (
+                pattern.lower() not in full_content
+            ), f"Sensitive pattern '{pattern}' found in SQLite data"
 
     def test_no_secrets_after_update_with_error(self):
         """Error messages stored in DB should not contain credentials."""
@@ -74,6 +74,6 @@ class TestNoSecretsInDb:
 
         error_text = row["error"].lower()
         for pattern in self.SENSITIVE_PATTERNS:
-            assert pattern.lower() not in error_text, (
-                f"Sensitive pattern '{pattern}' found in error message"
-            )
+            assert (
+                pattern.lower() not in error_text
+            ), f"Sensitive pattern '{pattern}' found in error message"

--- a/proxy/tests/test_path_traversal.py
+++ b/proxy/tests/test_path_traversal.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from nx_neptune_proxy.app import app, UI_DIR
+from nx_neptune_proxy.app import UI_DIR, app
 
 
 @pytest.mark.skipif(
@@ -27,9 +27,14 @@ class TestPathTraversal:
     async def _raw_get(path: str) -> tuple[int, str]:
         """Send GET with un-normalized path directly to ASGI app."""
         scope = {
-            "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
-            "method": "GET", "path": path, "root_path": "",
-            "query_string": b"", "headers": [(b"host", b"test")],
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "path": path,
+            "root_path": "",
+            "query_string": b"",
+            "headers": [(b"host", b"test")],
         }
         status = None
         body_parts = []

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -7,14 +7,18 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from nx_neptune_proxy.app import app
-from nx_neptune_proxy.services.projection_store import store
 from nx_neptune_proxy.services.db import get_connection
+from nx_neptune_proxy.services.projection_store import store
 
 
 @pytest.fixture
 def client():
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test", headers={"X-Requested-With": "nx-neptune"})
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"X-Requested-With": "nx-neptune"},
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -77,7 +81,9 @@ async def test_update_projection(client):
     create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY)
     pid = create_resp.json()["id"]
 
-    resp = await client.put(f"/api/v0/projection/{pid}", json={"sql_query": "SELECT id FROM t"})
+    resp = await client.put(
+        f"/api/v0/projection/{pid}", json={"sql_query": "SELECT id FROM t"}
+    )
     assert resp.status_code == 200
     assert resp.json()["sql_query"] == "SELECT id FROM t"
     # Other fields unchanged
@@ -230,7 +236,9 @@ async def test_list_projections(client):
 
 @pytest.mark.asyncio
 async def test_create_projection_invalid_body(client):
-    resp = await client.post("/api/v0/projection", json={"graph_memory_gb": "not_a_number"})
+    resp = await client.post(
+        "/api/v0/projection", json={"graph_memory_gb": "not_a_number"}
+    )
     assert resp.status_code == 422
 
 
@@ -253,7 +261,12 @@ async def test_execute_poll_lifecycle(client):
     assert resp.json()["progress"] == 50
 
     # Simulate completion
-    store.update(pid, status="complete", progress=100, graph_endpoint="https://g-123.neptune-graph.amazonaws.com")
+    store.update(
+        pid,
+        status="complete",
+        progress=100,
+        graph_endpoint="https://g-123.neptune-graph.amazonaws.com",
+    )
     resp = await client.get(f"/api/v0/projection/{pid}/status")
     assert resp.json()["status"] == "complete"
     assert resp.json()["progress"] == 100


### PR DESCRIPTION
### Summary :memo:

Follow-up to #429 — makes the proxy pass the lint gate (was red on pre-existing debt).

- Formatting (`make proxy-fmt`): black + isort across the module; mechanical, no behavior change.

- mypy fixes, minimal/behavior-preserving: `projection_store.py` 7 params `str = None` → `Optional[str] = None`; 4 `# type: ignore` at use sites; `all_results: list` annotation.

- `opencypher_builder.py`: widened `_escape_labels` return to `list | str` (pre-existing mypy error found via `make test`).


Testing: `make proxy-lint` passes (flake8 + black + mypy); proxy suite 137 passed; root `make test` 434 passed.

