### PR TITLE
Refactor: DB connection context manager + fix test-cases for missing project ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ proxy-lint:       ## Run flake8, black, mypy linters on the proxy module.
 	$(ENV_PREFIX)black --check proxy/src/ proxy/tests/
 	$(ENV_PREFIX)mypy --ignore-missing-imports proxy/src/
 
+.PHONY: proxy-test
+proxy-test:       ## Run the proxy module test suite.
+	cd proxy && $(if $(ENV_PREFIX),$(CURDIR)/$(ENV_PREFIX))pytest tests/ -v
+
 .PHONY: test
 test: lint        ## Run tests and generate coverage report.
 	$(ENV_PREFIX)pytest -v --cov-config=.coveragerc --cov=nx_neptune -l --tb=short --maxfail=1 --cov-fail-under=80 tests/

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -3,7 +3,9 @@
 
 import os
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
 DB_PATH = os.environ.get(
     "NX_NEPTUNE_DB_PATH", str(Path.home() / ".nx-neptune" / "proxy.db")
@@ -20,9 +22,25 @@ def get_connection() -> sqlite3.Connection:
     return conn
 
 
-def init_db() -> None:
+@contextmanager
+def connection() -> Iterator[sqlite3.Connection]:
+    """Yield a connection, committing on success and always closing.
+
+    Using this instead of calling ``get_connection()`` directly guarantees the
+    connection is closed even when a query raises (e.g. an IntegrityError),
+    preventing leaked connections that hold SQLite locks.
+    """
     conn = get_connection()
-    conn.executescript("""
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    with connection() as conn:
+        conn.executescript("""
         CREATE TABLE IF NOT EXISTS projects (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,
@@ -50,5 +68,3 @@ def init_db() -> None:
             FOREIGN KEY (project_id) REFERENCES projects(id)
         );
     """)
-    conn.commit()
-    conn.close()

--- a/proxy/src/nx_neptune_proxy/services/project_store.py
+++ b/proxy/src/nx_neptune_proxy/services/project_store.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
 
-from .db import get_connection
+from .db import connection
 
 
 @dataclass
@@ -22,27 +22,25 @@ class Project:
 class ProjectStore:
     def create(self, name: str) -> Project:
         p = Project(id=str(uuid.uuid4()), name=name)
-        conn = get_connection()
-        conn.execute(
-            "INSERT INTO projects (id, name, status, created_at) VALUES (?, ?, ?, ?)",
-            (p.id, p.name, p.status, p.created_at.isoformat()),
-        )
-        conn.commit()
-        conn.close()
+        with connection() as conn:
+            conn.execute(
+                "INSERT INTO projects (id, name, status, created_at) VALUES (?, ?, ?, ?)",
+                (p.id, p.name, p.status, p.created_at.isoformat()),
+            )
         return p
 
     def get(self, project_id: str) -> Optional[Project]:
-        conn = get_connection()
-        row = conn.execute(
-            "SELECT * FROM projects WHERE id = ?", (project_id,)
-        ).fetchone()
-        conn.close()
+        with connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM projects WHERE id = ?", (project_id,)
+            ).fetchone()
         return self._row_to_project(row) if row else None
 
     def list(self) -> list[Project]:
-        conn = get_connection()
-        rows = conn.execute("SELECT * FROM projects ORDER BY created_at ASC").fetchall()
-        conn.close()
+        with connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM projects ORDER BY created_at ASC"
+            ).fetchall()
         return [self._row_to_project(r) for r in rows]
 
     _ALLOWED_UPDATE_COLUMNS = {"name", "status"}
@@ -55,18 +53,14 @@ class ProjectStore:
             raise ValueError(f"Invalid column(s): {invalid}")
         sets = ", ".join(f"{k} = ?" for k in kwargs)
         vals = list(kwargs.values()) + [project_id]
-        conn = get_connection()
-        conn.execute(f"UPDATE projects SET {sets} WHERE id = ?", vals)
-        conn.commit()
-        conn.close()
+        with connection() as conn:
+            conn.execute(f"UPDATE projects SET {sets} WHERE id = ?", vals)
         return self.get(project_id)
 
     def delete(self, project_id: str) -> bool:
-        conn = get_connection()
-        cur = conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
-        conn.commit()
-        conn.close()
-        return cur.rowcount > 0
+        with connection() as conn:
+            cur = conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
+            return cur.rowcount > 0
 
     @staticmethod
     def _row_to_project(row) -> Project:

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from .db import get_connection
+from .db import connection
 
 _FIELDS = [
     "id",
@@ -78,41 +78,36 @@ class ProjectionStore:
             s3_staging_bucket=s3_staging_bucket,
             project_id=project_id,
         )
-        conn = get_connection()
-        conn.execute(
-            f"INSERT INTO projections ({', '.join(_FIELDS)}) VALUES ({', '.join('?' for _ in _FIELDS)})",
-            [
-                getattr(p, f) if f != "created_at" else p.created_at.isoformat()
-                for f in _FIELDS
-            ],
-        )
-        conn.commit()
-        conn.close()
+        with connection() as conn:
+            conn.execute(
+                f"INSERT INTO projections ({', '.join(_FIELDS)}) VALUES ({', '.join('?' for _ in _FIELDS)})",
+                [
+                    getattr(p, f) if f != "created_at" else p.created_at.isoformat()
+                    for f in _FIELDS
+                ],
+            )
         return p
 
     def get(self, projection_id: str) -> Optional[Projection]:
-        conn = get_connection()
-        row = conn.execute(
-            "SELECT * FROM projections WHERE id = ?", (projection_id,)
-        ).fetchone()
-        conn.close()
+        with connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM projections WHERE id = ?", (projection_id,)
+            ).fetchone()
         return self._row_to_projection(row) if row else None
 
     def list(self) -> List[Projection]:
-        conn = get_connection()
-        rows = conn.execute(
-            "SELECT * FROM projections ORDER BY created_at DESC"
-        ).fetchall()
-        conn.close()
+        with connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM projections ORDER BY created_at DESC"
+            ).fetchall()
         return [self._row_to_projection(r) for r in rows]
 
     def list_by_project(self, project_id: str) -> List[Projection]:
-        conn = get_connection()
-        rows = conn.execute(
-            "SELECT * FROM projections WHERE project_id = ? ORDER BY created_at DESC",
-            (project_id,),
-        ).fetchall()
-        conn.close()
+        with connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM projections WHERE project_id = ? ORDER BY created_at DESC",
+                (project_id,),
+            ).fetchall()
         return [self._row_to_projection(r) for r in rows]
 
     _ALLOWED_UPDATE_COLUMNS = {
@@ -141,18 +136,14 @@ class ProjectionStore:
             raise ValueError(f"Invalid column(s): {invalid}")
         sets = ", ".join(f"{k} = ?" for k in kwargs)
         vals = list(kwargs.values()) + [projection_id]
-        conn = get_connection()
-        conn.execute(f"UPDATE projections SET {sets} WHERE id = ?", vals)
-        conn.commit()
-        conn.close()
+        with connection() as conn:
+            conn.execute(f"UPDATE projections SET {sets} WHERE id = ?", vals)
         return self.get(projection_id)
 
     def delete(self, projection_id: str) -> bool:
-        conn = get_connection()
-        cur = conn.execute("DELETE FROM projections WHERE id = ?", (projection_id,))
-        conn.commit()
-        conn.close()
-        return cur.rowcount > 0
+        with connection() as conn:
+            cur = conn.execute("DELETE FROM projections WHERE id = ?", (projection_id,))
+            return cur.rowcount > 0
 
     @staticmethod
     def _row_to_projection(row) -> Projection:

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import List, Optional
 
 from .db import get_connection
 
@@ -98,7 +98,7 @@ class ProjectionStore:
         conn.close()
         return self._row_to_projection(row) if row else None
 
-    def list(self) -> list[Projection]:
+    def list(self) -> List[Projection]:
         conn = get_connection()
         rows = conn.execute(
             "SELECT * FROM projections ORDER BY created_at DESC"
@@ -106,7 +106,7 @@ class ProjectionStore:
         conn.close()
         return [self._row_to_projection(r) for r in rows]
 
-    def list_by_project(self, project_id: str) -> list[Projection]:
+    def list_by_project(self, project_id: str) -> List[Projection]:
         conn = get_connection()
         rows = conn.execute(
             "SELECT * FROM projections WHERE project_id = ? ORDER BY created_at DESC",

--- a/proxy/tests/test_graph_name_collision.py
+++ b/proxy/tests/test_graph_name_collision.py
@@ -20,6 +20,7 @@ import pytest
 
 from nx_neptune_proxy.services.pipeline import run_pipeline
 from nx_neptune_proxy.services.projection_store import store
+from nx_neptune_proxy.services.project_store import store as project_store
 
 # --- Schema validation (defense-in-depth) ---
 
@@ -29,21 +30,29 @@ class TestGraphNameSchemaValidation:
     @pytest.mark.parametrize(
         "bad_name", ["", "a", "ab", "-abc", "has space", "bad!char"]
     )
-    async def test_rejects_invalid_graph_name(self, client, bad_name):
+    async def test_rejects_invalid_graph_name(self, client, test_project_id, bad_name):
         """Empty, too-short, or illegal graph_name is rejected with 422."""
         resp = await client.post(
             "/api/v0/projection",
-            json={"database": "mydb", "graph_name": bad_name},
+            json={
+                "database": "mydb",
+                "graph_name": bad_name,
+                "project_id": test_project_id,
+            },
         )
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("ok_name", ["abc", "Test-Graph", "my_graph_1", "ABC123"])
-    async def test_accepts_valid_graph_name(self, client, ok_name):
+    async def test_accepts_valid_graph_name(self, client, test_project_id, ok_name):
         """Valid names (incl. uppercase and underscore) are accepted."""
         resp = await client.post(
             "/api/v0/projection",
-            json={"database": "mydb", "graph_name": ok_name},
+            json={
+                "database": "mydb",
+                "graph_name": ok_name,
+                "project_id": test_project_id,
+            },
         )
         assert resp.status_code == 201
         assert resp.json()["graph_name"] == ok_name
@@ -60,6 +69,8 @@ def _make_projection(**overrides):
         s3_staging_bucket="s3://bucket/staging/",
     )
     defaults.update(overrides)
+    if "project_id" not in defaults:
+        defaults["project_id"] = project_store.create(name="Test Project").id
     return store.create(**defaults)
 
 


### PR DESCRIPTION
**Description:**


Refactors DB connection handling into a reusable context manager and fixes the proxy test-cases that were missing a mandatory `project_id`.

- **Optimisation / refactor — `connection()` context manager:** store methods previously called `get_connection()` with manual `close()` and no `try/finally`,
  so a failed query left the connection open holding a SQLite lock and subsequent calls blocked ~5s on it. Added a `connection()` context manager in `db.py` that commits on success and always closes, and converted all call sites to it.

- **Fix test-cases for missing project ID:** tests now supply the mandatory `project_id`.

- **DX:** add a `make proxy-test` target so the proxy suite can be run from repo root
    (mirrors the proxy module's `pytest tests/ -v`).

- **Minor:** `typing.List` annotations to keep mypy / `make proxy-lint` green.
