### PR TITLE
Feat: Add graph-query endpoint for a projection + query console UI skeleton

### DIFF
--- a/proxy/src/nx_neptune_proxy/routers/projection.py
+++ b/proxy/src/nx_neptune_proxy/routers/projection.py
@@ -21,6 +21,8 @@ from nx_neptune.validators import (
 )
 
 from nx_neptune_proxy.routers.schemas import (
+    GraphQueryRequest,
+    GraphQueryResponse,
     PreviewResponse,
     ProjectionCreate,
     ProjectionResponse,
@@ -33,6 +35,8 @@ from nx_neptune_proxy.routers.schemas import (
 from nx_neptune_proxy.services.pipeline import run_pipeline
 from nx_neptune_proxy.services.projection_service import (
     ProjectionNotFound,
+    ProjectionNotQueryable,
+    ReadOnlyQueryViolation,
     projection_service,
 )
 from nx_neptune_proxy.utils import unpack_query_results
@@ -187,6 +191,35 @@ async def preview_projection(projection_id: str, limit: int = Query(10, ge=1, le
         all_results.append(unpack_query_results(rows))
 
     return {"error": None, "results": all_results}
+
+
+@router.post(
+    "/{projection_id}/graph-query",
+    summary="Run a read-only openCypher query against the projection's graph",
+    response_model=GraphQueryResponse,
+)
+async def graph_query(projection_id: str, body: GraphQueryRequest):
+    """Execute a read-only openCypher query and return ``{columns, rows}``.
+
+    Mirrors the ``/preview`` handler's conventions (same router, same auth,
+    tabular response). A missing projection returns 404; a non-queryable
+    projection or a disallowed mutation returns 400; execution failures are
+    returned as a sanitized ``{error}`` body.
+    """
+    kwargs = {} if body.limit is None else {"limit": body.limit}
+    try:
+        return projection_service.run_graph_query(projection_id, body.query, **kwargs)
+    except ProjectionNotFound:
+        raise HTTPException(status_code=404, detail="Projection not found")
+    except (ProjectionNotQueryable, ReadOnlyQueryViolation) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:  # noqa: BLE001 - surface a sanitized message, not a 500
+        return {
+            "error": {
+                "message": sanitize_error_message(str(e)),
+                "hint": "Check the query syntax and that the graph is available.",
+            }
+        }
 
 
 @router.post(

--- a/proxy/src/nx_neptune_proxy/routers/schemas.py
+++ b/proxy/src/nx_neptune_proxy/routers/schemas.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -110,6 +110,24 @@ class PreviewQueryResult(BaseModel):
 class PreviewResponse(BaseModel):
     error: Optional[str] = None
     results: list[PreviewQueryResult]
+
+
+class GraphQueryRequest(BaseModel):
+    query: str = Field(..., description="Read-only openCypher query to execute")
+    limit: Optional[int] = Field(
+        None, ge=1, description="Max rows to return (capped by a server-side ceiling)"
+    )
+
+
+class GraphQueryError(BaseModel):
+    message: str
+    hint: Optional[str] = None
+
+
+class GraphQueryResponse(BaseModel):
+    columns: Optional[list[str]] = None
+    rows: Optional[list[list[Any]]] = None
+    error: Optional[GraphQueryError] = None
 
 
 class ProjectionStatus(BaseModel):

--- a/proxy/src/nx_neptune_proxy/services/projection_service.py
+++ b/proxy/src/nx_neptune_proxy/services/projection_service.py
@@ -16,10 +16,47 @@ tests). Routers translate ``ProjectionNotFound`` into a 404.
 
 from __future__ import annotations
 
-from typing import List, Optional
+import re
+from typing import Any, List, Optional
 
-from .projection_store import Projection, store as projection_store
+from nx_neptune.clients import NeptuneAnalyticsClient
+
+from .projection_store import Projection
+from .projection_store import store as projection_store
 from .query_store import EdgeQuery, NodeQuery, query_store
+
+# --- Read-only graph-query configuration ---
+
+# Projection status at which the backing Neptune graph exists and is queryable.
+QUERYABLE_STATUS = "complete"
+
+# Default LIMIT appended when a query has none, and the hard ceiling on rows
+# returned regardless of any user-supplied LIMIT. These are sensible defaults
+# and are expected to be revisited based on client feedback.
+DEFAULT_LIMIT = 100
+MAX_ROWS = 1000
+
+# Per-query timeout (seconds) applied to the Neptune Analytics client. The
+# service converts this to queryTimeoutMilliseconds natively.
+QUERY_TIMEOUT_SECONDS = 30
+
+# Best-effort read-only guard. This is NOT a parser — IAM (a read-only scoped
+# session) is the real control; this denylist is a coarse first line applied
+# server-side before execution. Case-insensitive, substring match.
+_MUTATION_KEYWORDS = (
+    "DETACH DELETE",
+    "CREATE",
+    "MERGE",
+    "DELETE",
+    "SET",
+    "REMOVE",
+)
+
+# Detect a trailing LIMIT clause so we only append one when missing.
+_LIMIT_RE = re.compile(r"\blimit\b\s+\d+\s*;?\s*$", re.IGNORECASE)
+
+
+# --- Exceptions ---
 
 
 class ProjectionNotFound(Exception):
@@ -28,6 +65,94 @@ class ProjectionNotFound(Exception):
     def __init__(self, projection_id: str):
         self.projection_id = projection_id
         super().__init__(f"Projection not found: {projection_id}")
+
+
+class ProjectionNotQueryable(Exception):
+    """Raised when a projection has no live, queryable graph.
+
+    Carries a human-readable message so the router can return a 400 with a
+    clear explanation rather than surfacing a 500.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
+class ReadOnlyQueryViolation(Exception):
+    """Raised when a query contains a disallowed mutation keyword."""
+
+    def __init__(self, keyword: str):
+        self.keyword = keyword
+        super().__init__(
+            f"Only read-only queries are allowed; disallowed keyword: {keyword}"
+        )
+
+
+# --- Internal Utils ---
+
+
+def _find_mutation_keyword(query: str) -> Optional[str]:
+    """Return the first disallowed mutation keyword found, else None.
+
+    This denylist is a best-effort, case-insensitive substring match — a coarse
+    first line of defense applied server-side before execution. It is NOT the
+    primary guard: the authoritative read-only enforcement is at the IAM level
+    (a read-only-scoped session/role for the Neptune data plane), which cannot
+    be bypassed by query phrasing. This check exists to fail obvious mutations
+    fast with a clear error, not to be a substitute for that IAM scoping.
+
+    ``DETACH DELETE`` is checked first so it is reported in preference to the
+    bare ``DELETE`` it contains.
+    """
+    upper = query.upper()
+    for keyword in _MUTATION_KEYWORDS:
+        if keyword in upper:
+            return keyword
+    return None
+
+
+def _ensure_limit(query: str, limit: int) -> str:
+    """Append ``LIMIT <limit>`` when the query has no trailing LIMIT clause.
+
+    A user-supplied LIMIT is left intact; the row ceiling is still enforced on
+    the results after execution as a belt-and-suspenders bound.
+    """
+    stripped = query.rstrip().rstrip(";").rstrip()
+    if _LIMIT_RE.search(query):
+        return query
+    return f"{stripped} LIMIT {limit}"
+
+
+# --- Result normalization ---
+
+
+def _normalize_cell(value: Any) -> Any:
+    """Normalize a single openCypher result value for the tabular response.
+
+    Only scalars pass through; everything else (nodes,
+    relationships, lists, maps) is stringified. Proper structured node/list
+    rendering is deferred; the outer ``{columns, rows}``
+    shape does not change when that lands.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def graph_result_from_records(
+    results: List[dict],
+) -> tuple[list[str], list[list[Any]]]:
+    """Build ``(columns, rows)`` from a list of openCypher record dicts.
+
+    Column order is derived from the first record's key order (which reflects
+    the query's RETURN order). An empty result set yields empty columns/rows.
+    """
+    if not results:
+        return [], []
+    columns = list(results[0].keys())
+    rows = [[_normalize_cell(record.get(col)) for col in columns] for record in results]
+    return columns, rows
 
 
 class ProjectionService:
@@ -46,6 +171,52 @@ class ProjectionService:
         if projection is None:
             raise ProjectionNotFound(projection_id)
         return projection
+
+    # --- Read-only graph query ---
+
+    def run_graph_query(
+        self, projection_id: str, query: str, limit: int = DEFAULT_LIMIT
+    ) -> dict:
+        """Run a read-only openCypher query against a projection's graph.
+
+        Returns ``{"columns": [...], "rows": [[...], ...]}``.
+
+        Raises:
+            ProjectionNotFound: unknown projection id (router -> 404).
+            ProjectionNotQueryable: no live/queryable graph (router -> 400).
+            ReadOnlyQueryViolation: query contains a mutation keyword (-> 400).
+            Exception: execution failures propagate for the router to sanitize.
+        """
+        projection = self.get_or_raise(projection_id)
+
+        if not projection.graph_id:
+            raise ProjectionNotQueryable(
+                "This projection has no graph yet. Run the import pipeline first."
+            )
+        if projection.status != QUERYABLE_STATUS:
+            raise ProjectionNotQueryable(
+                f"Projection is not queryable (status: {projection.status}). "
+                "The graph must finish importing before it can be queried."
+            )
+
+        keyword = _find_mutation_keyword(query)
+        if keyword is not None:
+            raise ReadOnlyQueryViolation(keyword)
+
+        capped_limit = min(limit, MAX_ROWS)
+        effective_query = _ensure_limit(query, capped_limit)
+
+        na_client = NeptuneAnalyticsClient(
+            graph_id=projection.graph_id,
+            timeout_seconds=QUERY_TIMEOUT_SECONDS,
+        )
+        results = na_client.execute_query(effective_query)
+
+        columns, rows = graph_result_from_records(results)
+        # Bound rows even if a user-supplied LIMIT was
+        # larger than the ceiling (or absent and ignored by the engine).
+        rows = rows[:MAX_ROWS]
+        return {"columns": columns, "rows": rows}
 
     def list(self) -> List[Projection]:
         return projection_store.list()

--- a/proxy/tests/test_graph_name_collision.py
+++ b/proxy/tests/test_graph_name_collision.py
@@ -21,6 +21,7 @@ import pytest
 from nx_neptune_proxy.services.pipeline import run_pipeline
 from nx_neptune_proxy.services.project_store import store as project_store
 from nx_neptune_proxy.services.projection_store import store
+from nx_neptune_proxy.services.project_store import store as project_store
 
 # --- Schema validation (defense-in-depth) ---
 

--- a/proxy/tests/test_graph_query.py
+++ b/proxy/tests/test_graph_query.py
@@ -1,0 +1,213 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the read-only graph-query path: ProjectionService.run_graph_query
+and POST /api/v0/projection/{id}/graph-query."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nx_neptune_proxy.services.projection_service import (
+    MAX_ROWS,
+    ProjectionNotFound,
+    ProjectionNotQueryable,
+    ReadOnlyQueryViolation,
+    projection_service,
+)
+from nx_neptune_proxy.services.projection_store import store
+
+# Patch target: the symbol as imported into the service module.
+_NA_CLIENT = "nx_neptune_proxy.services.projection_service.NeptuneAnalyticsClient"
+
+
+def _queryable_projection(project_id):
+    """Create a projection with a live graph in the queryable ('complete') state."""
+    p = store.create(graph_name="g", project_id=project_id)
+    store.update(p.id, status="complete", graph_id="g-abc123")
+    return p
+
+
+def _mock_na(results):
+    """Patch NeptuneAnalyticsClient so execute_query returns ``results``."""
+    instance = MagicMock()
+    instance.execute_query.return_value = results
+    ctx = patch(_NA_CLIENT, return_value=instance)
+    return ctx, instance
+
+
+# --------------------------------------------------------------------------
+# Service: run_graph_query
+# --------------------------------------------------------------------------
+
+
+class TestRunGraphQueryService:
+    def test_happy_path_scalars(self, test_project_id):
+        p = _queryable_projection(test_project_id)
+        results = [{"name": "Alice", "score": 1.5}, {"name": "Bob", "score": 2.0}]
+        ctx, _ = _mock_na(results)
+        with ctx:
+            out = projection_service.run_graph_query(
+                p.id, "MATCH (n) RETURN n.name, n.score"
+            )
+        assert out["columns"] == ["name", "score"]
+        assert out["rows"] == [["Alice", 1.5], ["Bob", 2.0]]
+
+    def test_limit_appended_when_missing(self, test_project_id):
+        p = _queryable_projection(test_project_id)
+        ctx, instance = _mock_na([{"x": 1}])
+        with ctx:
+            projection_service.run_graph_query(p.id, "MATCH (n) RETURN n", limit=25)
+        executed = instance.execute_query.call_args[0][0]
+        assert executed.strip().upper().endswith("LIMIT 25")
+
+    def test_existing_limit_preserved(self, test_project_id):
+        p = _queryable_projection(test_project_id)
+        ctx, instance = _mock_na([{"x": 1}])
+        with ctx:
+            projection_service.run_graph_query(p.id, "MATCH (n) RETURN n LIMIT 3")
+        executed = instance.execute_query.call_args[0][0]
+        # No second LIMIT appended.
+        assert executed.upper().count("LIMIT") == 1
+
+    def test_limit_capped_at_max_rows(self, test_project_id):
+        p = _queryable_projection(test_project_id)
+        ctx, instance = _mock_na([{"x": 1}])
+        with ctx:
+            projection_service.run_graph_query(
+                p.id, "MATCH (n) RETURN n", limit=MAX_ROWS + 500
+            )
+        executed = instance.execute_query.call_args[0][0]
+        assert executed.strip().upper().endswith(f"LIMIT {MAX_ROWS}")
+
+    def test_rows_bounded_by_ceiling(self, test_project_id):
+        p = _queryable_projection(test_project_id)
+        results = [{"x": i} for i in range(MAX_ROWS + 50)]
+        ctx, _ = _mock_na(results)
+        with ctx:
+            out = projection_service.run_graph_query(p.id, "MATCH (n) RETURN n")
+        assert len(out["rows"]) == MAX_ROWS
+
+    def test_node_and_list_cells_stringified(self, test_project_id):
+        p = _queryable_projection(test_project_id)
+        results = [
+            {
+                "scalar": 42,
+                "node": {"~id": "1", "~labels": ["Person"]},
+                "members": [1, 2, 3],
+            }
+        ]
+        ctx, _ = _mock_na(results)
+        with ctx:
+            out = projection_service.run_graph_query(p.id, "MATCH (n) RETURN n")
+        row = out["rows"][0]
+        assert row[0] == 42  # scalar passthrough
+        assert isinstance(row[1], str) and "Person" in row[1]  # node -> str
+        assert isinstance(row[2], str) and row[2] == "[1, 2, 3]"  # list -> str
+
+    def test_empty_results(self, test_project_id):
+        p = _queryable_projection(test_project_id)
+        ctx, _ = _mock_na([])
+        with ctx:
+            out = projection_service.run_graph_query(p.id, "MATCH (n) RETURN n")
+        assert out == {"columns": [], "rows": []}
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "CREATE (n:Person)",
+            "MATCH (n) SET n.x = 1",
+            "MATCH (n) DELETE n",
+            "MATCH (n) DETACH DELETE n",
+            "MERGE (n:Person {id: 1})",
+            "MATCH (n) REMOVE n.x",
+            "match (n) delete n",  # case-insensitive
+        ],
+    )
+    def test_denylist_rejects_mutations(self, query, test_project_id):
+        p = _queryable_projection(test_project_id)
+        with pytest.raises(ReadOnlyQueryViolation):
+            projection_service.run_graph_query(p.id, query)
+
+    def test_unknown_projection_raises_not_found(self, test_project_id):
+        with pytest.raises(ProjectionNotFound):
+            projection_service.run_graph_query("does-not-exist", "MATCH (n) RETURN n")
+
+    def test_no_graph_id_not_queryable(self, test_project_id):
+        p = store.create(
+            graph_name="g", project_id=test_project_id
+        )  # draft, no graph_id
+        with pytest.raises(ProjectionNotQueryable):
+            projection_service.run_graph_query(p.id, "MATCH (n) RETURN n")
+
+    def test_status_not_complete_not_queryable(self, test_project_id):
+        p = store.create(graph_name="g", project_id=test_project_id)
+        store.update(p.id, status="importing", graph_id="g-abc123")
+        with pytest.raises(ProjectionNotQueryable):
+            projection_service.run_graph_query(p.id, "MATCH (n) RETURN n")
+
+
+# --------------------------------------------------------------------------
+# Endpoint: POST /api/v0/projection/{id}/graph-query
+# --------------------------------------------------------------------------
+
+
+class TestGraphQueryEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_columns_and_rows(self, client, test_project_id):
+        p = _queryable_projection(test_project_id)
+        ctx, _ = _mock_na([{"name": "Alice"}, {"name": "Bob"}])
+        with ctx:
+            resp = await client.post(
+                f"/api/v0/projection/{p.id}/graph-query",
+                json={"query": "MATCH (n) RETURN n.name"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["columns"] == ["name"]
+        assert data["rows"] == [["Alice"], ["Bob"]]
+        assert data["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_projection_404(self, client):
+        resp = await client.post(
+            "/api/v0/projection/nope/graph-query",
+            json={"query": "MATCH (n) RETURN n"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_queryable_400(self, client, test_project_id):
+        p = store.create(graph_name="g", project_id=test_project_id)  # draft
+        resp = await client.post(
+            f"/api/v0/projection/{p.id}/graph-query",
+            json={"query": "MATCH (n) RETURN n"},
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_mutation_rejected_400(self, client, test_project_id):
+        p = _queryable_projection(test_project_id)
+        resp = await client.post(
+            f"/api/v0/projection/{p.id}/graph-query",
+            json={"query": "MATCH (n) DETACH DELETE n"},
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_execution_error_sanitized(self, client, test_project_id):
+        p = _queryable_projection(test_project_id)
+        instance = MagicMock()
+        instance.execute_query.side_effect = Exception(
+            "boom at arn:aws:iam::123456789012:user/dev"
+        )
+        with patch(_NA_CLIENT, return_value=instance):
+            resp = await client.post(
+                f"/api/v0/projection/{p.id}/graph-query",
+                json={"query": "MATCH (n) RETURN n"},
+            )
+        # Not a 500 — a readable, sanitized error body.
+        assert resp.status_code == 200
+        err = resp.json()["error"]
+        assert err is not None
+        assert "123456789012" not in err["message"]

--- a/proxy/ui-src/src/components/GraphQueryConsole.tsx
+++ b/proxy/ui-src/src/components/GraphQueryConsole.tsx
@@ -1,0 +1,169 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Play, X, AlertTriangle, Loader2 } from "lucide-react";
+
+/**
+ * GraphQueryConsole — bottom-docked, resizable query console (UI skeleton).
+ *
+ * Implements the manual (Phase 1) layout in
+ * docs/design-graph-query-console-full.md:
+ *   compact meta header · editable query + Run | results
+ *
+ * SCOPE: This PR ships the UI skeleton only — the layout, the resizable panel,
+ * the query editor, the Run button, and the results/error render shells.
+ * Run is intentionally NOT wired to the backend yet: the backend endpoint
+ * (POST /api/v0/projection/{id}/graph-query) ships separately, and wiring
+ * `handleRun` to it — plus rendering real { columns, rows } — is the next PR.
+ * There is deliberately no canned/dummy data here.
+ */
+
+interface GraphMeta {
+  graphName: string;
+  graphId: string;
+  status: string;
+}
+
+interface ResultTable {
+  columns: string[];
+  rows: string[][];
+}
+
+const DEFAULT_QUERY = "MATCH (n) RETURN n LIMIT 25";
+
+export function GraphQueryConsole({
+  meta,
+  onClose,
+}: {
+  meta: GraphMeta;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState(DEFAULT_QUERY);
+  // Result/error state and the render shells below are intentionally kept so the
+  // next PR only needs to populate them from the API response.
+  const [result] = useState<ResultTable | null>(null);
+  const [error] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+
+  // --- resizable height ---
+  const [height, setHeight] = useState(340);
+  const dragging = useRef(false);
+
+  const onDrag = useCallback((e: MouseEvent) => {
+    if (!dragging.current) return;
+    const next = window.innerHeight - e.clientY;
+    setHeight(Math.min(Math.max(next, 180), window.innerHeight * 0.85));
+  }, []);
+
+  useEffect(() => {
+    const stop = () => (dragging.current = false);
+    window.addEventListener("mousemove", onDrag);
+    window.addEventListener("mouseup", stop);
+    return () => {
+      window.removeEventListener("mousemove", onDrag);
+      window.removeEventListener("mouseup", stop);
+    };
+  }, [onDrag]);
+
+  // --- run action ---
+  // TODO(next PR): call projection.graphQuery(meta.graphId, query) and set
+  // result / error from the { columns, rows } | { error } response.
+  function handleRun() {
+    // Not wired yet — UI skeleton only.
+  }
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 flex flex-col border-t border-gray-300 bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.08)]"
+      style={{ height }}
+    >
+      {/* drag handle */}
+      <div
+        onMouseDown={() => (dragging.current = true)}
+        className="flex h-3 w-full cursor-row-resize items-center justify-center border-b border-gray-100 bg-gray-50 hover:bg-gray-100"
+        title="Drag to resize"
+      >
+        <div className="h-1 w-10 rounded-full bg-gray-300" />
+      </div>
+
+      {/* compact meta header */}
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-2 text-sm">
+        <div className="flex items-center gap-2 truncate">
+          <span className="font-semibold">{meta.graphName}</span>
+          <span className="text-gray-400">·</span>
+          <span className="font-mono text-xs text-gray-500">{meta.graphId}</span>
+          <span className="text-gray-400">·</span>
+          <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+            {meta.status}
+          </span>
+        </div>
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-600" title="Close">
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* body: left (query) | right (results) */}
+      <div className="flex min-h-0 flex-1">
+        {/* LEFT COLUMN */}
+        <div className="flex w-1/2 min-w-0 flex-col gap-2 border-r border-gray-200 p-3">
+          {/* editable query */}
+          <div className="flex min-h-0 flex-1 flex-col rounded-md border border-gray-200">
+            <div className="border-b border-gray-200 bg-gray-50 px-3 py-1.5 text-xs font-medium text-gray-600">
+              Query
+            </div>
+            <textarea
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+              }}
+              spellCheck={false}
+              className="min-h-0 flex-1 resize-none px-3 py-2 font-mono text-sm focus:outline-none"
+            />
+            <div className="flex justify-end border-t border-gray-100 p-2">
+              <button
+                onClick={handleRun}
+                disabled={running}
+                className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+                Run
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT COLUMN: results */}
+        <div className="flex w-1/2 min-w-0 flex-col p-3">
+          <div className="mb-2 text-xs font-medium text-gray-600">Results</div>
+          <div className="min-h-0 flex-1 overflow-auto rounded-md border border-gray-200">
+            {error ? (
+              <div className="flex items-start gap-2 p-3 text-sm text-red-700">
+                <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <span>{error}</span>
+              </div>
+            ) : result ? (
+              <table className="w-full text-left text-sm">
+                <thead className="sticky top-0 border-b bg-gray-50">
+                  <tr>
+                    {result.columns.map((c) => (
+                      <th key={c} className="px-3 py-2 font-medium">{c}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.rows.map((row, i) => (
+                    <tr key={i} className="border-b last:border-0">
+                      {row.map((cell, j) => (
+                        <td key={j} className="px-3 py-2 text-gray-700">{cell}</td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <div className="p-3 text-sm text-gray-400">Run a query to see results.</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/proxy/ui-src/src/components/GraphQueryConsole.tsx
+++ b/proxy/ui-src/src/components/GraphQueryConsole.tsx
@@ -8,12 +8,10 @@ import { Play, X, AlertTriangle, Loader2 } from "lucide-react";
  * docs/design-graph-query-console-full.md:
  *   compact meta header · editable query + Run | results
  *
- * SCOPE: This PR ships the UI skeleton only — the layout, the resizable panel,
- * the query editor, the Run button, and the results/error render shells.
- * Run is intentionally NOT wired to the backend yet: the backend endpoint
- * (POST /api/v0/projection/{id}/graph-query) ships separately, and wiring
- * `handleRun` to it — plus rendering real { columns, rows } — is the next PR.
- * There is deliberately no canned/dummy data here.
+ * SCOPE: UI skeleton only — the layout, the resizable panel, the query editor,
+ * the Run button, and the results/error render shells. Run is not wired to the
+ * backend (POST /api/v0/projection/{id}/graph-query) yet, and there is no
+ * canned/dummy data.
  */
 
 interface GraphMeta {
@@ -37,8 +35,8 @@ export function GraphQueryConsole({
   onClose: () => void;
 }) {
   const [query, setQuery] = useState(DEFAULT_QUERY);
-  // Result/error state and the render shells below are intentionally kept so the
-  // next PR only needs to populate them from the API response.
+  // Result/error state and the render shells below are kept so wiring the API
+  // response only needs to populate them.
   const [result] = useState<ResultTable | null>(null);
   const [error] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
@@ -64,11 +62,17 @@ export function GraphQueryConsole({
   }, [onDrag]);
 
   // --- run action ---
-  // TODO(next PR): call projection.graphQuery(meta.graphId, query) and set
-  // result / error from the { columns, rows } | { error } response.
+  // TODO: call projection.graphQuery(meta.graphId, query) and set result / error
+  // from the { columns, rows } | { error } response.
   function handleRun() {
     // Not wired yet — UI skeleton only.
   }
+
+  // Run is enabled only when there is a query to run AND the graph is available.
+  const canRun =
+    query.trim().length > 0 &&
+    meta.status.toLowerCase() === "available" &&
+    !running;
 
   return (
     <div
@@ -120,7 +124,14 @@ export function GraphQueryConsole({
             <div className="flex justify-end border-t border-gray-100 p-2">
               <button
                 onClick={handleRun}
-                disabled={running}
+                disabled={!canRun}
+                title={
+                  meta.status.toLowerCase() !== "available"
+                    ? "Graph is not available to query"
+                    : query.trim().length === 0
+                      ? "Enter a query to run"
+                      : "Run query"
+                }
                 className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
               >
                 {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -533,16 +533,16 @@ export function Projections() {
         </Card>
       )}
 
-      {/* Bottom-docked graph query console (UI mockup, dummy data) */}
+      {/* Bottom-docked graph query console (UI skeleton — Run not wired to backend) */}
       {consoleTarget && consoleOpen && (
         <GraphQueryConsole
           onClose={() => { setConsoleOpen(false); setConsoleTarget(null); }}
           meta={{
             graphName: consoleTarget.graph_name || consoleTarget.id.slice(0, 8),
-            graphId: consoleTarget.graph_id || "g-e2ddaz7nm0",
+            graphId: consoleTarget.graph_id || "",
             status:
               (consoleTarget.graph_id && graphStatuses.get(consoleTarget.graph_id)?.toLowerCase()) ||
-              "available",
+              "unknown",
           }}
         />
       )}

--- a/proxy/ui-src/src/pages/Projections.tsx
+++ b/proxy/ui-src/src/pages/Projections.tsx
@@ -2,13 +2,16 @@ import { useEffect, useState, useRef } from "react";
 import { useSearchParams, NavLink } from "react-router";
 import { projection, metadata, projectApi, graphActions, type Projection, type Project, type Inflight } from "../api";
 import { Card, Button, RefreshButton } from "../components/ui";
-import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Download } from "lucide-react";
+import { GraphQueryConsole } from "../components/GraphQueryConsole";
+import { X, ExternalLink, Trash2, Square, Play, AlertTriangle, ChevronRight, ChevronDown, Download, Terminal } from "lucide-react";
 import { useNavigate } from "react-router";
 
 export function Projections() {
   const [searchParams] = useSearchParams();
   const [projections, setProjections] = useState<Projection[]>([]);
   const [selected, setSelected] = useState<Projection | null>(null);
+  const [consoleOpen, setConsoleOpen] = useState(false);
+  const [consoleTarget, setConsoleTarget] = useState<Projection | null>(null);
   const [region, setRegion] = useState("");
   const [projects, setProjects] = useState<Map<string, Project>>(new Map());
   const [summaries, setSummaries] = useState<Map<string, { numNodes: number; numEdges: number }>>(new Map());
@@ -291,6 +294,16 @@ export function Projections() {
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex gap-1">
+                      {/* Query Graph (opens bottom console) */}
+                      <button
+                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-blue-600 disabled:opacity-30 disabled:hover:bg-transparent"
+                        disabled={!s.graph_id}
+                        title="Query graph"
+                        onClick={(e) => { e.stopPropagation(); setConsoleTarget(s); setConsoleOpen(true); }}
+                      >
+                        <Terminal className="h-4 w-4" />
+                      </button>
+
                       {/* Graph Explorer */}
                       <button
                         className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-blue-600 disabled:opacity-30 disabled:hover:bg-transparent"
@@ -425,7 +438,7 @@ export function Projections() {
         <Card className="w-80 shrink-0 space-y-3 self-start">
           <div className="flex items-center justify-between">
             <h2 className="text-sm font-semibold">{selected.graph_name || selected.id.slice(0, 8)}</h2>
-            <button onClick={() => setSelected(null)} className="text-gray-400 hover:text-gray-600"><X className="h-4 w-4" /></button>
+            <button onClick={() => { setSelected(null); setConsoleOpen(false); }} className="text-gray-400 hover:text-gray-600"><X className="h-4 w-4" /></button>
           </div>
           <div className="space-y-2 text-sm">
             {selected.project_id && <div><span className="text-gray-500">Project:</span> {projects.get(selected.project_id)?.name || selected.project_id}</div>}
@@ -472,6 +485,9 @@ export function Projections() {
               }}>
                 <ExternalLink className="h-3 w-3" /> Open in Graph Explorer
               </Button>
+              <Button variant="secondary" className="w-full" onClick={() => { setConsoleTarget(selected); setConsoleOpen(true); }}>
+                <Terminal className="h-3 w-3" /> Query Graph
+              </Button>
               <div className="flex gap-2">
                 <Button
                   variant="secondary"
@@ -515,6 +531,20 @@ export function Projections() {
             </div>
           )}
         </Card>
+      )}
+
+      {/* Bottom-docked graph query console (UI mockup, dummy data) */}
+      {consoleTarget && consoleOpen && (
+        <GraphQueryConsole
+          onClose={() => { setConsoleOpen(false); setConsoleTarget(null); }}
+          meta={{
+            graphName: consoleTarget.graph_name || consoleTarget.id.slice(0, 8),
+            graphId: consoleTarget.graph_id || "g-e2ddaz7nm0",
+            status:
+              (consoleTarget.graph_id && graphStatuses.get(consoleTarget.graph_id)?.toLowerCase()) ||
+              "available",
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
### Summary
Backend endpoint to run an **openCypher query** against a projection's graph and return `{ columns, rows }`, plus the **UI skeleton** for the query console (layout only).

### Backend
- `ProjectionService.run_graph_query(id, query, limit)` — resolves the projection, verifies it's queryable (`status == "complete"` + live `graph_id`), runs via `NeptuneAnalyticsClient.execute_query`, returns `{ columns, rows }`.
- `POST /api/v0/projection/{id}/graph-query` — mirrors the existing `/preview` handler.
- **Mutation-keyword denylist** (`CREATE/MERGE/DELETE/DETACH DELETE/SET/REMOVE`, case-insensitive) as a best-effort guardrail applied before execution. **This is not a security control** — it's substring-based and bypassable. Authoritative read-only enforcement requires an IAM-scoped (`ReadDataViaQuery`-only) session, which is **not** in this PR (tracked as follow-up hardening).
- `LIMIT` appended-if-missing + capped, hard row ceiling, query timeout.
- Errors: `ProjectionNotFound`→404, non-queryable/mutation→400, execution failures→sanitized `{ error }` (no ARNs), never 500.

### Frontend (skeleton only)
- `GraphQueryConsole.tsx`: Layout/editor/results shells. Run enabled only when a query exists **and** graph is `available`.


### Testing
- `test_graph_query.py`: 22 unit + endpoint tests. Full backend suite passes; lint clean; UI builds.
