### PR TITLE
Test: parametrize repetitive proxy test cases

### DIFF
--- a/proxy/tests/test_column_allowlist.py
+++ b/proxy/tests/test_column_allowlist.py
@@ -11,33 +11,26 @@ from nx_neptune_proxy.services.projection_store import store
 class TestColumnAllowlist:
     """Store.update() must reject columns not in _ALLOWED_UPDATE_COLUMNS."""
 
-    def test_invalid_column_raises_value_error(self, test_project_id):
+    @pytest.mark.parametrize(
+        "bad_kwargs",
+        [
+            pytest.param({"id": "injected-id"}, id="primary_key_id_rejected"),
+            pytest.param(
+                {"created_at": "2020-01-01"}, id="immutable_created_at_rejected"
+            ),
+            pytest.param({"drop_table": "yes"}, id="arbitrary_unknown_column_rejected"),
+            pytest.param(
+                {"malicious": "x", "another_bad": "y"},
+                id="multiple_invalid_columns_rejected",
+            ),
+        ],
+    )
+    def test_invalid_column_raises_value_error(self, test_project_id, bad_kwargs):
         p = store.create(
             database="testdb", graph_name="test", project_id=test_project_id
         )
         with pytest.raises(ValueError, match="Invalid column"):
-            store.update(p.id, id="injected-id")
-
-    def test_invalid_column_created_at_rejected(self, test_project_id):
-        p = store.create(
-            database="testdb", graph_name="test", project_id=test_project_id
-        )
-        with pytest.raises(ValueError, match="Invalid column"):
-            store.update(p.id, created_at="2020-01-01")
-
-    def test_arbitrary_column_rejected(self, test_project_id):
-        p = store.create(
-            database="testdb", graph_name="test", project_id=test_project_id
-        )
-        with pytest.raises(ValueError, match="Invalid column"):
-            store.update(p.id, drop_table="yes")
-
-    def test_multiple_invalid_columns_rejected(self, test_project_id):
-        p = store.create(
-            database="testdb", graph_name="test", project_id=test_project_id
-        )
-        with pytest.raises(ValueError, match="Invalid column"):
-            store.update(p.id, malicious="x", another_bad="y")
+            store.update(p.id, **bad_kwargs)
 
     def test_valid_column_accepted(self, test_project_id):
         p = store.create(

--- a/proxy/tests/test_origin_validation.py
+++ b/proxy/tests/test_origin_validation.py
@@ -21,27 +21,32 @@ def client():
 
 class TestOriginValidation:
     @pytest.mark.asyncio
-    async def test_evil_origin_rejected(self, client):
-        resp = await client.get("/health", headers={"Origin": "http://evil.com"})
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            pytest.param("http://localhost:8080", id="localhost"),
+            pytest.param("http://127.0.0.1:8080", id="127_0_0_1"),
+            # urlparse correctly strips IPv6 brackets before comparison, unlike
+            # Starlette's TrustedHostMiddleware, which cannot parse them at all.
+            pytest.param("http://[::1]:8080", id="ipv6_loopback"),
+        ],
+    )
+    async def test_loopback_origin_allowed(self, client, origin):
+        resp = await client.get("/health", headers={"Origin": origin})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            pytest.param("http://evil.com", id="evil_host"),
+            pytest.param("not-a-valid-url", id="malformed"),
+        ],
+    )
+    async def test_untrusted_origin_rejected(self, client, origin):
+        resp = await client.get("/health", headers={"Origin": origin})
         assert resp.status_code == 403
         assert resp.json()["error"] == "origin_rejected"
-
-    @pytest.mark.asyncio
-    async def test_localhost_origin_allowed(self, client):
-        resp = await client.get("/health", headers={"Origin": "http://localhost:8080"})
-        assert resp.status_code == 200
-
-    @pytest.mark.asyncio
-    async def test_127_0_0_1_origin_allowed(self, client):
-        resp = await client.get("/health", headers={"Origin": "http://127.0.0.1:8080"})
-        assert resp.status_code == 200
-
-    @pytest.mark.asyncio
-    async def test_ipv6_loopback_origin_allowed(self, client):
-        """urlparse correctly strips IPv6 brackets before comparison, unlike
-        Starlette's TrustedHostMiddleware, which cannot parse them at all."""
-        resp = await client.get("/health", headers={"Origin": "http://[::1]:8080"})
-        assert resp.status_code == 200
 
     @pytest.mark.asyncio
     async def test_no_origin_allowed(self, client):
@@ -49,11 +54,6 @@ class TestOriginValidation:
         not subject to this check."""
         resp = await client.get("/health")
         assert resp.status_code == 200
-
-    @pytest.mark.asyncio
-    async def test_malformed_origin_rejected(self, client):
-        resp = await client.get("/health", headers={"Origin": "not-a-valid-url"})
-        assert resp.status_code == 403
 
 
 class TestOriginValidationFullOrigin:
@@ -75,24 +75,26 @@ class TestOriginValidationFullOrigin:
         )
 
     @pytest.mark.asyncio
-    async def test_configured_full_origin_allowed(self, client_with_allowed_origin):
+    @pytest.mark.parametrize(
+        "origin, expected_status",
+        [
+            pytest.param(
+                "https://app.example.com:8443", 200, id="configured_full_origin"
+            ),
+            # A trusted hostname on a non-configured port is rejected — matching
+            # is on the full origin, not the hostname alone.
+            pytest.param(
+                "https://app.example.com:9999", 403, id="same_host_wrong_port"
+            ),
+            pytest.param(
+                "http://app.example.com:8443", 403, id="same_host_wrong_scheme"
+            ),
+        ],
+    )
+    async def test_full_origin_matching(
+        self, client_with_allowed_origin, origin, expected_status
+    ):
         resp = await client_with_allowed_origin.get(
-            "/health", headers={"Origin": "https://app.example.com:8443"}
+            "/health", headers={"Origin": origin}
         )
-        assert resp.status_code == 200
-
-    @pytest.mark.asyncio
-    async def test_same_host_wrong_port_rejected(self, client_with_allowed_origin):
-        """A trusted hostname on a non-configured port is rejected — matching
-        is on the full origin, not the hostname alone."""
-        resp = await client_with_allowed_origin.get(
-            "/health", headers={"Origin": "https://app.example.com:9999"}
-        )
-        assert resp.status_code == 403
-
-    @pytest.mark.asyncio
-    async def test_same_host_wrong_scheme_rejected(self, client_with_allowed_origin):
-        resp = await client_with_allowed_origin.get(
-            "/health", headers={"Origin": "http://app.example.com:8443"}
-        )
-        assert resp.status_code == 403
+        assert resp.status_code == expected_status

--- a/proxy/tests/test_prefix_guard.py
+++ b/proxy/tests/test_prefix_guard.py
@@ -20,29 +20,21 @@ def test_assert_managed_graph_passes_with_prefix(mock_get_settings):
     assert_managed_graph("nxp-my-graph")
 
 
+@pytest.mark.parametrize(
+    "graph_name",
+    [
+        pytest.param("other-graph", id="wrong_prefix_rejected"),
+        pytest.param(None, id="none_rejected"),
+        pytest.param("", id="empty_string_rejected"),
+    ],
+)
 @patch("nx_neptune_proxy.utils.aws_helper.get_settings")
-def test_assert_managed_graph_rejects_wrong_prefix(mock_get_settings):
+def test_assert_managed_graph_rejects(mock_get_settings, graph_name):
     mock_get_settings.return_value.graph_prefix = "nxp-"
     with pytest.raises(HTTPException) as exc_info:
-        assert_managed_graph("other-graph")
+        assert_managed_graph(graph_name)
     assert exc_info.value.status_code == 403
     assert "not managed" in exc_info.value.detail
-
-
-@patch("nx_neptune_proxy.utils.aws_helper.get_settings")
-def test_assert_managed_graph_rejects_none(mock_get_settings):
-    mock_get_settings.return_value.graph_prefix = "nxp-"
-    with pytest.raises(HTTPException) as exc_info:
-        assert_managed_graph(None)
-    assert exc_info.value.status_code == 403
-
-
-@patch("nx_neptune_proxy.utils.aws_helper.get_settings")
-def test_assert_managed_graph_rejects_empty_string(mock_get_settings):
-    mock_get_settings.return_value.graph_prefix = "nxp-"
-    with pytest.raises(HTTPException) as exc_info:
-        assert_managed_graph("")
-    assert exc_info.value.status_code == 403
 
 
 # --- get_graph_or_exception ---


### PR DESCRIPTION
### Summary
Collapses groups of near-identical proxy unit tests into `pytest.mark.parametrize` cases. Pure test refactor — no production code changes, same assertions, same coverage. Net −13 lines and fewer duplicated test bodies.

### Changes
- **`test_prefix_guard.py`** — 3 `assert_managed_graph` rejection tests (wrong prefix / `None` / empty) → 1 parametrized test over the bad input.
- **`test_column_allowlist.py`** — 4 invalid-column rejection tests (`id`, `created_at`, arbitrary, multiple) → 1 parametrized test; the multi-column case is a dict-splat param.
- **`test_origin_validation.py`**
  - `TestOriginValidation`: 6 → 3 — allowed loopback origins (localhost / 127.0.0.1 / `[::1]`) and rejected origins (evil host / malformed) each parametrized; `no_origin_allowed` kept standalone (no header doesn't fit the param).
  - `TestOriginValidationFullOrigin`: 3 → 1 parametrized over `(origin, expected_status)`.
