### PR TITLE
Feat: Support multiple node and edge queries per projection

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/project.py
+++ b/proxy/src/nx_neptune_proxy/routers/project.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from nx_neptune_proxy.services.project_deletion import delete_project
 from nx_neptune_proxy.services.project_store import store
-from nx_neptune_proxy.services.projection_store import store as projection_store
+from nx_neptune_proxy.services.projection_service import projection_service
 
 router = APIRouter(prefix="/api/v0/project", tags=["project"])
 
@@ -76,12 +76,12 @@ def delete_project_endpoint(project_id: str, background_tasks: BackgroundTasks):
         raise HTTPException(status_code=409, detail="Already deleting")
 
     # If no graphs to delete, do it immediately
-    projections = [pr for pr in projection_store.list() if pr.project_id == project_id]
+    projections = projection_service.list_by_project(project_id)
     has_graphs = any(pr.graph_id for pr in projections)
 
     if not has_graphs:
         for pr in projections:
-            projection_store.delete(pr.id)
+            projection_service.delete(pr.id)
         store.delete(project_id)
         return Response(status_code=204)
 

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -24,6 +24,7 @@ from nx_neptune_proxy.config import Settings
 from nx_neptune_proxy.routers.schemas import ProjectExportPayload, ProjectionExport
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
+from nx_neptune_proxy.services.query_store import query_store
 from nx_neptune_proxy.utils.aws_helper import (
     check_body_size,
     check_content_length,
@@ -68,7 +69,14 @@ def _build_export_payload(project_id: str) -> tuple[dict, str]:
         raise HTTPException(status_code=404, detail="Project not found")
 
     projections = projection_store.list_by_project(project_id)
-    payload = ProjectExportPayload.from_project(p, projections)
+    queries_by_projection = {
+        pr.id: (
+            [nq.sql for nq in query_store.list_node_queries(pr.id)],
+            [eq.sql for eq in query_store.list_edge_queries(pr.id)],
+        )
+        for pr in projections
+    }
+    payload = ProjectExportPayload.from_project(p, projections, queries_by_projection)
     return payload.model_dump(), p.name
 
 
@@ -97,7 +105,16 @@ def _import_from_payload(payload: ProjectExportPayload) -> dict:
     p = project_store.create(name=name)
 
     for pr_data in payload.projections:
-        projection_store.create(**pr_data.model_dump(), project_id=p.id)
+        pr_dict = pr_data.model_dump(exclude={"node_queries", "edge_queries"})
+        pr = projection_store.create(**pr_dict, project_id=p.id)
+        if pr_data.node_queries:
+            query_store.save_node_queries(
+                pr.id, [{"sql": sql} for sql in pr_data.node_queries]
+            )
+        if pr_data.edge_queries:
+            query_store.save_edge_queries(
+                pr.id, [{"sql": sql} for sql in pr_data.edge_queries]
+            )
 
     return {"id": p.id, "name": p.name}
 

--- a/proxy/src/nx_neptune_proxy/routers/project_io.py
+++ b/proxy/src/nx_neptune_proxy/routers/project_io.py
@@ -23,8 +23,7 @@ from pydantic import BaseModel, Field
 from nx_neptune_proxy.config import Settings
 from nx_neptune_proxy.routers.schemas import ProjectExportPayload, ProjectionExport
 from nx_neptune_proxy.services.project_store import store as project_store
-from nx_neptune_proxy.services.projection_store import store as projection_store
-from nx_neptune_proxy.services.query_store import query_store
+from nx_neptune_proxy.services.projection_service import projection_service
 from nx_neptune_proxy.utils.aws_helper import (
     check_body_size,
     check_content_length,
@@ -68,14 +67,9 @@ def _build_export_payload(project_id: str) -> tuple[dict, str]:
     if p is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    projections = projection_store.list_by_project(project_id)
-    queries_by_projection = {
-        pr.id: (
-            [nq.sql for nq in query_store.list_node_queries(pr.id)],
-            [eq.sql for eq in query_store.list_edge_queries(pr.id)],
-        )
-        for pr in projections
-    }
+    projections, queries_by_projection = (
+        projection_service.list_projections_with_query_sql(project_id)
+    )
     payload = ProjectExportPayload.from_project(p, projections, queries_by_projection)
     return payload.model_dump(), p.name
 
@@ -106,15 +100,10 @@ def _import_from_payload(payload: ProjectExportPayload) -> dict:
 
     for pr_data in payload.projections:
         pr_dict = pr_data.model_dump(exclude={"node_queries", "edge_queries"})
-        pr = projection_store.create(**pr_dict, project_id=p.id)
-        if pr_data.node_queries:
-            query_store.save_node_queries(
-                pr.id, [{"sql": sql} for sql in pr_data.node_queries]
-            )
-        if pr_data.edge_queries:
-            query_store.save_edge_queries(
-                pr.id, [{"sql": sql} for sql in pr_data.edge_queries]
-            )
+        pr_dict["project_id"] = p.id
+        projection_service.create_with_queries(
+            pr_dict, pr_data.node_queries, pr_data.edge_queries
+        )
 
     return {"id": p.id, "name": p.name}
 

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -31,9 +31,10 @@ from nx_neptune_proxy.routers.schemas import (
     ValidateResponse,
 )
 from nx_neptune_proxy.services.pipeline import run_pipeline
-from nx_neptune_proxy.services.projection_service import projection_service
-from nx_neptune_proxy.services.projection_store import store
-from nx_neptune_proxy.services.query_store import query_store
+from nx_neptune_proxy.services.projection_service import (
+    ProjectionNotFound,
+    projection_service,
+)
 from nx_neptune_proxy.utils import unpack_query_results
 from nx_neptune_proxy.utils.aws_helper import (
     assert_managed_graph,
@@ -45,10 +46,10 @@ router = APIRouter(prefix="/api/v0/projection", tags=["projection"])
 
 
 def _get_projection_or_404(projection_id: str):
-    projection = store.get(projection_id)
-    if projection is None:
+    try:
+        return projection_service.get_or_raise(projection_id)
+    except ProjectionNotFound:
         raise HTTPException(status_code=404, detail="Projection not found")
-    return projection
 
 
 @router.post(
@@ -59,14 +60,14 @@ def _get_projection_or_404(projection_id: str):
 )
 def create_projection(body: ProjectionCreate):
     """Create a new projection in draft state."""
-    projection = store.create(**body.model_dump())
+    projection = projection_service.create(**body.model_dump())
     return asdict(projection)
 
 
 @router.get("", summary="List all projections", response_model=list[ProjectionResponse])
 def list_projections():
     """List all projections."""
-    return [asdict(p) for p in store.list()]
+    return [asdict(p) for p in projection_service.list()]
 
 
 @router.get(
@@ -84,7 +85,9 @@ def get_projection(projection_id: str):
 )
 def update_projection(projection_id: str, body: ProjectionUpdate):
     _get_projection_or_404(projection_id)
-    projection = store.update(projection_id, **body.model_dump(exclude_unset=True))
+    projection = projection_service.update(
+        projection_id, **body.model_dump(exclude_unset=True)
+    )
     return asdict(projection)  # type: ignore[arg-type]
 
 
@@ -133,17 +136,7 @@ def validate_query(projection_id: str):
     p = _get_projection_or_404(projection_id)
     checks = []
 
-    node_queries_list = query_store.list_node_queries(projection_id)
-    edge_queries_list = query_store.list_edge_queries(projection_id)
-
-    queries_to_validate = []
-    for i, nq in enumerate(node_queries_list):
-        if nq.sql.strip():
-            queries_to_validate.append((f"node_query_{i+1}", nq.sql, "node"))
-
-    for i, eq in enumerate(edge_queries_list):
-        if eq.sql.strip():
-            queries_to_validate.append((f"edge_query_{i+1}", eq.sql, "edge"))
+    queries_to_validate = projection_service.list_labeled_queries(projection_id)
 
     for label, query, query_type in queries_to_validate:
         result = check_athena_query(
@@ -170,11 +163,7 @@ async def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le
     p = _get_projection_or_404(projection_id)
     client = ClientFactory().athena()
 
-    node_queries_list = query_store.list_node_queries(projection_id)
-    edge_queries_list = query_store.list_edge_queries(projection_id)
-
-    queries = [nq.sql for nq in node_queries_list if nq.sql.strip()]
-    queries += [eq.sql for eq in edge_queries_list if eq.sql.strip()]
+    queries = projection_service.list_query_sql(projection_id)
 
     all_results: list = []
 
@@ -220,7 +209,7 @@ def delete_projection(projection_id: str):
         raise HTTPException(
             status_code=409, detail="Graph deletion in progress, cannot purge yet"
         )
-    store.delete(projection_id)
+    projection_service.delete(projection_id)
     return {"id": p.id, "status": "deleted"}
 
 
@@ -244,7 +233,7 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
     resp = get_graph_or_exception(client, p.graph_id)
     assert_managed_graph(resp.get("name"))
 
-    store.update(
+    projection_service.update(
         projection_id,
         status="deleting",
         step="graph_delete",
@@ -257,7 +246,7 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
             client.delete_graph(graphIdentifier=p.graph_id, skipSnapshot=True)
         except ClientError as e:
             if e.response["Error"]["Code"] != "ResourceNotFoundException":
-                store.update(
+                projection_service.update(
                     projection_id, status="failed", error=sanitize_error_message(str(e))
                 )
                 return
@@ -269,13 +258,13 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
             except ClientError:
                 break
         else:
-            store.update(
+            projection_service.update(
                 projection_id,
                 status="failed",
                 error="Timeout waiting for graph deletion",
             )
             return
-        store.update(
+        projection_service.update(
             projection_id,
             status="archived",
             graph_id=None,

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -31,6 +31,7 @@ from nx_neptune_proxy.routers.schemas import (
     ValidateResponse,
 )
 from nx_neptune_proxy.services.pipeline import run_pipeline
+from nx_neptune_proxy.services.projection_service import projection_service
 from nx_neptune_proxy.services.projection_store import store
 from nx_neptune_proxy.services.query_store import query_store
 from nx_neptune_proxy.utils import unpack_query_results
@@ -296,9 +297,10 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
 def get_queries(projection_id: str):
     """Return all node and edge queries for a projection."""
     _get_projection_or_404(projection_id)
+    node_queries, edge_queries = projection_service.get_queries(projection_id)
     return QueriesResponse(
-        node_queries=query_store.list_node_responses(projection_id),  # type: ignore[arg-type]
-        edge_queries=query_store.list_edge_responses(projection_id),  # type: ignore[arg-type]
+        node_queries=node_queries,  # type: ignore[arg-type]
+        edge_queries=edge_queries,  # type: ignore[arg-type]
     )
 
 
@@ -310,9 +312,10 @@ def get_queries(projection_id: str):
 def save_queries(projection_id: str, body: QueriesPayload):
     """Replace all node and edge queries for a projection."""
     _get_projection_or_404(projection_id)
-    query_store.save_node_from_payload(projection_id, body.node_queries)
-    query_store.save_edge_from_payload(projection_id, body.edge_queries)
+    node_queries, edge_queries = projection_service.save_queries(
+        projection_id, body.node_queries, body.edge_queries
+    )
     return QueriesResponse(
-        node_queries=query_store.list_node_responses(projection_id),  # type: ignore[arg-type]
-        edge_queries=query_store.list_edge_responses(projection_id),  # type: ignore[arg-type]
+        node_queries=node_queries,  # type: ignore[arg-type]
+        edge_queries=edge_queries,  # type: ignore[arg-type]
     )

--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -26,10 +26,13 @@ from nx_neptune_proxy.routers.schemas import (
     ProjectionResponse,
     ProjectionStatus,
     ProjectionUpdate,
+    QueriesPayload,
+    QueriesResponse,
     ValidateResponse,
 )
 from nx_neptune_proxy.services.pipeline import run_pipeline
 from nx_neptune_proxy.services.projection_store import store
+from nx_neptune_proxy.services.query_store import query_store
 from nx_neptune_proxy.utils import unpack_query_results
 from nx_neptune_proxy.utils.aws_helper import (
     assert_managed_graph,
@@ -128,15 +131,26 @@ def validate_query(projection_id: str):
     """Validate node and edge queries individually"""
     p = _get_projection_or_404(projection_id)
     checks = []
-    for label, query in [("node_query", p.node_query), ("edge_query", p.edge_query)]:
-        if not query:
-            continue
+
+    node_queries_list = query_store.list_node_queries(projection_id)
+    edge_queries_list = query_store.list_edge_queries(projection_id)
+
+    queries_to_validate = []
+    for i, nq in enumerate(node_queries_list):
+        if nq.sql.strip():
+            queries_to_validate.append((f"node_query_{i+1}", nq.sql, "node"))
+
+    for i, eq in enumerate(edge_queries_list):
+        if eq.sql.strip():
+            queries_to_validate.append((f"edge_query_{i+1}", eq.sql, "edge"))
+
+    for label, query, query_type in queries_to_validate:
         result = check_athena_query(
             sql_query=query,
             catalog=p.catalog,
             database=p.database,
             output_location=p.s3_staging_bucket,
-            query_type="edge" if label == "edge_query" else "node",
+            query_type=query_type,
         )
         checks.append(
             {"check": label, "passed": result.passed, "message": result.message}
@@ -155,9 +169,12 @@ async def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le
     p = _get_projection_or_404(projection_id)
     client = ClientFactory().athena()
 
-    queries = [q for q in [p.node_query, p.edge_query] if q]
-    if not queries and p.sql_query:
-        queries = [q.strip() for q in p.sql_query.split(";") if q.strip()]
+    node_queries_list = query_store.list_node_queries(projection_id)
+    edge_queries_list = query_store.list_edge_queries(projection_id)
+
+    queries = [nq.sql for nq in node_queries_list if nq.sql.strip()]
+    queries += [eq.sql for eq in edge_queries_list if eq.sql.strip()]
+
     all_results: list = []
 
     for q in queries:
@@ -269,3 +286,33 @@ def delete_projection_graph(projection_id: str, background_tasks: BackgroundTask
 
     background_tasks.add_task(_delete_graph)
     return {"id": p.id, "status": "deleting"}
+
+
+@router.get(
+    "/{projection_id}/queries",
+    summary="Get node and edge queries for a projection",
+    response_model=QueriesResponse,
+)
+def get_queries(projection_id: str):
+    """Return all node and edge queries for a projection."""
+    _get_projection_or_404(projection_id)
+    return QueriesResponse(
+        node_queries=query_store.list_node_responses(projection_id),  # type: ignore[arg-type]
+        edge_queries=query_store.list_edge_responses(projection_id),  # type: ignore[arg-type]
+    )
+
+
+@router.put(
+    "/{projection_id}/queries",
+    summary="Save node and edge queries for a projection",
+    response_model=QueriesResponse,
+)
+def save_queries(projection_id: str, body: QueriesPayload):
+    """Replace all node and edge queries for a projection."""
+    _get_projection_or_404(projection_id)
+    query_store.save_node_from_payload(projection_id, body.node_queries)
+    query_store.save_edge_from_payload(projection_id, body.edge_queries)
+    return QueriesResponse(
+        node_queries=query_store.list_node_responses(projection_id),  # type: ignore[arg-type]
+        edge_queries=query_store.list_edge_responses(projection_id),  # type: ignore[arg-type]
+    )

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -67,8 +67,6 @@ class NeptuneAnalyticsGraphsResponse(BaseModel):
 class ProjectionCreate(BaseModel):
     catalog: str = "AwsDataCatalog"
     database: Optional[str] = None
-    node_query: Optional[str] = None
-    edge_query: Optional[str] = None
     graph_name: Optional[str] = Field(
         default=None,
         min_length=GRAPH_NAME_MIN_LENGTH,
@@ -77,14 +75,12 @@ class ProjectionCreate(BaseModel):
     )
     graph_memory_gb: int = 16
     s3_staging_bucket: Optional[str] = None
-    project_id: str
+    project_id: Optional[str] = None
 
 
 class ProjectionUpdate(BaseModel):
     catalog: Optional[str] = None
     database: Optional[str] = None
-    node_query: Optional[str] = None
-    edge_query: Optional[str] = None
     graph_name: Optional[str] = Field(
         default=None,
         min_length=GRAPH_NAME_MIN_LENGTH,
@@ -131,8 +127,6 @@ class ProjectionResponse(BaseModel):
     status: str
     catalog: str
     database: Optional[str] = None
-    node_query: Optional[str] = None
-    edge_query: Optional[str] = None
     graph_name: Optional[str] = None
     graph_id: Optional[str] = None
     graph_endpoint: Optional[str] = None
@@ -171,20 +165,31 @@ class ProjectionExport(BaseModel):
         None,
         description="S3 bucket path for staging Athena results (e.g. s3://bucket/prefix)",
     )
+    node_queries: list[str] = Field(
+        default_factory=list, description="Node SQL queries"
+    )
+    edge_queries: list[str] = Field(
+        default_factory=list, description="Edge SQL queries"
+    )
 
     model_config = {"extra": "forbid"}
 
     @classmethod
-    def from_projection(cls, pr) -> "ProjectionExport":
+    def from_projection(
+        cls,
+        pr,
+        node_queries: Optional[list[str]] = None,
+        edge_queries: Optional[list[str]] = None,
+    ) -> "ProjectionExport":
         """Create from a Projection dataclass instance."""
-        return cls(
+        return cls(  # type: ignore[call-arg]
             catalog=pr.catalog,
             database=pr.database,
-            node_query=pr.node_query,
-            edge_query=pr.edge_query,
             graph_name=pr.graph_name,
             graph_memory_gb=pr.graph_memory_gb,
             s3_staging_bucket=pr.s3_staging_bucket,
+            node_queries=node_queries or [],
+            edge_queries=edge_queries or [],
         )
 
 
@@ -198,9 +203,58 @@ class ProjectExportPayload(BaseModel):
     model_config = {"extra": "forbid"}
 
     @classmethod
-    def from_project(cls, project, projections: list) -> "ProjectExportPayload":
-        """Build export payload from a project and its projections."""
+    def from_project(
+        cls, project, projections: list, queries_by_projection: Optional[dict] = None
+    ) -> "ProjectExportPayload":
+        """Build export payload from a project and its projections.
+
+        Args:
+            queries_by_projection: dict mapping projection_id to (node_queries, edge_queries) tuple of SQL strings.
+        """
+        qmap = queries_by_projection or {}
         return cls(
             project={"name": project.name},
-            projections=[ProjectionExport.from_projection(pr) for pr in projections],
+            projections=[
+                ProjectionExport.from_projection(
+                    pr,
+                    node_queries=qmap.get(pr.id, ([], []))[0],
+                    edge_queries=qmap.get(pr.id, ([], []))[1],
+                )
+                for pr in projections
+            ],
         )
+
+
+# --- Multi-Query ---
+
+
+class NodeQueryInput(BaseModel):
+    id: Optional[str] = None
+    sql: str = ""
+
+
+class EdgeQueryInput(BaseModel):
+    id: Optional[str] = None
+    sql: str = ""
+
+
+class NodeQueryResponse(BaseModel):
+    id: str
+    sql: str
+    position: int
+
+
+class EdgeQueryResponse(BaseModel):
+    id: str
+    sql: str
+    position: int
+
+
+class QueriesPayload(BaseModel):
+    node_queries: list[NodeQueryInput] = []
+    edge_queries: list[EdgeQueryInput] = []
+
+
+class QueriesResponse(BaseModel):
+    node_queries: list[NodeQueryResponse]
+    edge_queries: list[EdgeQueryResponse]

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -75,7 +75,7 @@ class ProjectionCreate(BaseModel):
     )
     graph_memory_gb: int = 16
     s3_staging_bucket: Optional[str] = None
-    project_id: Optional[str] = None
+    project_id: str
 
 
 class ProjectionUpdate(BaseModel):

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -38,6 +38,12 @@ def connection() -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
+def query(sql: str, params: tuple = ()) -> list[sqlite3.Row]:
+    """Run a read query and return all rows, always closing the connection."""
+    with connection() as conn:
+        return conn.execute(sql, params).fetchall()
+
+
 def init_db() -> None:
     with connection() as conn:
         conn.executescript("""

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -18,7 +18,12 @@ def get_connection() -> sqlite3.Connection:
     Path(DB_PATH).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DB_PATH, check_same_thread=False)
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
+    # Fetch the result so the pragma statement doesn't stay pending and
+    # swallow the next pragma on some SQLite builds.
+    conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    # Enforce FKs per-connection (off by default), so the ON DELETE CASCADE
+    # in init_db() acts as a real backstop for the explicit query cleanup.
+    conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
 

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -67,4 +67,18 @@ def init_db() -> None:
             created_at TEXT NOT NULL,
             FOREIGN KEY (project_id) REFERENCES projects(id)
         );
+        CREATE TABLE IF NOT EXISTS node_queries (
+            id TEXT PRIMARY KEY,
+            projection_id TEXT NOT NULL,
+            sql TEXT NOT NULL DEFAULT '',
+            position INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (projection_id) REFERENCES projections(id) ON DELETE CASCADE
+        );
+        CREATE TABLE IF NOT EXISTS edge_queries (
+            id TEXT PRIMARY KEY,
+            projection_id TEXT NOT NULL,
+            sql TEXT NOT NULL DEFAULT '',
+            position INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (projection_id) REFERENCES projections(id) ON DELETE CASCADE
+        );
     """)

--- a/proxy/src/nx_neptune_proxy/services/db.py
+++ b/proxy/src/nx_neptune_proxy/services/db.py
@@ -38,12 +38,6 @@ def connection() -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
-def query(sql: str, params: tuple = ()) -> list[sqlite3.Row]:
-    """Run a read query and return all rows, always closing the connection."""
-    with connection() as conn:
-        return conn.execute(sql, params).fetchall()
-
-
 def init_db() -> None:
     with connection() as conn:
         conn.executescript("""

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -4,8 +4,8 @@
 import logging
 
 from nx_neptune_proxy.config import get_settings
-from nx_neptune_proxy.services.projection_store import Projection, store
-from nx_neptune_proxy.services.query_store import query_store
+from nx_neptune_proxy.services.projection_service import projection_service
+from nx_neptune_proxy.services.projection_store import Projection
 from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ async def run_pipeline(projection: Projection) -> None:
     s3_location = projection.s3_staging_bucket.rstrip("/") + f"/{projection.id}/"  # type: ignore[union-attr]  # noqa: E501
 
     try:
-        store.update(projection.id, status="importing")
+        projection_service.update(projection.id, status="importing")
 
         # Step 1: Create or reuse graph
         _update(
@@ -70,7 +70,7 @@ async def run_pipeline(projection: Projection) -> None:
         if existing:
             # Reuse existing graph (retry scenario) — reset data
             graph = existing
-            store.update(
+            projection_service.update(
                 projection.id,
                 graph_id=graph.graph_id,
                 graph_endpoint=f"https://{graph.graph_id}.neptune-graph.amazonaws.com",
@@ -87,7 +87,7 @@ async def run_pipeline(projection: Projection) -> None:
             graph = await sm.get_or_create_graph(
                 config={"provisionedMemory": projection.graph_memory_gb}
             )
-            store.update(
+            projection_service.update(
                 projection.id,
                 graph_id=graph.graph_id,
                 graph_endpoint=f"https://{graph.graph_id}.neptune-graph.amazonaws.com",
@@ -100,13 +100,7 @@ async def run_pipeline(projection: Projection) -> None:
             label="Running Athena query and importing data",
             progress=45,
         )
-        node_sql = [
-            nq.sql for nq in query_store.list_node_queries(projection.id) if nq.sql
-        ]
-        edge_sql = [
-            eq.sql for eq in query_store.list_edge_queries(projection.id) if eq.sql
-        ]
-        sql_queries = node_sql + edge_sql
+        sql_queries = projection_service.list_query_sql(projection.id)
         await sm.import_from_table(
             graph=graph,
             s3_location=s3_location,
@@ -121,7 +115,7 @@ async def run_pipeline(projection: Projection) -> None:
 
         # Step 3: Done
         _update(projection.id, step="ready", label="Graph ready", progress=100)
-        store.update(projection.id, status="complete")
+        projection_service.update(projection.id, status="complete")
 
     except Exception as e:
         logger.exception("Pipeline failed")
@@ -132,10 +126,12 @@ async def run_pipeline(projection: Projection) -> None:
             error_msg = str(e)
 
         # Sanitize before persisting — strip ARNs, account IDs
-        store.update(
+        projection_service.update(
             projection.id, status="failed", error=sanitize_error_message(error_msg)
         )
 
 
 def _update(projection_id: str, step: str, label: str, progress: float) -> None:
-    store.update(projection_id, step=step, step_label=label, progress=progress)
+    projection_service.update(
+        projection_id, step=step, step_label=label, progress=progress
+    )

--- a/proxy/src/nx_neptune_proxy/services/pipeline.py
+++ b/proxy/src/nx_neptune_proxy/services/pipeline.py
@@ -5,6 +5,7 @@ import logging
 
 from nx_neptune_proxy.config import get_settings
 from nx_neptune_proxy.services.projection_store import Projection, store
+from nx_neptune_proxy.services.query_store import query_store
 from nx_neptune_proxy.utils.sanitize import sanitize_error_message
 
 logger = logging.getLogger(__name__)
@@ -99,7 +100,13 @@ async def run_pipeline(projection: Projection) -> None:
             label="Running Athena query and importing data",
             progress=45,
         )
-        sql_queries = [q for q in [projection.node_query, projection.edge_query] if q]
+        node_sql = [
+            nq.sql for nq in query_store.list_node_queries(projection.id) if nq.sql
+        ]
+        edge_sql = [
+            eq.sql for eq in query_store.list_edge_queries(projection.id) if eq.sql
+        ]
+        sql_queries = node_sql + edge_sql
         await sm.import_from_table(
             graph=graph,
             s3_location=s3_location,

--- a/proxy/src/nx_neptune_proxy/services/project_deletion.py
+++ b/proxy/src/nx_neptune_proxy/services/project_deletion.py
@@ -11,7 +11,7 @@ from botocore.exceptions import ClientError
 from nx_neptune.clients.client_factory import ClientFactory
 
 from nx_neptune_proxy.services.project_store import store as project_store
-from nx_neptune_proxy.services.projection_store import store as projection_store
+from nx_neptune_proxy.services.projection_service import projection_service
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ TIMEOUT = 600  # 10 min max wait per graph
 
 async def delete_project(project_id: str) -> None:
     """Delete all graphs for a project's projections, then remove records."""
-    projections = [p for p in projection_store.list() if p.project_id == project_id]
+    projections = projection_service.list_by_project(project_id)
 
     # Delete all graphs in parallel
     graphs_to_delete = [p for p in projections if p.graph_id]
@@ -41,7 +41,7 @@ async def delete_project(project_id: str) -> None:
 
     for p in projections:
         if p.id not in failed_ids:
-            projection_store.delete(p.id)
+            projection_service.delete(p.id)
 
     # Only delete the project if all graphs were cleaned up
     if failed_ids:

--- a/proxy/src/nx_neptune_proxy/services/projection_service.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_service.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Application service that orchestrates projection + query persistence.
+
+The web layer (routers) and the pipeline talk to this service instead of
+reaching into ``projection_store`` and ``query_store`` directly. The service is
+the single place where the two stores are coordinated, and the natural home for
+any cross-store consistency logic (e.g. deleting a projection also removes its
+queries).
+
+It is intentionally HTTP-agnostic: it raises ``ProjectionNotFound`` rather than
+an ``HTTPException`` so it can be reused outside the request path (pipeline,
+tests). Routers translate ``ProjectionNotFound`` into a 404.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .projection_store import Projection, store as projection_store
+from .query_store import EdgeQuery, NodeQuery, query_store
+
+
+class ProjectionNotFound(Exception):
+    """Raised when a projection id does not exist."""
+
+    def __init__(self, projection_id: str):
+        self.projection_id = projection_id
+        super().__init__(f"Projection not found: {projection_id}")
+
+
+class ProjectionService:
+    """Coordinates projection metadata and its node/edge queries."""
+
+    # --- Projection metadata ---
+
+    def create(self, **data) -> Projection:
+        return projection_store.create(**data)
+
+    def get(self, projection_id: str) -> Optional[Projection]:
+        return projection_store.get(projection_id)
+
+    def get_or_raise(self, projection_id: str) -> Projection:
+        projection = projection_store.get(projection_id)
+        if projection is None:
+            raise ProjectionNotFound(projection_id)
+        return projection
+
+    def list(self) -> List[Projection]:
+        return projection_store.list()
+
+    def update(self, projection_id: str, **data) -> Optional[Projection]:
+        return projection_store.update(projection_id, **data)
+
+    def delete(self, projection_id: str) -> bool:
+        """Delete a projection and its associated node/edge queries."""
+        # Remove child queries first so nothing is orphaned regardless of
+        # whether SQLite FK cascade is enabled.
+        query_store.save_node_queries(projection_id, [])
+        query_store.save_edge_queries(projection_id, [])
+        return projection_store.delete(projection_id)
+
+    # --- Queries (child of a projection) ---
+
+    def list_node_queries(self, projection_id: str) -> List[NodeQuery]:
+        return query_store.list_node_queries(projection_id)
+
+    def list_edge_queries(self, projection_id: str) -> List[EdgeQuery]:
+        return query_store.list_edge_queries(projection_id)
+
+    def get_queries(self, projection_id: str) -> tuple[List[dict], List[dict]]:
+        """Return (node_responses, edge_responses) as API-ready dicts."""
+        return (
+            query_store.list_node_responses(projection_id),
+            query_store.list_edge_responses(projection_id),
+        )
+
+    def save_queries(
+        self, projection_id: str, node_models: List, edge_models: List
+    ) -> tuple[List[dict], List[dict]]:
+        """Replace all node/edge queries, then return the stored responses."""
+        query_store.save_node_from_payload(projection_id, node_models)
+        query_store.save_edge_from_payload(projection_id, edge_models)
+        return self.get_queries(projection_id)
+
+
+# Singleton service instance
+projection_service = ProjectionService()

--- a/proxy/src/nx_neptune_proxy/services/projection_service.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_service.py
@@ -50,6 +50,9 @@ class ProjectionService:
     def list(self) -> List[Projection]:
         return projection_store.list()
 
+    def list_by_project(self, project_id: str) -> List[Projection]:
+        return projection_store.list_by_project(project_id)
+
     def update(self, projection_id: str, **data) -> Optional[Projection]:
         return projection_store.update(projection_id, **data)
 
@@ -69,6 +72,27 @@ class ProjectionService:
     def list_edge_queries(self, projection_id: str) -> List[EdgeQuery]:
         return query_store.list_edge_queries(projection_id)
 
+    def list_query_sql(self, projection_id: str) -> List[str]:
+        """All non-empty node+edge query SQL, node queries first."""
+        node = [
+            nq.sql for nq in self.list_node_queries(projection_id) if nq.sql.strip()
+        ]
+        edge = [
+            eq.sql for eq in self.list_edge_queries(projection_id) if eq.sql.strip()
+        ]
+        return node + edge
+
+    def list_labeled_queries(self, projection_id: str) -> List[tuple[str, str, str]]:
+        """(label, sql, query_type) for each non-empty node/edge query."""
+        labeled: List[tuple[str, str, str]] = []
+        for i, nq in enumerate(self.list_node_queries(projection_id)):
+            if nq.sql.strip():
+                labeled.append((f"node_query_{i + 1}", nq.sql, "node"))
+        for i, eq in enumerate(self.list_edge_queries(projection_id)):
+            if eq.sql.strip():
+                labeled.append((f"edge_query_{i + 1}", eq.sql, "edge"))
+        return labeled
+
     def get_queries(self, projection_id: str) -> tuple[List[dict], List[dict]]:
         """Return (node_responses, edge_responses) as API-ready dicts."""
         return (
@@ -83,6 +107,42 @@ class ProjectionService:
         query_store.save_node_from_payload(projection_id, node_models)
         query_store.save_edge_from_payload(projection_id, edge_models)
         return self.get_queries(projection_id)
+
+    # --- Import / export helpers ---
+
+    def get_query_sql_lists(self, projection_id: str) -> tuple[List[str], List[str]]:
+        """Return (node_sql, edge_sql) lists verbatim (no filtering), for export."""
+        node = [nq.sql for nq in self.list_node_queries(projection_id)]
+        edge = [eq.sql for eq in self.list_edge_queries(projection_id)]
+        return node, edge
+
+    def list_projections_with_query_sql(
+        self, project_id: str
+    ) -> tuple[List[Projection], dict]:
+        """Return (projections, {projection_id: (node_sql, edge_sql)}) for export."""
+        projections = self.list_by_project(project_id)
+        queries_by_projection = {
+            pr.id: self.get_query_sql_lists(pr.id) for pr in projections
+        }
+        return projections, queries_by_projection
+
+    def create_with_queries(
+        self,
+        projection_data: dict,
+        node_sql: List[str],
+        edge_sql: List[str],
+    ) -> Projection:
+        """Create a projection and its node/edge queries (for import)."""
+        projection = projection_store.create(**projection_data)
+        if node_sql:
+            query_store.save_node_queries(
+                projection.id, [{"sql": sql} for sql in node_sql]
+            )
+        if edge_sql:
+            query_store.save_edge_queries(
+                projection.id, [{"sql": sql} for sql in edge_sql]
+            )
+        return projection
 
 
 # Singleton service instance

--- a/proxy/src/nx_neptune_proxy/services/projection_service.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_service.py
@@ -20,6 +20,7 @@ from typing import List, Optional
 
 from .projection_store import Projection, store as projection_store
 from .query_store import EdgeQuery, NodeQuery, query_store
+from .db import connection
 
 
 class ProjectionNotFound(Exception):
@@ -57,12 +58,15 @@ class ProjectionService:
         return projection_store.update(projection_id, **data)
 
     def delete(self, projection_id: str) -> bool:
-        """Delete a projection and its associated node/edge queries."""
-        # Remove child queries first so nothing is orphaned regardless of
-        # whether SQLite FK cascade is enabled.
-        query_store.save_node_queries(projection_id, [])
-        query_store.save_edge_queries(projection_id, [])
-        return projection_store.delete(projection_id)
+        """Delete a projection and its associated node/edge queries atomically.
+
+        All deletes run in a single transaction so a crash mid-sequence cannot
+        leave a partial state. Child queries are removed explicitly (rather than
+        relying solely on the ON DELETE CASCADE) as defense-in-depth.
+        """
+        with connection() as conn:
+            query_store.delete_node_and_edge_queries_on(conn, projection_id)
+            return projection_store.delete_on(conn, projection_id)
 
     # --- Queries (child of a projection) ---
 

--- a/proxy/src/nx_neptune_proxy/services/projection_store.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_store.py
@@ -146,6 +146,16 @@ class ProjectionStore:
             return cur.rowcount > 0
 
     @staticmethod
+    def delete_on(conn, projection_id: str) -> bool:
+        """Delete a projection row on an existing connection.
+
+        Runs on a caller-supplied connection so it can participate in a larger
+        transaction (e.g. deleting a projection and its queries atomically).
+        """
+        cur = conn.execute("DELETE FROM projections WHERE id = ?", (projection_id,))
+        return cur.rowcount > 0
+
+    @staticmethod
     def _row_to_projection(row) -> Projection:
         return Projection(
             id=row["id"],

--- a/proxy/src/nx_neptune_proxy/services/query_store.py
+++ b/proxy/src/nx_neptune_proxy/services/query_store.py
@@ -4,7 +4,7 @@
 import uuid
 from dataclasses import dataclass
 
-from .db import get_connection, query
+from .db import connection, query
 
 
 @dataclass
@@ -67,23 +67,21 @@ class QueryStore:
         self, projection_id: str, queries: list[dict]
     ) -> list[NodeQuery]:
         """Replace all node queries for a projection."""
-        conn = get_connection()
-        conn.execute(
-            "DELETE FROM node_queries WHERE projection_id = ?", (projection_id,)
-        )
-        results = []
-        for i, q in enumerate(queries):
-            qid = q.get("id") or str(uuid.uuid4())
-            sql = q.get("sql", "")
+        with connection() as conn:
             conn.execute(
-                "INSERT INTO node_queries (id, projection_id, sql, position) VALUES (?, ?, ?, ?)",
-                (qid, projection_id, sql, i),
+                "DELETE FROM node_queries WHERE projection_id = ?", (projection_id,)
             )
-            results.append(
-                NodeQuery(id=qid, projection_id=projection_id, sql=sql, position=i)
-            )
-        conn.commit()
-        conn.close()
+            results = []
+            for i, q in enumerate(queries):
+                qid = q.get("id") or str(uuid.uuid4())
+                sql = q.get("sql", "")
+                conn.execute(
+                    "INSERT INTO node_queries (id, projection_id, sql, position) VALUES (?, ?, ?, ?)",
+                    (qid, projection_id, sql, i),
+                )
+                results.append(
+                    NodeQuery(id=qid, projection_id=projection_id, sql=sql, position=i)
+                )
         return results
 
     def save_node_from_payload(self, projection_id: str, models: list) -> None:
@@ -107,23 +105,21 @@ class QueryStore:
         self, projection_id: str, queries: list[dict]
     ) -> list[EdgeQuery]:
         """Replace all edge queries for a projection."""
-        conn = get_connection()
-        conn.execute(
-            "DELETE FROM edge_queries WHERE projection_id = ?", (projection_id,)
-        )
-        results = []
-        for i, q in enumerate(queries):
-            qid = q.get("id") or str(uuid.uuid4())
-            sql = q.get("sql", "")
+        with connection() as conn:
             conn.execute(
-                "INSERT INTO edge_queries (id, projection_id, sql, position) VALUES (?, ?, ?, ?)",
-                (qid, projection_id, sql, i),
+                "DELETE FROM edge_queries WHERE projection_id = ?", (projection_id,)
             )
-            results.append(
-                EdgeQuery(id=qid, projection_id=projection_id, sql=sql, position=i)
-            )
-        conn.commit()
-        conn.close()
+            results = []
+            for i, q in enumerate(queries):
+                qid = q.get("id") or str(uuid.uuid4())
+                sql = q.get("sql", "")
+                conn.execute(
+                    "INSERT INTO edge_queries (id, projection_id, sql, position) VALUES (?, ?, ?, ?)",
+                    (qid, projection_id, sql, i),
+                )
+                results.append(
+                    EdgeQuery(id=qid, projection_id=projection_id, sql=sql, position=i)
+                )
         return results
 
     def save_edge_from_payload(self, projection_id: str, models: list) -> None:

--- a/proxy/src/nx_neptune_proxy/services/query_store.py
+++ b/proxy/src/nx_neptune_proxy/services/query_store.py
@@ -128,6 +128,22 @@ class QueryStore:
         """Variant that accepts Pydantic models directly (calls model_dump internally)."""
         self.save_edge_queries(projection_id, [m.model_dump() for m in models])
 
+    # --- Shared-transaction helpers ---
+
+    @staticmethod
+    def delete_node_and_edge_queries_on(conn, projection_id: str) -> None:
+        """Delete all node AND edge queries for a projection on an existing connection.
+
+        Runs on a caller-supplied connection so it can participate in a larger
+        transaction (e.g. deleting a projection and its queries atomically).
+        """
+        conn.execute(
+            "DELETE FROM node_queries WHERE projection_id = ?", (projection_id,)
+        )
+        conn.execute(
+            "DELETE FROM edge_queries WHERE projection_id = ?", (projection_id,)
+        )
+
 
 # Singleton
 query_store = QueryStore()

--- a/proxy/src/nx_neptune_proxy/services/query_store.py
+++ b/proxy/src/nx_neptune_proxy/services/query_store.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import uuid
+from dataclasses import dataclass
+
+from .db import get_connection, query
+
+
+@dataclass
+class NodeQuery:
+    id: str
+    projection_id: str
+    sql: str = ""
+    position: int = 0
+
+    @classmethod
+    def from_row(cls, row) -> "NodeQuery":
+        return cls(
+            id=row["id"],
+            projection_id=row["projection_id"],
+            sql=row["sql"],
+            position=row["position"],
+        )
+
+    def to_response(self) -> dict:
+        return {"id": self.id, "sql": self.sql, "position": self.position}
+
+
+@dataclass
+class EdgeQuery:
+    id: str
+    projection_id: str
+    sql: str = ""
+    position: int = 0
+
+    @classmethod
+    def from_row(cls, row) -> "EdgeQuery":
+        return cls(
+            id=row["id"],
+            projection_id=row["projection_id"],
+            sql=row["sql"],
+            position=row["position"],
+        )
+
+    def to_response(self) -> dict:
+        return {"id": self.id, "sql": self.sql, "position": self.position}
+
+
+class QueryStore:
+    """Manages node and edge queries for projections."""
+
+    # --- Node Queries ---
+
+    def list_node_queries(self, projection_id: str) -> list[NodeQuery]:
+        rows = query(
+            "SELECT * FROM node_queries WHERE projection_id = ? ORDER BY position",
+            (projection_id,),
+        )
+        return [NodeQuery.from_row(r) for r in rows]
+
+    def list_node_responses(self, projection_id: str) -> list[dict]:
+        """Same as list_node_queries but returns API-ready dicts (excludes projection_id)."""
+        return [q.to_response() for q in self.list_node_queries(projection_id)]
+
+    def save_node_queries(
+        self, projection_id: str, queries: list[dict]
+    ) -> list[NodeQuery]:
+        """Replace all node queries for a projection."""
+        conn = get_connection()
+        conn.execute(
+            "DELETE FROM node_queries WHERE projection_id = ?", (projection_id,)
+        )
+        results = []
+        for i, q in enumerate(queries):
+            qid = q.get("id") or str(uuid.uuid4())
+            sql = q.get("sql", "")
+            conn.execute(
+                "INSERT INTO node_queries (id, projection_id, sql, position) VALUES (?, ?, ?, ?)",
+                (qid, projection_id, sql, i),
+            )
+            results.append(
+                NodeQuery(id=qid, projection_id=projection_id, sql=sql, position=i)
+            )
+        conn.commit()
+        conn.close()
+        return results
+
+    def save_node_from_payload(self, projection_id: str, models: list) -> None:
+        """Variant that accepts Pydantic models directly (calls model_dump internally)."""
+        self.save_node_queries(projection_id, [m.model_dump() for m in models])
+
+    # --- Edge Queries ---
+
+    def list_edge_queries(self, projection_id: str) -> list[EdgeQuery]:
+        rows = query(
+            "SELECT * FROM edge_queries WHERE projection_id = ? ORDER BY position",
+            (projection_id,),
+        )
+        return [EdgeQuery.from_row(r) for r in rows]
+
+    def list_edge_responses(self, projection_id: str) -> list[dict]:
+        """Same as list_edge_queries but returns API-ready dicts (excludes projection_id)."""
+        return [q.to_response() for q in self.list_edge_queries(projection_id)]
+
+    def save_edge_queries(
+        self, projection_id: str, queries: list[dict]
+    ) -> list[EdgeQuery]:
+        """Replace all edge queries for a projection."""
+        conn = get_connection()
+        conn.execute(
+            "DELETE FROM edge_queries WHERE projection_id = ?", (projection_id,)
+        )
+        results = []
+        for i, q in enumerate(queries):
+            qid = q.get("id") or str(uuid.uuid4())
+            sql = q.get("sql", "")
+            conn.execute(
+                "INSERT INTO edge_queries (id, projection_id, sql, position) VALUES (?, ?, ?, ?)",
+                (qid, projection_id, sql, i),
+            )
+            results.append(
+                EdgeQuery(id=qid, projection_id=projection_id, sql=sql, position=i)
+            )
+        conn.commit()
+        conn.close()
+        return results
+
+    def save_edge_from_payload(self, projection_id: str, models: list) -> None:
+        """Variant that accepts Pydantic models directly (calls model_dump internally)."""
+        self.save_edge_queries(projection_id, [m.model_dump() for m in models])
+
+
+# Singleton
+query_store = QueryStore()

--- a/proxy/src/nx_neptune_proxy/services/query_store.py
+++ b/proxy/src/nx_neptune_proxy/services/query_store.py
@@ -4,7 +4,7 @@
 import uuid
 from dataclasses import dataclass
 
-from .db import connection, query
+from .db import connection
 
 
 @dataclass
@@ -53,10 +53,11 @@ class QueryStore:
     # --- Node Queries ---
 
     def list_node_queries(self, projection_id: str) -> list[NodeQuery]:
-        rows = query(
-            "SELECT * FROM node_queries WHERE projection_id = ? ORDER BY position",
-            (projection_id,),
-        )
+        with connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM node_queries WHERE projection_id = ? ORDER BY position",
+                (projection_id,),
+            ).fetchall()
         return [NodeQuery.from_row(r) for r in rows]
 
     def list_node_responses(self, projection_id: str) -> list[dict]:
@@ -91,10 +92,11 @@ class QueryStore:
     # --- Edge Queries ---
 
     def list_edge_queries(self, projection_id: str) -> list[EdgeQuery]:
-        rows = query(
-            "SELECT * FROM edge_queries WHERE projection_id = ? ORDER BY position",
-            (projection_id,),
-        )
+        with connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM edge_queries WHERE projection_id = ? ORDER BY position",
+                (projection_id,),
+            ).fetchall()
         return [EdgeQuery.from_row(r) for r in rows]
 
     def list_edge_responses(self, projection_id: str) -> list[dict]:

--- a/proxy/tests/conftest.py
+++ b/proxy/tests/conftest.py
@@ -6,7 +6,7 @@ from httpx import ASGITransport, AsyncClient
 
 from nx_neptune_proxy.app import app
 from nx_neptune_proxy.auth import get_token
-from nx_neptune_proxy.services.db import get_connection
+from nx_neptune_proxy.services.db import connection
 from nx_neptune_proxy.services.project_store import store as project_store
 
 
@@ -32,17 +32,13 @@ def bare_client():
 
 @pytest.fixture(autouse=True)
 def clear_store():
-    conn = get_connection()
-    conn.execute("DELETE FROM projections")
-    conn.execute("DELETE FROM projects")
-    conn.commit()
-    conn.close()
+    with connection() as conn:
+        conn.execute("DELETE FROM projections")
+        conn.execute("DELETE FROM projects")
     yield
-    conn = get_connection()
-    conn.execute("DELETE FROM projections")
-    conn.execute("DELETE FROM projects")
-    conn.commit()
-    conn.close()
+    with connection() as conn:
+        conn.execute("DELETE FROM projections")
+        conn.execute("DELETE FROM projects")
 
 
 @pytest.fixture

--- a/proxy/tests/test_graph_name_collision.py
+++ b/proxy/tests/test_graph_name_collision.py
@@ -19,8 +19,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from nx_neptune_proxy.services.pipeline import run_pipeline
-from nx_neptune_proxy.services.projection_store import store
 from nx_neptune_proxy.services.project_store import store as project_store
+from nx_neptune_proxy.services.projection_store import store
 
 # --- Schema validation (defense-in-depth) ---
 

--- a/proxy/tests/test_no_secrets.py
+++ b/proxy/tests/test_no_secrets.py
@@ -3,7 +3,7 @@
 
 """Absence of credentials or secrets in local storage."""
 
-from nx_neptune_proxy.services.db import get_connection
+from nx_neptune_proxy.services.db import connection
 from nx_neptune_proxy.services.projection_store import store
 
 
@@ -39,10 +39,9 @@ class TestNoSecretsInDb:
         )
 
         # Read the raw database content
-        conn = get_connection()
-        cursor = conn.execute("SELECT * FROM projections")
-        rows = cursor.fetchall()
-        conn.close()
+        with connection() as conn:
+            cursor = conn.execute("SELECT * FROM projections")
+            rows = cursor.fetchall()
 
         # Serialize all values to check for sensitive content
         all_values = []
@@ -70,11 +69,10 @@ class TestNoSecretsInDb:
             error="AccessDeniedException: User arn:aws:iam::123456789012:user/dev is not authorized",
         )
 
-        conn = get_connection()
-        row = conn.execute(
-            "SELECT error FROM projections WHERE id = ?", (p.id,)
-        ).fetchone()
-        conn.close()
+        with connection() as conn:
+            row = conn.execute(
+                "SELECT error FROM projections WHERE id = ?", (p.id,)
+            ).fetchone()
 
         error_text = row["error"].lower()
         for pattern in self.SENSITIVE_PATTERNS:

--- a/proxy/tests/test_project_io.py
+++ b/proxy/tests/test_project_io.py
@@ -7,6 +7,7 @@ import pytest
 
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store as projection_store
+from nx_neptune_proxy.services.query_store import query_store
 
 
 class TestProjectExport:
@@ -159,18 +160,32 @@ class TestRoundTrip:
     async def test_export_then_import(self, client):
         """Export a project, then import it — should recreate correctly."""
         p = project_store.create(name="Round Trip")
-        projection_store.create(
+        pr = projection_store.create(
             database="rt_db",
             node_query="SELECT 1",
             graph_name="nxp-roundtrip",
             graph_memory_gb=64,
             project_id=p.id,
         )
+        query_store.save_node_queries(
+            pr.id, [{"sql": "SELECT id FROM nodes"}, {"sql": "SELECT id FROM users"}]
+        )
+        query_store.save_edge_queries(pr.id, [{"sql": "SELECT src, dst FROM edges"}])
 
         # Export
         export_resp = await client.get(f"/api/v0/project/{p.id}/export")
         assert export_resp.status_code == 200
         export_data = export_resp.content
+
+        # Verify queries in export
+        export_json = export_resp.json()
+        assert export_json["projections"][0]["node_queries"] == [
+            "SELECT id FROM nodes",
+            "SELECT id FROM users",
+        ]
+        assert export_json["projections"][0]["edge_queries"] == [
+            "SELECT src, dst FROM edges"
+        ]
 
         # Import
         import_resp = await client.post(
@@ -194,6 +209,15 @@ class TestRoundTrip:
         assert projections[0].database == "rt_db"
         assert projections[0].graph_name == "nxp-roundtrip"
         assert projections[0].graph_memory_gb == 64
+
+        # Imported queries should match
+        imported_node_queries = query_store.list_node_queries(projections[0].id)
+        imported_edge_queries = query_store.list_edge_queries(projections[0].id)
+        assert len(imported_node_queries) == 2
+        assert imported_node_queries[0].sql == "SELECT id FROM nodes"
+        assert imported_node_queries[1].sql == "SELECT id FROM users"
+        assert len(imported_edge_queries) == 1
+        assert imported_edge_queries[0].sql == "SELECT src, dst FROM edges"
 
 
 # --- Additional validation tests ---

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -98,15 +98,13 @@ async def test_update_projection(client):
     resp = await client.put(
         f"/api/v0/projection/{pid}",
         json={
-            "node_query": "SELECT id FROM t",
-            "edge_query": "SELECT src, dst FROM edges",
+            "database": "updated_db",
+            "graph_name": "updated-graph",
         },
     )
     assert resp.status_code == 200
-    assert resp.json()["node_query"] == "SELECT id FROM t"
-    assert resp.json()["edge_query"] == "SELECT src, dst FROM edges"
-    # Other fields unchanged
-    assert resp.json()["database"] == "mydb"
+    assert resp.json()["database"] == "updated_db"
+    assert resp.json()["graph_name"] == "updated-graph"
 
 
 @pytest.mark.asyncio
@@ -183,6 +181,15 @@ async def test_validate_query(mock_check, client):
     create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
 
+    # Queries live in the multi-query store, not on the projection record.
+    await client.put(
+        f"/api/v0/projection/{pid}/queries",
+        json={
+            "node_queries": [{"sql": "SELECT id FROM nodes"}],
+            "edge_queries": [{"sql": "SELECT src, dst FROM edges"}],
+        },
+    )
+
     resp = await client.post(f"/api/v0/projection/{pid}/validate-query")
     assert resp.status_code == 200
     assert resp.json()["valid"] is True
@@ -206,6 +213,15 @@ async def test_preview(mock_cf, mock_wait, mock_results, client):
 
     create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
     pid = create_resp.json()["id"]
+
+    # Queries live in the multi-query store, not on the projection record.
+    await client.put(
+        f"/api/v0/projection/{pid}/queries",
+        json={
+            "node_queries": [{"sql": "SELECT id, name FROM nodes"}],
+            "edge_queries": [],
+        },
+    )
 
     resp = await client.post(f"/api/v0/projection/{pid}/preview")
     assert resp.status_code == 200
@@ -292,3 +308,78 @@ async def test_execute_poll_lifecycle(client):
     assert resp.json()["status"] == "complete"
     assert resp.json()["progress"] == 100
     assert resp.json()["graph_endpoint"] == "https://g-123.neptune-graph.amazonaws.com"
+
+
+# --- Queries endpoints ---
+
+
+@pytest.mark.asyncio
+async def test_get_queries_not_found(client):
+    resp = await client.get("/api/v0/projection/nonexistent/queries")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_save_queries_not_found(client):
+    resp = await client.put(
+        "/api/v0/projection/nonexistent/queries",
+        json={
+            "node_queries": [{"sql": "SELECT 1"}],
+            "edge_queries": [],
+        },
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_save_and_get_queries(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
+    pid = create_resp.json()["id"]
+
+    save_resp = await client.put(
+        f"/api/v0/projection/{pid}/queries",
+        json={
+            "node_queries": [
+                {"sql": "SELECT id FROM nodes"},
+                {"sql": "SELECT id FROM users"},
+            ],
+            "edge_queries": [{"sql": "SELECT src, dst FROM edges"}],
+        },
+    )
+    assert save_resp.status_code == 200
+    data = save_resp.json()
+    assert len(data["node_queries"]) == 2
+    assert len(data["edge_queries"]) == 1
+    assert data["node_queries"][0]["sql"] == "SELECT id FROM nodes"
+    assert data["node_queries"][1]["position"] == 1
+
+    get_resp = await client.get(f"/api/v0/projection/{pid}/queries")
+    assert get_resp.status_code == 200
+    assert get_resp.json() == data
+
+
+@pytest.mark.asyncio
+async def test_save_queries_replaces_previous(client):
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
+    pid = create_resp.json()["id"]
+
+    await client.put(
+        f"/api/v0/projection/{pid}/queries",
+        json={
+            "node_queries": [{"sql": "old query 1"}, {"sql": "old query 2"}],
+            "edge_queries": [],
+        },
+    )
+
+    await client.put(
+        f"/api/v0/projection/{pid}/queries",
+        json={
+            "node_queries": [{"sql": "new query only"}],
+            "edge_queries": [],
+        },
+    )
+
+    get_resp = await client.get(f"/api/v0/projection/{pid}/queries")
+    data = get_resp.json()
+    assert len(data["node_queries"]) == 1
+    assert data["node_queries"][0]["sql"] == "new query only"

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -8,7 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from nx_neptune_proxy.app import app
 from nx_neptune_proxy.auth import get_token
-from nx_neptune_proxy.services.db import get_connection
+from nx_neptune_proxy.services.db import connection
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store
 
@@ -28,21 +28,17 @@ def client():
 
 @pytest.fixture(autouse=True)
 def clear_store():
-    conn = get_connection()
-    conn.execute("DELETE FROM projections")
-    conn.execute("DELETE FROM projects")
-    conn.commit()
-    conn.close()
+    with connection() as conn:
+        conn.execute("DELETE FROM projections")
+        conn.execute("DELETE FROM projects")
     # Create a default project for tests
     p = project_store.create(name="Test Project")
     global _TEST_PROJECT_ID
     _TEST_PROJECT_ID = p.id
     yield
-    conn = get_connection()
-    conn.execute("DELETE FROM projections")
-    conn.execute("DELETE FROM projects")
-    conn.commit()
-    conn.close()
+    with connection() as conn:
+        conn.execute("DELETE FROM projections")
+        conn.execute("DELETE FROM projects")
 
 
 _TEST_PROJECT_ID = ""

--- a/proxy/tests/test_projection.py
+++ b/proxy/tests/test_projection.py
@@ -379,3 +379,98 @@ async def test_save_queries_replaces_previous(client):
     data = get_resp.json()
     assert len(data["node_queries"]) == 1
     assert data["node_queries"][0]["sql"] == "new query only"
+
+
+# --- Delete clears queries (regression) ---
+
+
+@pytest.mark.asyncio
+async def test_delete_projection_clears_queries(client):
+    """Deleting a projection must remove its node/edge queries (no orphans)."""
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
+    pid = create_resp.json()["id"]
+
+    await client.put(
+        f"/api/v0/projection/{pid}/queries",
+        json={
+            "node_queries": [{"sql": "SELECT id FROM nodes"}],
+            "edge_queries": [{"sql": "SELECT src, dst FROM edges"}],
+        },
+    )
+
+    # Sanity: rows exist before delete.
+    with connection() as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) AS c FROM node_queries WHERE projection_id = ?",
+                (pid,),
+            ).fetchone()["c"]
+            == 1
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) AS c FROM edge_queries WHERE projection_id = ?",
+                (pid,),
+            ).fetchone()["c"]
+            == 1
+        )
+
+    del_resp = await client.delete(f"/api/v0/projection/{pid}")
+    assert del_resp.status_code == 200
+    assert del_resp.json()["status"] == "deleted"
+
+    # No orphaned query rows remain after the projection is gone.
+    with connection() as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) AS c FROM node_queries WHERE projection_id = ?",
+                (pid,),
+            ).fetchone()["c"]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) AS c FROM edge_queries WHERE projection_id = ?",
+                (pid,),
+            ).fetchone()["c"]
+            == 0
+        )
+
+
+@pytest.mark.asyncio
+async def test_fk_cascade_backstop_clears_queries(client):
+    """Deleting the projection row directly must cascade to query rows.
+
+    Guards the ``PRAGMA foreign_keys = ON`` + ``ON DELETE CASCADE`` backstop so
+    a future direct deletion path can't silently re-orphan query rows.
+    """
+    create_resp = await client.post("/api/v0/projection", json=SAMPLE_BODY())
+    pid = create_resp.json()["id"]
+
+    await client.put(
+        f"/api/v0/projection/{pid}/queries",
+        json={
+            "node_queries": [{"sql": "SELECT id FROM nodes"}],
+            "edge_queries": [{"sql": "SELECT src, dst FROM edges"}],
+        },
+    )
+
+    # Delete only the projection row — rely on the FK cascade, not the service.
+    with connection() as conn:
+        conn.execute("DELETE FROM projections WHERE id = ?", (pid,))
+
+    with connection() as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) AS c FROM node_queries WHERE projection_id = ?",
+                (pid,),
+            ).fetchone()["c"]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) AS c FROM edge_queries WHERE projection_id = ?",
+                (pid,),
+            ).fetchone()["c"]
+            == 0
+        )

--- a/proxy/tests/test_sql_injection.py
+++ b/proxy/tests/test_sql_injection.py
@@ -4,6 +4,7 @@
 """SQL injection resistance via parameterized queries."""
 
 from nx_neptune_proxy.services.projection_store import store
+from nx_neptune_proxy.services.query_store import query_store
 
 
 class TestSqlInjection:
@@ -61,3 +62,24 @@ class TestSqlInjection:
         retrieved = store.get(p.id)
         assert retrieved is not None
         assert retrieved.graph_name == payload
+
+    def test_injection_in_edge_query_field(self, test_project_id):
+        payload = "SELECT * FROM t; DROP TABLE edge_queries;--"
+        p = store.create(
+            database="testdb", graph_name="test", project_id=test_project_id
+        )
+        query_store.save_edge_queries(p.id, [{"sql": payload}])
+        retrieved = query_store.list_edge_queries(p.id)
+        assert len(retrieved) == 1
+        assert retrieved[0].sql == payload
+
+    def test_query_isolation_across_projections(self, test_project_id):
+        """Queries saved to one projection must not leak to another."""
+        p1 = store.create(database="db1", graph_name="g1", project_id=test_project_id)
+        p2 = store.create(database="db2", graph_name="g2", project_id=test_project_id)
+        query_store.save_node_queries(p1.id, [{"sql": "SELECT secret FROM p1"}])
+        query_store.save_node_queries(p2.id, [{"sql": "SELECT public FROM p2"}])
+        assert len(query_store.list_node_queries(p1.id)) == 1
+        assert query_store.list_node_queries(p1.id)[0].sql == "SELECT secret FROM p1"
+        assert len(query_store.list_node_queries(p2.id)) == 1
+        assert query_store.list_node_queries(p2.id)[0].sql == "SELECT public FROM p2"

--- a/proxy/ui-src/src/api/index.ts
+++ b/proxy/ui-src/src/api/index.ts
@@ -74,8 +74,6 @@ export interface Projection {
   status: string;
   catalog: string;
   database?: string;
-  node_query?: string;
-  edge_query?: string;
   graph_name?: string;
   graph_id?: string;
   graph_endpoint?: string;
@@ -109,9 +107,45 @@ export const projection = {
   validateQuery: (id: string) => request<{ valid: boolean; checks: { check: string; passed: boolean; message?: string }[] }>(`/projection/${id}/validate-query`, { method: "POST" }),
   preview: (id: string, limit = 10) => request<{ error?: string; results: { columns: string[]; rows: string[][] }[] }>(`/projection/${id}/preview?limit=${limit}`, { method: "POST" }),
   execute: (id: string) => request<{ message: string }>(`/projection/${id}/execute`, { method: "POST" }),
+  getQueries: (id: string) => request<QueriesResponse>(`/projection/${id}/queries`),
+  saveQueries: (id: string, data: QueriesPayload) => request<QueriesResponse>(`/projection/${id}/queries`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(data) }),
   delete: (id: string) => request<{ id: string; status: string }>(`/projection/${id}`, { method: "DELETE" }),
   deleteGraph: (id: string) => request<{ id: string; status: string }>(`/projection/${id}/delete-graph`, { method: "POST" }),
 };
+
+// --- Multi-Query ---
+
+export interface NodeQueryInput {
+  id?: string;
+  sql: string;
+}
+
+export interface EdgeQueryInput {
+  id?: string;
+  sql: string;
+}
+
+export interface NodeQueryResponse {
+  id: string;
+  sql: string;
+  position: number;
+}
+
+export interface EdgeQueryResponse {
+  id: string;
+  sql: string;
+  position: number;
+}
+
+export interface QueriesPayload {
+  node_queries: NodeQueryInput[];
+  edge_queries: EdgeQueryInput[];
+}
+
+export interface QueriesResponse {
+  node_queries: NodeQueryResponse[];
+  edge_queries: EdgeQueryResponse[];
+}
 
 // --- Project ---
 

--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useSearchParams } from "react-router";
-import { metadata, projection, projectApi, type Projection, type ProjectionStatus, type Project } from "../api";
+import { metadata, projection, projectApi, type Projection, type ProjectionStatus, type Project, type NodeQueryInput, type EdgeQueryInput } from "../api";
 import { Button, Select, ProgressBar, Card, RefreshButton } from "../components/ui";
-import { Play, CheckCircle, Eye } from "lucide-react";
+import { Play, CheckCircle, Eye, Plus, Trash2 } from "lucide-react";
 
 export function Import() {
   const [searchParams] = useSearchParams();
@@ -20,11 +20,13 @@ export function Import() {
   // --- Form state ---
   const [catalog, setCatalog] = useState("AwsDataCatalog");
   const [database, setDatabase] = useState("");
-  const [nodeQuery, setNodeQuery] = useState("");
-  const [edgeQuery, setEdgeQuery] = useState("");
   const [bucket, setBucket] = useState("");
   const [graphName, setGraphName] = useState("");
   const [graphMemoryGb, setGraphMemoryGb] = useState(16);
+
+  // --- Multi-query state ---
+  const [nodeQueries, setNodeQueries] = useState<NodeQueryInput[]>([{ sql: "" }]);
+  const [edgeQueries, setEdgeQueries] = useState<EdgeQueryInput[]>([{ sql: "" }]);
 
   // --- Projection state ---
   const [projectionsList, setProjectionsList] = useState<Projection[]>([]);
@@ -59,19 +61,7 @@ export function Import() {
     if (wsParam) {
       setProjectId(wsParam);
       if (!projectionId) {
-        setCurrentId(null);
-        setStatus(null);
-        setPolling(false);
-        setChecks([]);
-        setPreview(null);
-        setError(null);
-        setCatalog("AwsDataCatalog");
-        setDatabase("");
-        setNodeQuery("");
-        setEdgeQuery("");
-        setBucket("");
-        setGraphName("");
-        setGraphMemoryGb(16);
+        resetForm();
       }
     }
     if (projectionId) {
@@ -84,21 +74,97 @@ export function Import() {
     metadata.databases(catalog).then((d) => { setDatabases(d.databases); setDbLoading(false); });
   }, [catalog]);
 
+  function resetForm() {
+    setCurrentId(null);
+    setStatus(null);
+    setPolling(false);
+    setChecks([]);
+    setPreview(null);
+    setError(null);
+    setCatalog("AwsDataCatalog");
+    setDatabase("");
+    setNodeQueries([{ sql: "" }]);
+    setEdgeQueries([{ sql: "" }]);
+    setBucket("");
+    setGraphName("");
+    setGraphMemoryGb(16);
+  }
+
   async function loadProjections() {
     const list = await projection.list();
     setProjectionsList(list);
   }
 
   // --- Projection management ---
+
+  // Auto-create projection once user starts filling the form
+  useEffect(() => {
+    if (currentId) return;
+    const hasContent = database || bucket || graphName || nodeQueries.some(q => q.sql.trim()) || edgeQueries.some(q => q.sql.trim());
+    if (!hasContent) return;
+    projection.create({
+      catalog,
+      database,
+      s3_staging_bucket: bucket,
+      graph_name: graphName,
+      graph_memory_gb: graphMemoryGb,
+      project_id: projectId || undefined,
+    }).then((p) => {
+      setCurrentId(p.id);
+      loadProjections();
+      window.dispatchEvent(new Event("projects-changed"));
+    });
+  }, [database, bucket, graphName, nodeQueries, edgeQueries]);
+
+  // Auto-create projection once user starts filling the form, then auto-save config on changes
+  const configTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const hasContent = database || bucket || graphName || nodeQueries.some(q => q.sql.trim()) || edgeQueries.some(q => q.sql.trim());
+    if (!hasContent) return;
+
+    const data = {
+      catalog,
+      database,
+      s3_staging_bucket: bucket,
+      graph_name: graphName,
+      graph_memory_gb: graphMemoryGb,
+      project_id: projectId || undefined,
+    };
+
+    if (!currentId) {
+      // First time — create
+      projection.create(data).then((p) => {
+        setCurrentId(p.id);
+        loadProjections();
+        window.dispatchEvent(new Event("projects-changed"));
+      });
+    } else {
+      // Subsequent changes — debounced update
+      if (configTimer.current) clearTimeout(configTimer.current);
+      configTimer.current = setTimeout(() => {
+        projection.update(currentId, data);
+      }, 1000);
+    }
+  }, [catalog, database, bucket, graphName, graphMemoryGb, projectId]);
+
   async function ensureProjection(): Promise<string> {
-    if (!projectId) throw new Error("Please select a project first");
-    const data = { catalog, database, node_query: nodeQuery || undefined, edge_query: edgeQuery || undefined, s3_staging_bucket: bucket, graph_name: graphName, graph_memory_gb: graphMemoryGb, project_id: projectId };
+    const data = {
+      catalog,
+      database,
+      s3_staging_bucket: bucket,
+      graph_name: graphName,
+      graph_memory_gb: graphMemoryGb,
+      project_id: projectId || undefined,
+    };
     if (currentId) {
       await projection.update(currentId, data);
+      await projection.saveQueries(currentId, { node_queries: nodeQueries, edge_queries: edgeQueries });
       return currentId;
     }
     const p = await projection.create(data);
     setCurrentId(p.id);
+    await projection.saveQueries(p.id, { node_queries: nodeQueries, edge_queries: edgeQueries });
     await loadProjections();
     window.dispatchEvent(new Event("projects-changed"));
     return p.id;
@@ -106,17 +172,23 @@ export function Import() {
 
   function loadProjection(p: Projection) {
     setCurrentId(p.id);
-    if (p.project_id) setProjectId(p.project_id);
     if (p.catalog) setCatalog(p.catalog);
     if (p.database) setDatabase(p.database);
-    if (p.node_query) setNodeQuery(p.node_query);
-    if (p.edge_query) setEdgeQuery(p.edge_query);
     if (p.s3_staging_bucket) setBucket(p.s3_staging_bucket);
     if (p.graph_name) setGraphName(p.graph_name);
     if (p.graph_memory_gb) setGraphMemoryGb(p.graph_memory_gb);
     setChecks([]);
     setPreview(null);
     setError(null);
+
+    // Load multi-queries
+    projection.getQueries(p.id).then((res) => {
+      if (res.node_queries.length > 0) setNodeQueries(res.node_queries.map((q) => ({ id: q.id, sql: q.sql })));
+      else setNodeQueries([{ sql: "" }]);
+
+      if (res.edge_queries.length > 0) setEdgeQueries(res.edge_queries.map((q) => ({ id: q.id, sql: q.sql })));
+      else setEdgeQueries([{ sql: "" }]);
+    });
 
     if (p.status === "executing") startPolling(p.id);
     else if (p.status === "complete") {
@@ -125,6 +197,50 @@ export function Import() {
       setStatus(null);
       setPolling(false);
     }
+  }
+
+  // --- Query management ---
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function saveCurrentQueries() {
+    if (!currentId) return;
+    projection.saveQueries(currentId, { node_queries: nodeQueries, edge_queries: edgeQueries });
+  }
+
+  function scheduleSave(nq: NodeQueryInput[], eq: EdgeQueryInput[]) {
+    if (!currentId) return;
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      projection.saveQueries(currentId, { node_queries: nq, edge_queries: eq });
+    }, 1000);
+  }
+
+  function updateNodeQuery(index: number, sql: string) {
+    const updated = nodeQueries.map((q, i) => (i === index ? { ...q, sql } : q));
+    setNodeQueries(updated);
+    scheduleSave(updated, edgeQueries);
+  }
+  function addNodeQuery() {
+    setNodeQueries((prev) => [...prev, { sql: "" }]);
+  }
+  function removeNodeQuery(index: number) {
+    const updated = nodeQueries.filter((_, i) => i !== index);
+    setNodeQueries(updated);
+    if (currentId) projection.saveQueries(currentId, { node_queries: updated, edge_queries: edgeQueries });
+  }
+
+  function updateEdgeQuery(index: number, updates: Partial<EdgeQueryInput>) {
+    const updated = edgeQueries.map((q, i) => (i === index ? { ...q, ...updates } : q));
+    setEdgeQueries(updated);
+    scheduleSave(nodeQueries, updated);
+  }
+  function addEdgeQuery() {
+    setEdgeQueries((prev) => [...prev, { sql: "" }]);
+  }
+  function removeEdgeQuery(index: number) {
+    const updated = edgeQueries.filter((_, i) => i !== index);
+    setEdgeQueries(updated);
+    if (currentId) projection.saveQueries(currentId, { node_queries: nodeQueries, edge_queries: updated });
   }
 
   // --- Actions ---
@@ -231,26 +347,29 @@ export function Import() {
               </Select>
             </label>
           <label className="block space-y-1">
-              <span className="text-sm font-medium text-gray-700">Copy config from</span>
-              <Select
-                value=""
-                onChange={(e) => {
-                  const s = projectionsList.find((s) => s.id === e.target.value);
-                  if (!s) return;
-                  if (s.catalog) setCatalog(s.catalog);
-                  if (s.database) setDatabase(s.database);
-                  if (s.node_query) setNodeQuery(s.node_query);
-                  if (s.edge_query) setEdgeQuery(s.edge_query);
-                  if (s.s3_staging_bucket) setBucket(s.s3_staging_bucket);
-                  if (s.graph_memory_gb) setGraphMemoryGb(s.graph_memory_gb);
-                }}
-              >
-                <option value="">Select a projection...</option>
-                {(projectId ? projectionsList.filter(s => s.project_id === projectId) : projectionsList).map((s) => (
-                  <option key={s.id} value={s.id}>{s.graph_name || s.id.slice(0, 8)}</option>
-                ))}
-              </Select>
-            </label>
+            <span className="text-sm font-medium text-gray-700">Copy config from</span>
+            <Select
+              value=""
+              onChange={(e) => {
+                const s = projectionsList.find((s) => s.id === e.target.value);
+                if (!s) return;
+                if (s.catalog) setCatalog(s.catalog);
+                if (s.database) setDatabase(s.database);
+                if (s.s3_staging_bucket) setBucket(s.s3_staging_bucket);
+                if (s.graph_memory_gb) setGraphMemoryGb(s.graph_memory_gb);
+                // Load queries from source projection
+                projection.getQueries(s.id).then((res) => {
+                  if (res.node_queries.length > 0) setNodeQueries(res.node_queries.map((q) => ({ sql: q.sql })));
+                  if (res.edge_queries.length > 0) setEdgeQueries(res.edge_queries.map((q) => ({ sql: q.sql })));
+                });
+              }}
+            >
+              <option value="">Select a projection...</option>
+              {(projectId ? projectionsList.filter(s => s.project_id === projectId) : projectionsList).map((s) => (
+                <option key={s.id} value={s.id}>{s.graph_name || s.id.slice(0, 8)}</option>
+              ))}
+            </Select>
+          </label>
           <div className="grid grid-cols-2 gap-4">
             <label className="space-y-1">
               <span className="text-sm font-medium text-gray-700">Catalog</span>
@@ -266,29 +385,6 @@ export function Import() {
               </Select>
             </label>
           </div>
-
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-gray-700">Node Query</span>
-            <textarea
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm font-mono shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              rows={3}
-              placeholder="SELECT ~id, ~label, col1, col2 FROM nodes_table"
-              value={nodeQuery}
-              onChange={(e) => setNodeQuery(e.target.value)}
-            />
-          </label>
-
-          <label className="block space-y-1">
-            <span className="text-sm font-medium text-gray-700">Edge Query</span>
-            <textarea
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm font-mono shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              rows={3}
-              placeholder="SELECT ~id, ~from, ~to, ~label FROM edges_table"
-              value={edgeQuery}
-              onChange={(e) => setEdgeQuery(e.target.value)}
-            />
-          </label>
-
           <div className="grid grid-cols-3 gap-4">
             <label className="space-y-1">
               <span className="text-sm font-medium text-gray-700">S3 Staging Bucket</span>
@@ -315,6 +411,70 @@ export function Import() {
               />
             </label>
           </div>
+        </div>
+      </Card>
+
+      {/* Node Queries */}
+      <Card>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold">Node Queries</h2>
+            <button onClick={addNodeQuery} className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800">
+              <Plus className="h-3 w-3" /> Add
+            </button>
+          </div>
+          {nodeQueries.map((nq, i) => (
+            <div key={i} className="rounded-md border border-gray-200 overflow-hidden">
+              <div className="flex items-center justify-between bg-gray-50 px-3 py-1.5 border-b border-gray-200">
+                <span className="text-xs font-medium text-gray-700">Node {i + 1}</span>
+                {nodeQueries.length > 1 && (
+                  <button onClick={() => removeNodeQuery(i)} className="text-gray-400 hover:text-red-600">
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+              <textarea
+                className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
+                rows={3}
+                placeholder="SELECT id AS &quot;~id&quot;, 'Label' AS &quot;~label&quot;, col1 FROM table"
+                value={nq.sql}
+                onChange={(e) => updateNodeQuery(i, e.target.value)}
+                onBlur={() => saveCurrentQueries()}
+              />
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      {/* Edge Queries */}
+      <Card>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold">Edge Queries</h2>
+            <button onClick={addEdgeQuery} className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800">
+              <Plus className="h-3 w-3" /> Add
+            </button>
+          </div>
+          {edgeQueries.map((eq, i) => (
+            <div key={i} className="rounded-md border border-gray-200 overflow-hidden">
+              <div className="flex items-center justify-between bg-gray-50 px-3 py-1.5 border-b border-gray-200">
+                <span className="text-xs font-medium text-gray-700">Edge {i + 1}</span>
+                {edgeQueries.length > 1 && (
+                  <button onClick={() => removeEdgeQuery(i)} className="text-gray-400 hover:text-red-600">
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+              <textarea
+                className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
+                rows={3}
+                placeholder="SELECT id AS &quot;~id&quot;, src AS &quot;~from&quot;, dst AS &quot;~to&quot;, 'Label' AS &quot;~label&quot; FROM table"
+                value={eq.sql}
+                onChange={(e) => updateEdgeQuery(i, { sql: e.target.value })}
+                onBlur={() => saveCurrentQueries()}
+              />
+            </div>
+          ))}
         </div>
       </Card>
 
@@ -345,25 +505,29 @@ export function Import() {
       {/* Preview */}
       {preview && (
         <div className="space-y-4">
-          {preview.map((result, i) => (
-            <Card key={i}>
-              <h2 className="mb-2 text-sm font-medium">{i === 0 ? "Node Preview" : "Edge Preview"}</h2>
-              <div className="overflow-auto">
-                <table className="w-full text-left text-sm">
-                  <thead className="border-b bg-gray-50">
-                    <tr>{result.columns.map((col) => <th key={col} className="px-3 py-2 font-medium">{col}</th>)}</tr>
-                  </thead>
-                  <tbody>
-                    {result.rows.map((row, ri) => (
-                      <tr key={ri} className="border-b last:border-0">
-                        {row.map((cell, ci) => <td key={ci} className="px-3 py-2">{cell}</td>)}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </Card>
-          ))}
+          {preview.map((result, i) => {
+            const activeNodeCount = nodeQueries.filter(q => q.sql.trim()).length;
+            const isNode = i < activeNodeCount;
+            return (
+              <Card key={i}>
+                <h2 className="mb-2 text-sm font-medium">{isNode ? `Node ${i + 1}` : `Edge ${i - activeNodeCount + 1}`} Preview</h2>
+                <div className="overflow-auto">
+                  <table className="w-full text-left text-sm">
+                    <thead className="border-b bg-gray-50">
+                      <tr>{result.columns.map((col) => <th key={col} className="px-3 py-2 font-medium">{col}</th>)}</tr>
+                    </thead>
+                    <tbody>
+                      {result.rows.map((row, ri) => (
+                        <tr key={ri} className="border-b last:border-0">
+                          {row.map((cell, ci) => <td key={ci} className="px-3 py-2">{cell}</td>)}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </Card>
+            );
+          })}
         </div>
       )}
 

--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -435,7 +435,7 @@ export function Import() {
                   )}
                 </div>
                 <textarea
-                  className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
+                  className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-y"
                   rows={3}
                   placeholder="SELECT id AS &quot;~id&quot;, 'Label' AS &quot;~label&quot;, col1 FROM table"
                   value={nq.sql}
@@ -469,7 +469,7 @@ export function Import() {
                   )}
                 </div>
                 <textarea
-                  className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
+                  className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-y"
                   rows={3}
                   placeholder="SELECT id AS &quot;~id&quot;, src AS &quot;~from&quot;, dst AS &quot;~to&quot;, 'Label' AS &quot;~label&quot; FROM table"
                   value={eq.sql}

--- a/proxy/ui-src/src/pages/Import.tsx
+++ b/proxy/ui-src/src/pages/Import.tsx
@@ -423,26 +423,28 @@ export function Import() {
               <Plus className="h-3 w-3" /> Add
             </button>
           </div>
-          {nodeQueries.map((nq, i) => (
-            <div key={i} className="rounded-md border border-gray-200 overflow-hidden">
-              <div className="flex items-center justify-between bg-gray-50 px-3 py-1.5 border-b border-gray-200">
-                <span className="text-xs font-medium text-gray-700">Node {i + 1}</span>
-                {nodeQueries.length > 1 && (
-                  <button onClick={() => removeNodeQuery(i)} className="text-gray-400 hover:text-red-600">
-                    <Trash2 className="h-3 w-3" />
-                  </button>
-                )}
+          <div className="max-h-72 space-y-3 overflow-y-auto pr-1">
+            {nodeQueries.map((nq, i) => (
+              <div key={i} className="rounded-md border border-gray-200 overflow-hidden">
+                <div className="flex items-center justify-between bg-gray-50 px-3 py-1.5 border-b border-gray-200">
+                  <span className="text-xs font-medium text-gray-700">Node {i + 1}</span>
+                  {nodeQueries.length > 1 && (
+                    <button onClick={() => removeNodeQuery(i)} className="text-gray-400 hover:text-red-600">
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  )}
+                </div>
+                <textarea
+                  className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
+                  rows={3}
+                  placeholder="SELECT id AS &quot;~id&quot;, 'Label' AS &quot;~label&quot;, col1 FROM table"
+                  value={nq.sql}
+                  onChange={(e) => updateNodeQuery(i, e.target.value)}
+                  onBlur={() => saveCurrentQueries()}
+                />
               </div>
-              <textarea
-                className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
-                rows={3}
-                placeholder="SELECT id AS &quot;~id&quot;, 'Label' AS &quot;~label&quot;, col1 FROM table"
-                value={nq.sql}
-                onChange={(e) => updateNodeQuery(i, e.target.value)}
-                onBlur={() => saveCurrentQueries()}
-              />
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </Card>
 
@@ -455,26 +457,28 @@ export function Import() {
               <Plus className="h-3 w-3" /> Add
             </button>
           </div>
-          {edgeQueries.map((eq, i) => (
-            <div key={i} className="rounded-md border border-gray-200 overflow-hidden">
-              <div className="flex items-center justify-between bg-gray-50 px-3 py-1.5 border-b border-gray-200">
-                <span className="text-xs font-medium text-gray-700">Edge {i + 1}</span>
-                {edgeQueries.length > 1 && (
-                  <button onClick={() => removeEdgeQuery(i)} className="text-gray-400 hover:text-red-600">
-                    <Trash2 className="h-3 w-3" />
-                  </button>
-                )}
+          <div className="max-h-72 space-y-3 overflow-y-auto pr-1">
+            {edgeQueries.map((eq, i) => (
+              <div key={i} className="rounded-md border border-gray-200 overflow-hidden">
+                <div className="flex items-center justify-between bg-gray-50 px-3 py-1.5 border-b border-gray-200">
+                  <span className="text-xs font-medium text-gray-700">Edge {i + 1}</span>
+                  {edgeQueries.length > 1 && (
+                    <button onClick={() => removeEdgeQuery(i)} className="text-gray-400 hover:text-red-600">
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  )}
+                </div>
+                <textarea
+                  className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
+                  rows={3}
+                  placeholder="SELECT id AS &quot;~id&quot;, src AS &quot;~from&quot;, dst AS &quot;~to&quot;, 'Label' AS &quot;~label&quot; FROM table"
+                  value={eq.sql}
+                  onChange={(e) => updateEdgeQuery(i, { sql: e.target.value })}
+                  onBlur={() => saveCurrentQueries()}
+                />
               </div>
-              <textarea
-                className="w-full px-3 py-2 text-sm font-mono border-0 focus:ring-0 resize-none"
-                rows={3}
-                placeholder="SELECT id AS &quot;~id&quot;, src AS &quot;~from&quot;, dst AS &quot;~to&quot;, 'Label' AS &quot;~label&quot; FROM table"
-                value={eq.sql}
-                onChange={(e) => updateEdgeQuery(i, { sql: e.target.value })}
-                onBlur={() => saveCurrentQueries()}
-              />
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </Card>
 

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -431,14 +431,6 @@ export function Projections() {
             {selected.project_id && <div><span className="text-gray-500">Project:</span> {projects.get(selected.project_id)?.name || selected.project_id}</div>}
             <div><span className="text-gray-500">Catalog:</span> {selected.catalog || "—"}</div>
             <div><span className="text-gray-500">Database:</span> {selected.database || "—"}</div>
-            <div>
-              <span className="text-gray-500">Node Query:</span>
-              <pre className="mt-1 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs">{selected.node_query || "—"}</pre>
-            </div>
-            <div>
-              <span className="text-gray-500">Edge Query:</span>
-              <pre className="mt-1 overflow-auto rounded bg-gray-50 p-2 font-mono text-xs">{selected.edge_query || "—"}</pre>
-            </div>
             <div><span className="text-gray-500">S3 Bucket:</span> {selected.s3_staging_bucket || "—"}</div>
             <div><span className="text-gray-500">Graph ID:</span> {selected.graph_id || "—"}</div>
             {selected.graph_id && graphStatuses.get(selected.graph_id) && (


### PR DESCRIPTION
## Summary

A projection can now define multiple node queries and multiple edge queries
(previously a single `node_query` / `edge_query`). All are run on import.

## Changes

- **Data model:** new `node_queries` / `edge_queries` tables + `NodeQuery` / `EdgeQuery` models and a `query_store`. `project_id` now required on a projection.

- **API:** `GET`/`POST /api/v0/projection/{id}/queries` to fetch/save the query set; validate, preview, and export/import all handle the full list.

- **Architecture:** new `ProjectionService` layer — routers/pipeline no longer touch the stores directly. DB access centralized on a single `connection()` context manager (fixes a connection leak on failed writes).

- **Bug fix:** deleting a projection/project now also clears its queries (was leaving
  orphaned rows).

- **UI:** node/edge queries are add/remove lists in scrollable frames; editors are
  vertically resizable.

<img width="844" height="874" alt="635741508-b1fffd27-1460-49a2-9fe9-e421233d056a" src="https://github.com/user-attachments/assets/92d41221-9627-4e72-9908-84d9fe965051" />


## Testing

- `make proxy-lint` clean, `make proxy-test` **236 passed**, `make ui` builds.