### PR TITLE
Misc: Bump pinned dependencies (lock refresh)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --extra=developer --extra=test --no-index --output-file=requirements-dev.txt --strip-extras pyproject.toml
 #
-ast-serialize==0.8.0
+ast-serialize==0.9.0
     # via mypy
 black==26.5.1
     # via nx-neptune (pyproject.toml)
-boto3==1.43.82
+boto3==1.43.87
     # via nx-neptune (pyproject.toml)
-botocore==1.43.82
+botocore==1.43.87
     # via
     #   boto3
     #   s3transfer
@@ -18,7 +18,7 @@ cfgv==3.5.0
     # via pre-commit
 click==8.5.0
     # via black
-coverage==7.15.4
+coverage==7.16.0
     # via pytest-cov
 cymple==0.12.0
     # via nx-neptune (pyproject.toml)
@@ -26,7 +26,7 @@ distlib==0.4.3
     # via virtualenv
 dotenv==0.9.9
     # via nx-neptune (pyproject.toml)
-filelock==3.32.4
+filelock==3.32.5
     # via
     #   python-discovery
     #   virtualenv
@@ -76,7 +76,7 @@ pathspec==1.1.1
     #   mypy
 pip-licenses==5.5.5
     # via nx-neptune (pyproject.toml)
-platformdirs==4.11.5
+platformdirs==4.11.7
     # via
     #   black
     #   virtualenv
@@ -110,7 +110,7 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   pandas
-python-discovery==1.5.3
+python-discovery==1.6.0
     # via virtualenv
 python-dotenv==1.2.3
     # via dotenv
@@ -132,7 +132,7 @@ typing-extensions==4.16.0
     #   pytest-asyncio
 urllib3==2.7.0
     # via botocore
-virtualenv==21.7.5
+virtualenv==21.7.8
     # via pre-commit
-wcwidth==0.8.2
+wcwidth==0.8.3
     # via prettytable

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --no-index --output-file=requirements.txt --strip-extras pyproject.toml
 #
-boto3==1.43.82
+boto3==1.43.87
     # via nx-neptune (pyproject.toml)
-botocore==1.43.82
+botocore==1.43.87
     # via
     #   boto3
     #   s3transfer


### PR DESCRIPTION
### Summary
Regenerates the pinned lock files (`requirements.txt`, `requirements-dev.txt`) to pick up patch/minor bumps of `boto3`/`botocore` and dev tooling. No source or `pyproject.toml` changes — lock refresh only.

### Runtime deps (`requirements.txt`)
- `boto3` 1.43.82 → 1.43.87
- `botocore` 1.43.82 → 1.43.87

### Dev deps (`requirements-dev.txt`)
- `boto3` / `botocore` 1.43.82 → 1.43.87 (mirrors runtime)
- `ast-serialize` 0.8.0 → 0.9.0
- `coverage` 7.15.4 → 7.16.0
- `filelock` 3.32.4 → 3.32.5
- `platformdirs` 4.11.5 → 4.11.7
- `python-discovery` 1.5.3 → 1.6.0
- `virtualenv` 21.7.5 → 21.7.8
- `wcwidth` 0.8.2 → 0.8.3