### PR TITLE
Misc: Apply proxy-fmt (black + isort) to proxy module (P2)

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -9,23 +9,30 @@ and re-importing it to recreate the project in another environment.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import json
 from datetime import datetime, timezone
+from typing import Optional
+
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
-
 from nx_neptune.clients.client_factory import ClientFactory
 from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+from pydantic import BaseModel, Field
+
 from nx_neptune_proxy.config import Settings
-from nx_neptune_proxy.routers.schemas import ProjectionExport, ProjectExportPayload
+from nx_neptune_proxy.routers.schemas import ProjectExportPayload, ProjectionExport
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
-from nx_neptune_proxy.utils.aws_helper import friendly_s3_error, check_content_length, check_body_size, check_key_not_exists, list_s3_json_objects, require_name
-from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name, sanitize_filename
+from nx_neptune_proxy.utils.aws_helper import (
+    check_body_size,
+    check_content_length,
+    check_key_not_exists,
+    friendly_s3_error,
+    list_s3_json_objects,
+    require_name,
+)
+from nx_neptune_proxy.utils.sanitize import sanitize_filename, sanitize_s3_key_name
 
 router = APIRouter(prefix="/api/v0/project", tags=["project-io"])
 
@@ -95,12 +102,14 @@ def _import_from_payload(payload: ProjectExportPayload) -> dict:
     return {"id": p.id, "name": p.name}
 
 
-
 # --- Export endpoints ---
 
 
-@router.get("/{project_id}/export", summary="Export a project as JSON",
-            response_description="JSON file containing the project configuration and its projections")
+@router.get(
+    "/{project_id}/export",
+    summary="Export a project as JSON",
+    response_description="JSON file containing the project configuration and its projections",
+)
 def export_project(project_id: str):
     """Export a project and all its projection configurations as a downloadable JSON file.
 
@@ -114,7 +123,9 @@ def export_project(project_id: str):
 
     return JSONResponse(
         content=payload,
-        headers={"Content-Disposition": f'attachment; filename="{sanitize_filename(name)}.json"'},
+        headers={
+            "Content-Disposition": f'attachment; filename="{sanitize_filename(name)}.json"'
+        },
     )
 
 
@@ -171,9 +182,7 @@ def list_s3_exports():
         json_objects.sort(key=lambda o: o["LastModified"], reverse=True)
         recent = json_objects[:10]
 
-        return {
-            "files": [_s3_object_to_entry(obj) for obj in recent]
-        }
+        return {"files": [_s3_object_to_entry(obj) for obj in recent]}
     except ClientError as e:
         raise HTTPException(status_code=502, detail=friendly_s3_error(e))
 

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -154,11 +154,23 @@ class ProjectionExport(BaseModel):
 
     catalog: str = Field("AwsDataCatalog", description="Athena catalog name")
     database: Optional[str] = Field(None, description="Athena database name")
-    node_query: Optional[str] = Field(None, description="SQL query that produces nodes (must include ~id and ~label columns)")
-    edge_query: Optional[str] = Field(None, description="SQL query that produces edges (must include ~from, ~to, and ~label columns)")
-    graph_name: Optional[str] = Field(None, description="Neptune Analytics graph name suffix (prefix is added automatically)")
+    node_query: Optional[str] = Field(
+        None,
+        description="SQL query that produces nodes (must include ~id and ~label columns)",
+    )
+    edge_query: Optional[str] = Field(
+        None,
+        description="SQL query that produces edges (must include ~from, ~to, and ~label columns)",
+    )
+    graph_name: Optional[str] = Field(
+        None,
+        description="Neptune Analytics graph name suffix (prefix is added automatically)",
+    )
     graph_memory_gb: int = Field(16, description="Graph memory allocation in GB")
-    s3_staging_bucket: Optional[str] = Field(None, description="S3 bucket path for staging Athena results (e.g. s3://bucket/prefix)")
+    s3_staging_bucket: Optional[str] = Field(
+        None,
+        description="S3 bucket path for staging Athena results (e.g. s3://bucket/prefix)",
+    )
 
     model_config = {"extra": "forbid"}
 

--- a/proxy/src/nx_neptune_proxy/utils/aws_helper.py
+++ b/proxy/src/nx_neptune_proxy/utils/aws_helper.py
@@ -4,10 +4,10 @@
 from typing import Any, Callable
 
 from botocore.exceptions import ClientError
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 from nx_neptune_proxy.config import get_settings
-from fastapi import HTTPException, Request
+
 
 def get_graph_or_exception(client, graph_id: str) -> dict:
     """Fetch a graph from Neptune Analytics, raising HTTP exceptions on failure.
@@ -38,15 +38,16 @@ def assert_managed_graph(graph_name: str | None) -> None:
         )
 
 
-
-
 def check_content_length(request: Request, max_size: int) -> None:
     """Reject early if Content-Length header exceeds max_size."""
     content_length = request.headers.get("content-length")
     if content_length:
         try:
             if int(content_length) > max_size:
-                raise HTTPException(status_code=413, detail=f"Payload too large (max {max_size // (1024 * 1024)} MB)")
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"Payload too large (max {max_size // (1024 * 1024)} MB)",
+                )
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid Content-Length header")
 
@@ -57,9 +58,10 @@ def require_name(value: str | None, max_length: int = 100) -> str:
     if not stripped:
         raise HTTPException(status_code=400, detail="Name is required")
     if len(stripped) > max_length:
-        raise HTTPException(status_code=400, detail=f"Name too long (max {max_length} characters)")
+        raise HTTPException(
+            status_code=400, detail=f"Name too long (max {max_length} characters)"
+        )
     return stripped
-
 
 
 def paginate_aws(method: Callable, result_key: str, **kwargs: Any) -> list:
@@ -113,13 +115,16 @@ def friendly_s3_error(e) -> str:
 def check_body_size(contents: bytes, max_size: int) -> None:
     """Reject if body bytes exceed max_size."""
     if len(contents) > max_size:
-        raise HTTPException(status_code=413, detail=f"Payload too large (max {max_size // (1024 * 1024)} MB)")
+        raise HTTPException(
+            status_code=413,
+            detail=f"Payload too large (max {max_size // (1024 * 1024)} MB)",
+        )
 
 
 def check_key_not_exists(s3, bucket: str, key: str) -> None:
     """Raise 409 if the S3 key already exists."""
-    from fastapi import HTTPException
     from botocore.exceptions import ClientError
+    from fastapi import HTTPException
 
     try:
         s3.head_object(Bucket=bucket, Key=key)

--- a/proxy/src/nx_neptune_proxy/utils/sanitize.py
+++ b/proxy/src/nx_neptune_proxy/utils/sanitize.py
@@ -19,7 +19,9 @@ def sanitize_error_message(message: str) -> str:
     return message
 
 
-_SAFE_FILENAME_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ ")
+_SAFE_FILENAME_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ "
+)
 
 
 def sanitize_filename(name: str) -> str:

--- a/proxy/tests/test_column_allowlist.py
+++ b/proxy/tests/test_column_allowlist.py
@@ -12,26 +12,36 @@ class TestColumnAllowlist:
     """Store.update() must reject columns not in _ALLOWED_UPDATE_COLUMNS."""
 
     def test_invalid_column_raises_value_error(self, test_project_id):
-        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, id="injected-id")
 
     def test_invalid_column_created_at_rejected(self, test_project_id):
-        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, created_at="2020-01-01")
 
     def test_arbitrary_column_rejected(self, test_project_id):
-        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, drop_table="yes")
 
     def test_multiple_invalid_columns_rejected(self, test_project_id):
-        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
         with pytest.raises(ValueError, match="Invalid column"):
             store.update(p.id, malicious="x", another_bad="y")
 
     def test_valid_column_accepted(self, test_project_id):
-        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
         result = store.update(p.id, status="importing")
         assert result.status == "importing"

--- a/proxy/tests/test_no_secrets.py
+++ b/proxy/tests/test_no_secrets.py
@@ -61,7 +61,9 @@ class TestNoSecretsInDb:
 
     def test_no_secrets_after_update_with_error(self, test_project_id):
         """Error messages stored in DB should not contain credentials."""
-        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
         store.update(
             p.id,
             status="failed",

--- a/proxy/tests/test_project_io.py
+++ b/proxy/tests/test_project_io.py
@@ -43,7 +43,9 @@ class TestProjectExport:
             project_id=p.id,
         )
         # Simulate runtime state
-        projection_store.update(pr.id, status="running", step="import", progress=0.5, error="oops")
+        projection_store.update(
+            pr.id, status="running", step="import", progress=0.5, error="oops"
+        )
 
         resp = await client.get(f"/api/v0/project/{p.id}/export")
         data = resp.json()
@@ -135,7 +137,11 @@ class TestProjectImport:
     @pytest.mark.anyio
     async def test_import_too_large(self, client):
         # 6 MB of data
-        payload = {"version": "1.0", "project": {"name": "x" * (6 * 1024 * 1024)}, "projections": []}
+        payload = {
+            "version": "1.0",
+            "project": {"name": "x" * (6 * 1024 * 1024)},
+            "projections": [],
+        }
 
         resp = await client.post("/api/v0/project/import", content=json.dumps(payload))
         assert resp.status_code == 413
@@ -181,7 +187,9 @@ class TestRoundTrip:
         assert imported.name == "Round Trip"
 
         # Imported projection should match
-        projections = [pr for pr in projection_store.list() if pr.project_id == imported.id]
+        projections = [
+            pr for pr in projection_store.list() if pr.project_id == imported.id
+        ]
         assert len(projections) == 1
         assert projections[0].database == "rt_db"
         assert projections[0].graph_name == "nxp-roundtrip"

--- a/proxy/tests/test_project_io_s3.py
+++ b/proxy/tests/test_project_io_s3.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -25,12 +25,15 @@ class TestExportToS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_export_to_s3_success(self, mock_factory, mock_settings, client):
         """Exports project JSON to S3 with correct key format."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket/exports", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket/exports", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
         # head_object raises 404 (key doesn't exist)
         from botocore.exceptions import ClientError
+
         mock_s3.head_object.side_effect = ClientError(
             {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
         )
@@ -57,9 +60,13 @@ class TestExportToS3:
     @pytest.mark.anyio
     @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
-    async def test_export_to_s3_duplicate_key(self, mock_factory, mock_settings, client):
+    async def test_export_to_s3_duplicate_key(
+        self, mock_factory, mock_settings, client
+    ):
         """Returns 409 if S3 key already exists."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -74,13 +81,18 @@ class TestExportToS3:
     @pytest.mark.anyio
     @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
-    async def test_export_to_s3_permission_denied(self, mock_factory, mock_settings, client):
+    async def test_export_to_s3_permission_denied(
+        self, mock_factory, mock_settings, client
+    ):
         """Returns 502 with friendly message on permission error."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
         from botocore.exceptions import ClientError
+
         mock_s3.head_object.side_effect = ClientError(
             {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
         )
@@ -97,8 +109,12 @@ class TestExportToS3:
     @pytest.mark.anyio
     async def test_export_to_s3_project_not_found(self, client):
         """Returns 404 for non-existent project."""
-        with patch("nx_neptune_proxy.routers.project_io.Settings.from_env") as mock_settings:
-            mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
+        with patch(
+            "nx_neptune_proxy.routers.project_io.Settings.from_env"
+        ) as mock_settings:
+            mock_settings.return_value = MagicMock(
+                config_bucket="my-bucket", region="us-west-2"
+            )
             resp = await client.post("/api/v0/project/nonexistent/export/s3")
             assert resp.status_code == 404
 
@@ -113,9 +129,13 @@ class TestListS3Exports:
     @pytest.mark.anyio
     @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
-    async def test_list_returns_json_files_sorted(self, mock_factory, mock_settings, client):
+    async def test_list_returns_json_files_sorted(
+        self, mock_factory, mock_settings, client
+    ):
         """Lists .json files sorted by last modified descending."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket/exports", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket/exports", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -145,7 +165,9 @@ class TestListS3Exports:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_list_empty_bucket(self, mock_factory, mock_settings, client):
         """Returns empty list when no files in bucket."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -160,14 +182,19 @@ class TestListS3Exports:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_list_caps_at_10(self, mock_factory, mock_settings, client):
         """Returns at most 10 files."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
 
         # 15 .json files
         objects = [
-            {"Key": f"file_{i}.json", "LastModified": datetime(2026, 7, 31, i, 0, 0, tzinfo=timezone.utc)}
+            {
+                "Key": f"file_{i}.json",
+                "LastModified": datetime(2026, 7, 31, i, 0, 0, tzinfo=timezone.utc),
+            }
             for i in range(15)
         ]
         mock_s3.list_objects_v2.return_value = {"Contents": objects}
@@ -181,7 +208,9 @@ class TestImportFromS3:
     @pytest.mark.anyio
     async def test_import_from_s3_no_bucket(self, client):
         """Returns 404 when export bucket not configured."""
-        resp = await client.post("/api/v0/project/import/s3", content=json.dumps({"key": "test.json"}))
+        resp = await client.post(
+            "/api/v0/project/import/s3", content=json.dumps({"key": "test.json"})
+        )
         assert resp.status_code == 404
 
     @pytest.mark.anyio
@@ -189,7 +218,9 @@ class TestImportFromS3:
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
     async def test_import_from_s3_success(self, mock_factory, mock_settings, client):
         """Imports a project from S3 file."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket/exports", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket/exports", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -224,15 +255,26 @@ class TestImportFromS3:
     @pytest.mark.anyio
     @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
-    async def test_import_from_s3_file_not_found(self, mock_factory, mock_settings, client):
+    async def test_import_from_s3_file_not_found(
+        self, mock_factory, mock_settings, client
+    ):
         """Returns 502 when S3 key doesn't exist."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
         from botocore.exceptions import ClientError
+
         mock_s3.get_object.side_effect = ClientError(
-            {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}}, "GetObject"
+            {
+                "Error": {
+                    "Code": "NoSuchKey",
+                    "Message": "The specified key does not exist.",
+                }
+            },
+            "GetObject",
         )
 
         resp = await client.post(
@@ -245,9 +287,13 @@ class TestImportFromS3:
     @pytest.mark.anyio
     @patch("nx_neptune_proxy.routers.project_io.Settings.from_env")
     @patch("nx_neptune_proxy.routers.project_io.ClientFactory")
-    async def test_import_from_s3_invalid_json(self, mock_factory, mock_settings, client):
+    async def test_import_from_s3_invalid_json(
+        self, mock_factory, mock_settings, client
+    ):
         """Returns 400 when S3 file contains invalid JSON."""
-        mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
+        mock_settings.return_value = MagicMock(
+            config_bucket="my-bucket", region="us-west-2"
+        )
 
         mock_s3 = MagicMock()
         mock_factory.return_value.s3.return_value = mock_s3
@@ -265,9 +311,15 @@ class TestImportFromS3:
     @pytest.mark.anyio
     async def test_import_from_s3_missing_key_param(self, client):
         """Returns 400 when key is missing from request body."""
-        with patch("nx_neptune_proxy.routers.project_io.Settings.from_env") as mock_settings:
-            mock_settings.return_value = MagicMock(config_bucket="my-bucket", region="us-west-2")
-            resp = await client.post("/api/v0/project/import/s3", content=json.dumps({}))
+        with patch(
+            "nx_neptune_proxy.routers.project_io.Settings.from_env"
+        ) as mock_settings:
+            mock_settings.return_value = MagicMock(
+                config_bucket="my-bucket", region="us-west-2"
+            )
+            resp = await client.post(
+                "/api/v0/project/import/s3", content=json.dumps({})
+            )
             assert resp.status_code == 400
             assert "key" in resp.json()["detail"].lower()
 
@@ -275,30 +327,36 @@ class TestImportFromS3:
 class TestSanitizeName:
     def test_spaces_to_underscores(self):
         from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+
         assert sanitize_s3_key_name("Fraud Detection") == "Fraud_Detection"
 
     def test_special_characters_stripped(self):
         from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+
         assert sanitize_s3_key_name("My Project! (v2)") == "My_Project_v2"
 
     def test_hyphens_kept(self):
         from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+
         assert sanitize_s3_key_name("fraud-detection") == "fraud-detection"
 
     def test_underscores_kept(self):
         from nx_neptune_proxy.utils.sanitize import sanitize_s3_key_name
+
         assert sanitize_s3_key_name("my_project") == "my_project"
 
 
 class TestParseBucketConfig:
     def test_bucket_only(self):
         from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+
         bucket, prefix = split_s3_arn_to_bucket_and_path("s3://my-bucket")
         assert bucket == "my-bucket"
         assert prefix == ""
 
     def test_bucket_with_prefix(self):
         from nx_neptune.clients.iam_client import split_s3_arn_to_bucket_and_path
+
         bucket, prefix = split_s3_arn_to_bucket_and_path("s3://my-bucket/team/exports")
         assert bucket == "my-bucket"
         assert prefix == "team/exports"

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -8,8 +8,8 @@ from httpx import ASGITransport, AsyncClient
 
 from nx_neptune_proxy.app import app
 from nx_neptune_proxy.auth import get_token
-from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.db import get_connection
+from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store
 
 
@@ -96,10 +96,12 @@ async def test_update_projection(client):
     pid = create_resp.json()["id"]
 
     resp = await client.put(
-        f"/api/v0/projection/{pid}", json={
-        "node_query": "SELECT id FROM t",
-        "edge_query": "SELECT src, dst FROM edges",
-    })
+        f"/api/v0/projection/{pid}",
+        json={
+            "node_query": "SELECT id FROM t",
+            "edge_query": "SELECT src, dst FROM edges",
+        },
+    )
     assert resp.status_code == 200
     assert resp.json()["node_query"] == "SELECT id FROM t"
     assert resp.json()["edge_query"] == "SELECT src, dst FROM edges"
@@ -109,7 +111,9 @@ async def test_update_projection(client):
 
 @pytest.mark.asyncio
 async def test_update_projection_not_found(client):
-    resp = await client.put("/api/v0/projection/nonexistent", json={"node_query": "x", "edge_query": "y"})
+    resp = await client.put(
+        "/api/v0/projection/nonexistent", json={"node_query": "x", "edge_query": "y"}
+    )
     assert resp.status_code == 404
 
 

--- a/proxy/tests/test_sql_injection.py
+++ b/proxy/tests/test_sql_injection.py
@@ -11,7 +11,9 @@ class TestSqlInjection:
 
     def test_injection_in_graph_name(self, test_project_id):
         payload = "'; DROP TABLE projections; --"
-        p = store.create(database="testdb", graph_name=payload, project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name=payload, project_id=test_project_id
+        )
         # Table still exists and projection is retrievable
         retrieved = store.get(p.id)
         assert retrieved is not None
@@ -19,30 +21,43 @@ class TestSqlInjection:
 
     def test_injection_in_database_field(self, test_project_id):
         payload = "x' OR '1'='1"
-        p = store.create(database=payload, graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database=payload, graph_name="test", project_id=test_project_id
+        )
         retrieved = store.get(p.id)
         assert retrieved.database == payload
 
     def test_injection_in_update_value(self, test_project_id):
-        p = store.create(database="testdb", graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
         payload = "'; DELETE FROM projections WHERE '1'='1"
         store.update(p.id, error=payload)
         # Projection still exists with payload stored as literal
         retrieved = store.get(p.id)
         assert retrieved.error == payload
         # Verify other projections are not affected
-        p2 = store.create(database="testdb2", graph_name="test2", project_id=test_project_id)
+        p2 = store.create(
+            database="testdb2", graph_name="test2", project_id=test_project_id
+        )
         assert store.get(p2.id) is not None
 
     def test_injection_in_node_query_field(self, test_project_id):
         payload = "SELECT * FROM t; DROP TABLE projections;--"
-        p = store.create(database="testdb", node_query=payload, graph_name="test", project_id=test_project_id)
+        p = store.create(
+            database="testdb",
+            node_query=payload,
+            graph_name="test",
+            project_id=test_project_id,
+        )
         retrieved = store.get(p.id)
         assert retrieved.node_query == payload
 
     def test_unicode_injection(self, test_project_id):
         payload = "test\u0000'; DROP TABLE projections;--"
-        p = store.create(database="testdb", graph_name=payload, project_id=test_project_id)
+        p = store.create(
+            database="testdb", graph_name=payload, project_id=test_project_id
+        )
         retrieved = store.get(p.id)
         assert retrieved is not None
         assert retrieved.graph_name == payload


### PR DESCRIPTION
## Summary

Runs `make proxy-fmt` (black + isort) across the proxy module to bring it into line with the repo's formatting rules. **Formatting only — no logic or behavior changes.**

## Changes

Reformatted files (long-line wrapping, import ordering):

- `proxy/src/nx_neptune_proxy/routers/project_io.py`
- `proxy/src/nx_neptune_proxy/routers/schemas.py`
- `proxy/src/nx_neptune_proxy/utils/aws_helper.py`
- `proxy/src/nx_neptune_proxy/utils/sanitize.py`
- `proxy/tests/test_column_allowlist.py`
- `proxy/tests/test_no_secrets.py`
- `proxy/tests/test_project_io.py`
- `proxy/tests/test_project_io_s3.py`
- `proxy/tests/test_projection.py`
- `proxy/tests/test_sql_injection.py`

## Testing

- `make proxy-lint` passes (flake8 + black --check + mypy)