### PR TITLE
Fix: correct stale `IamClient` import in integ tests

### DIFF
--- a/integ_test/graph_operations/test_security_s3_versioning.py
+++ b/integ_test/graph_operations/test_security_s3_versioning.py
@@ -27,7 +27,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from nx_neptune import NETWORKX_GRAPH_ID
-from nx_neptune.clients.iam_client import IamClient
+from nx_neptune.clients.iam_client import IamClientWrapper
 
 BUCKET_PREFIX = "nx-neptune-versioning-test"
 
@@ -43,7 +43,7 @@ def iam_client():
         pytest.skip('Environment Variable "NETWORKX_GRAPH_ID" is not defined')
 
     sts_arn = boto3.client("sts").get_caller_identity()["Arn"]
-    return IamClient(role_arn=sts_arn, client=boto3.client("iam"))
+    return IamClientWrapper(role_arn=sts_arn, client=boto3.client("iam"))
 
 
 @pytest.fixture(scope="module")

--- a/integ_test/session_manager/conftest.py
+++ b/integ_test/session_manager/conftest.py
@@ -15,7 +15,7 @@ import networkx as nx
 import pytest
 
 from nx_neptune import NeptuneGraph, NETWORKX_GRAPH_ID, SessionManager, CleanupTask, Node, Edge
-from nx_neptune.clients.iam_client import IamClient
+from nx_neptune.clients.iam_client import IamClientWrapper
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("nx_neptune").setLevel(logging.INFO)
@@ -48,7 +48,7 @@ def s3_client():
 def iam_client():
     """IAM client for permission checks."""
     sts_arn = boto3.client("sts").get_caller_identity()["Arn"]
-    return IamClient(role_arn=sts_arn, client=boto3.client("iam"))
+    return IamClientWrapper(role_arn=sts_arn, client=boto3.client("iam"))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Summary :memo:

Two integ-test files imported `IamClient`, which was renamed to `IamClientWrapper`. This broke test collection with `ImportError`, so all `session_manager` integ tests (and the S3 versioning test) errored before running.

Renamed `IamClient` → `IamClientWrapper` (import + constructor call) in:
- `integ_test/session_manager/conftest.py`
- `integ_test/graph_operations/test_security_s3_versioning.py`

**Tested:** `pytest --collect-only` now collects all 7 tests cleanly (previously failed at conftest import). Constructor signature is unchanged, so it's a drop-in rename.

