### PR TITLE
Enhance: escape node/edge property keys in openCypher query builder

### DIFF
--- a/integ_test/graph_operations/test_security_property_key_injection.py
+++ b/integ_test/graph_operations/test_security_property_key_injection.py
@@ -1,0 +1,211 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Integration test: openCypher injection via node/edge property KEYS.
+
+Companion to ``test_security_injection.py`` (which covers property *values* and
+node *IDs* — the inputs that ride the Neptune Analytics ``parameters`` map and
+are therefore bound out-of-band). Property *keys* (attribute names) have no
+parameter-map channel: openCypher has no ``$``-placeholder for an identifier
+position, so a key is interpolated into the compiled query string and is made
+safe by client-side backtick-escaping in ``ParameterMapBuilder.read_map`` /
+``_escape_property_key`` / ``_escape_property_path``.
+
+This test proves, against a real Neptune Analytics instance, that a malicious
+attribute NAME cannot break out of the query:
+
+  1. A canary node survives every property-key injection attempt (graph not
+     destroyed / mutated by an injected clause).
+  2. Each injection payload is stored as a *literal property name*, not executed.
+  3. Legitimate keys still work — plain names, dotted ``ref.prop`` references,
+     and the ``id(n)`` structural predicate are interpreted, not corrupted
+     (positive controls).
+
+Usage:
+    export NETWORKX_GRAPH_ID=g-your-graph-id
+    pytest integ_test/graph_operations/test_security_property_key_injection.py -v
+"""
+
+import networkx as nx
+import pytest
+
+from nx_neptune import NETWORKX_GRAPH_ID, NeptuneGraph
+from nx_neptune.clients import Edge, Node
+
+# Payloads used as the property KEY (attribute name). Each tries to close the
+# ``{ ... }`` property map / node and append a destructive clause, with a
+# trailing ``//`` to comment out the generated remainder.
+KEY_INJECTION_PAYLOADS = [
+    "x: 1}) MATCH (m) DETACH DELETE m //",
+    "y`: 1}) MATCH (m) DETACH DELETE m //",  # embedded backtick breakout attempt
+    "z}) DETACH DELETE m //",
+    "`~id`}) MATCH (m) DETACH DELETE m //",  # tries to smuggle a fake ~id
+]
+
+CANARY_NODE_ID = "canary_property_key_test"
+
+
+@pytest.fixture(scope="module")
+def na_graph():
+    if not NETWORKX_GRAPH_ID:
+        pytest.skip('Environment Variable "NETWORKX_GRAPH_ID" is not defined')
+
+    g = nx.Graph()
+    graph = NeptuneGraph.from_config(graph=g)
+    graph.clear_graph()
+
+    canary = Node(
+        id=CANARY_NODE_ID, labels=["Canary"], properties={"purpose": "key_injection"}
+    )
+    graph.add_node(canary)
+
+    yield graph
+
+    graph.clear_graph()
+
+
+def _canary_alive(na_graph) -> bool:
+    results = na_graph.na_client.execute_generic_query(
+        "MATCH (n:`Canary`) WHERE id(n) = $id RETURN n",
+        parameter_map={"id": CANARY_NODE_ID},
+    )
+    return len(results) == 1
+
+
+class TestInsertNodePropertyKeyInjection:
+    """A malicious attribute NAME on add_node is stored literally, not executed."""
+
+    def test_insert_node_with_injection_keys(self, na_graph):
+        for i, payload in enumerate(KEY_INJECTION_PAYLOADS):
+            node = Node(
+                id=f"keyinj_node_{i}",
+                labels=["KeyInjectionTest"],
+                properties={payload: "v"},
+            )
+            na_graph.add_node(node)
+
+        assert _canary_alive(
+            na_graph
+        ), "Canary destroyed by node property-key injection"
+
+        # Each payload must come back as a *literal property name* on its node.
+        for i, payload in enumerate(KEY_INJECTION_PAYLOADS):
+            results = na_graph.na_client.execute_generic_query(
+                "MATCH (n) WHERE id(n) = $id RETURN n",
+                parameter_map={"id": f"keyinj_node_{i}"},
+            )
+            assert len(results) == 1
+            props = results[0]["n"].get("~properties", {})
+            assert payload in props, (
+                f"Payload '{payload[:30]}...' was not stored as a literal "
+                "property name — it may have been interpreted as query syntax"
+            )
+
+
+class TestInsertEdgePropertyKeyInjection:
+    """A malicious attribute NAME on add_edge is stored literally, not executed."""
+
+    def test_insert_edge_with_injection_keys(self, na_graph):
+        for i, payload in enumerate(KEY_INJECTION_PAYLOADS):
+            src = Node(id=f"keyinj_esrc_{i}", labels=["EdgeKeyTest"], properties={})
+            dest = Node(id=f"keyinj_edst_{i}", labels=["EdgeKeyTest"], properties={})
+            na_graph.add_node(src)
+            na_graph.add_node(dest)
+            edge = Edge(
+                label="KEY_INJECTION_EDGE",
+                properties={payload: "v"},
+                node_src=src,
+                node_dest=dest,
+            )
+            na_graph.add_edge(edge)
+
+        assert _canary_alive(
+            na_graph
+        ), "Canary destroyed by edge property-key injection"
+
+        all_edges = na_graph.get_all_edges()
+        seen_prop_names = set()
+        for e in all_edges:
+            seen_prop_names.update(e.get("~properties", {}).keys())
+        for payload in KEY_INJECTION_PAYLOADS:
+            assert payload in seen_prop_names, (
+                f"Edge payload '{payload[:30]}...' not stored as a literal "
+                "property name"
+            )
+
+
+class TestUpdateNodePropertyKeyInjection:
+    """A malicious attribute NAME in a dotted SET key (a.<payload>) is escaped:
+    only the property segment is quoted, the code-generated ref stays bare, and
+    the payload lands as a literal property name."""
+
+    def test_update_node_with_injection_reference_key(self, na_graph):
+        payload = KEY_INJECTION_PAYLOADS[0]
+        node = Node(id=CANARY_NODE_ID, labels=["Canary"], properties={})
+        na_graph.update_node("Canary", "a", node, {f"a.{payload}": "v"})
+
+        assert _canary_alive(na_graph), "Canary destroyed by SET property-key injection"
+
+        results = na_graph.na_client.execute_generic_query(
+            "MATCH (n) WHERE id(n) = $id RETURN n",
+            parameter_map={"id": CANARY_NODE_ID},
+        )
+        props = results[0]["n"].get("~properties", {})
+        assert payload in props, "Injected SET key not stored as a literal property"
+
+
+class TestLegitimateKeysStillWork:
+    """Positive controls: escaping must not break legitimate identifiers."""
+
+    def test_plain_property_key_roundtrips(self, na_graph):
+        node = Node(id="legit_plain", labels=["Legit"], properties={"age": 30})
+        na_graph.add_node(node)
+        results = na_graph.na_client.execute_generic_query(
+            "MATCH (n) WHERE id(n) = $id RETURN n",
+            parameter_map={"id": "legit_plain"},
+        )
+        props = results[0]["n"].get("~properties", {})
+        assert props.get("age") == 30
+
+    def test_dotted_reference_key_sets_real_property(self, na_graph):
+        # a.age must set a property named 'age' on the matched node — proving the
+        # ref.prop path is interpreted (only the prop segment is escaped), not
+        # turned into a single quoted `a.age` identifier.
+        node = Node(id=CANARY_NODE_ID, labels=["Canary"], properties={})
+        na_graph.update_node("Canary", "a", node, {"a.legit_age": "42"})
+        results = na_graph.na_client.execute_generic_query(
+            "MATCH (n) WHERE id(n) = $id RETURN n",
+            parameter_map={"id": CANARY_NODE_ID},
+        )
+        props = results[0]["n"].get("~properties", {})
+        assert (
+            props.get("legit_age") == "42"
+        ), "Dotted ref.prop key was not interpreted correctly"
+
+    def test_id_predicate_still_matches(self, na_graph):
+        # The id(n) structural predicate (used by bfs/descendants filters) must
+        # pass through unescaped so WHERE id(n) = ... still matches.
+        results = na_graph.na_client.execute_generic_query(
+            "MATCH (n) WHERE id(n) = $id RETURN n",
+            parameter_map={"id": CANARY_NODE_ID},
+        )
+        assert len(results) == 1
+
+
+class TestCanarySurvival:
+    def test_canary_survives_all(self, na_graph):
+        assert _canary_alive(
+            na_graph
+        ), "Canary did not survive property-key injection tests"
+
+    def test_graph_not_wiped(self, na_graph):
+        assert len(na_graph.get_all_nodes()) > 1, "Graph appears wiped"

--- a/nx_neptune/clients/opencypher_builder.py
+++ b/nx_neptune/clients/opencypher_builder.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import enum
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -24,6 +25,23 @@ from .neptune_constants import (
     ALLOWED_ALGO_PARAM_KEYS,
     RESPONSE_SUCCESS,
 )
+
+
+class KeyStyle(enum.Enum):
+    """How a property-map key is escaped in :meth:`ParameterMapBuilder.read_map`.
+
+    * ``PLAIN`` — the key is a bare property name (``CREATE``/``MERGE`` maps);
+      the whole key is backtick-escaped. Safe default for untrusted attribute
+      names.
+    * ``PATH`` — the key is a code-generated ``ref.prop`` path or a structural
+      predicate like ``id(n)`` (``SET``/``WHERE``); only the property segment is
+      escaped and ``func(ref)`` predicates pass through, so the reference stays
+      valid.
+    """
+
+    PLAIN = "plain"
+    PATH = "path"
+
 
 # Internal constants for reference names
 _SRC_NODE_REF = "a"
@@ -119,6 +137,70 @@ def _escape_identifier(value: str) -> str:
     if not isinstance(value, str):
         raise ValueError(f"Expected a string identifier, got {type(value).__name__}")
     return "`" + value.replace("`", "``") + "`"
+
+
+# Strict shapes for SET/WHERE key handling: a bare reference identifier
+# (``a``, ``movie``, ``n1``) and a structural predicate like ``id(n)``. Both
+# use plain ASCII identifiers only — an attacker-supplied key containing
+# injection characters will NOT fullmatch and is escaped wholesale instead.
+_BARE_REF_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_FUNC_PREDICATE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\([A-Za-z_][A-Za-z0-9_]*\)")
+
+
+def _escape_property_key(key: str) -> str:
+    """Backtick-escape a bare property name for use as a map/SET key.
+
+    The whole key is a single property name (e.g. ``name``, ``~id``, or an
+    untrusted attribute name that may contain dots), so it is escaped wholesale
+    via :func:`_escape_identifier`. This is the escaping used for property maps
+    in ``CREATE``/``MERGE`` node/edge construction.
+
+    Example:
+        >>> _escape_property_key("name")
+        '`name`'
+        >>> _escape_property_key("~id")
+        '`~id`'
+        >>> _escape_property_key('x: 1}) MATCH (m) DETACH DELETE m //')
+        '`x: 1}) MATCH (m) DETACH DELETE m //`'
+    """
+    return _escape_identifier(key)
+
+
+def _escape_property_path(key: str) -> str:
+    """Backtick-escape only the property segment of a ``ref.prop`` path.
+
+    ``SET`` and ``WHERE`` keys are code-generated in one of a few shapes where
+    only part of the key is a (potentially untrusted) property name:
+
+      * ``<ref>.<prop>`` — escape only ``<prop>`` (e.g. ``a.age`` -> ``a.`age```);
+        the reference prefix is code-controlled and left bare.
+      * ``<func>(<ref>)`` — a structural predicate such as ``id(n)``. It carries
+        no property name, so it is passed through unchanged, but ONLY when it
+        matches the strict ``identifier(identifier)`` shape — anything else
+        (e.g. an attacker-supplied key merely starting with ``id(``) falls
+        through to wholesale escaping and is neutralized.
+      * anything else / a bare key with no ``.`` — escaped wholesale via
+        :func:`_escape_identifier` (fail-safe).
+
+    Example:
+        >>> _escape_property_path("a.age")
+        'a.`age`'
+        >>> _escape_property_path("id(n)")
+        'id(n)'
+        >>> _escape_property_path('id(n) }) MATCH (m) DETACH DELETE m //')
+        '`id(n) }) MATCH (m) DETACH DELETE m //`'
+    """
+    # Structural predicate like ``id(n)`` — no property name to escape. Strict
+    # shape only; anything fancier is treated as untrusted and escaped below.
+    if _FUNC_PREDICATE_RE.fullmatch(key):
+        return key
+
+    ref, sep, prop = key.partition(".")
+    if not sep or not _BARE_REF_RE.fullmatch(ref):
+        # No reference prefix, or a ref segment that isn't a safe bare
+        # identifier — escape the whole key as a bare property name.
+        return _escape_identifier(key)
+    return f"{ref}.{_escape_identifier(prop)}"
 
 
 def _escape_string_literal(value: str) -> str:
@@ -236,26 +318,46 @@ class ParameterMapBuilder:
         self._counter = 0
         self._param_values = {}
 
-    def read_map(self, params: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
-        """
-        Process a dictionary and create a masked version with parameter placeholders.
-        If params is None or empty, returns an empty dictionary.
+    def read_map(
+        self,
+        params: Optional[Dict[str, Any]] = None,
+        key_style: KeyStyle = KeyStyle.PLAIN,
+    ) -> Dict[str, str]:
+        """Mask values as ``$N`` placeholders and backtick-escape the keys.
+
+        This is the single choke point where property-map keys are made safe:
+        the value of every entry is replaced with a ``$N`` parameter placeholder
+        (stored for later binding) and the key is backtick-escaped so an
+        untrusted attribute name cannot break out of the identifier and inject
+        openCypher syntax.
 
         Args:
-            params: A dictionary containing parameter names and values, or None
+            params: A dict of property name -> value, or None.
+            key_style: A :class:`KeyStyle` selecting how each key is escaped:
+                * :attr:`KeyStyle.PLAIN` (default) — bare property name
+                  (``CREATE``/``MERGE`` maps); escaped wholesale.
+                * :attr:`KeyStyle.PATH` — a code-generated ``ref.prop`` path or
+                  ``id(n)`` predicate (``SET``/``WHERE``); only the property
+                  segment is escaped and ``func(ref)`` predicates pass through.
 
         Returns:
-            A dictionary with the same keys but values replaced with parameter placeholders ($0, $1, etc.)
+            A dict mapping the escaped key to its ``$N`` placeholder.
         """
         if not params:
             return {}
+
+        escape_key = (
+            _escape_property_path
+            if key_style is KeyStyle.PATH
+            else _escape_property_key
+        )
 
         # handle a map of values
         masked_params = {}
         for key, value in params.items():
             param_name = str(self._counter)
             masked_param_name = f"${param_name}"
-            masked_params[key] = masked_param_name
+            masked_params[escape_key(key)] = masked_param_name
             self._param_values[param_name] = value
             self._counter += 1
 
@@ -341,13 +443,13 @@ def insert_node(node: Node) -> Tuple[str, Dict[str, Any]]:
     Examples:
         >>> node = Node(id='Alice', labels=['Person'], properties={'age': 15})
         >>> insert_node(node)
-        ('CREATE (:Person {'~id': $0, age: $1})', {'0': 'Alice', '1': '15'})
+        ('CREATE (:`Person` {`age`: $0, `~id`: $1})', {'0': '15', '1': 'Alice'})
     """
     # Initialize parameter map builder
     param_builder = ParameterMapBuilder()
 
     updated_parameters = node.properties
-    updated_parameters["`~id`"] = str(node.id)
+    updated_parameters["~id"] = str(node.id)
 
     # Mask node properties
     masked_properties = param_builder.read_map(updated_parameters)
@@ -401,8 +503,8 @@ def insert_edge(edge: Edge) -> Tuple[str, Dict[str, Any]]:
         >>> dest = Node(id='Bob', labels=['Person'], properties={})
         >>> edge = Edge(label='FRIEND_WITH', properties={'since': '2020'}, node_src=src, node_dest=dest)
         >>> insert_edge(edge)
-        ('MERGE (a:Person {`~id`: $0}) MERGE (b:Person {`~id`: $1})
-        MERGE (a)-[r:FRIEND_WITH {since: $2}]->(b)', {'0': 'Alice', '1': 'Bob', '2': '2020'})
+        ('MERGE (a:`Person` {`~id`: $0}) MERGE (b:`Person` {`~id`: $1})
+        MERGE (a)-[r:`FRIEND_WITH` {`since`: $2}]->(b)', {'0': 'Alice', '1': 'Bob', '2': '2020'})
     """
     # Initialize parameter map builder
     param_builder = ParameterMapBuilder()
@@ -502,7 +604,7 @@ def update_node(
 
     Example:
         >>> update_node('Person', 'a', ['Alice'], {'a.age': '25'})
-        ('MATCH (a:Person) WHERE id(a) = $0 SET a.age = $1', {'0': 'Alice', '1': '25'})
+        ('MATCH (a:`Person`) WHERE id(a) = $0 SET a.`age` = $1', {'0': 'Alice', '1': '25'})
     """
     # Initialize parameter map builder
     param_builder = ParameterMapBuilder()
@@ -511,7 +613,9 @@ def update_node(
     literal_where_clause = " OR ".join(
         [f"id({ref_name})={node_id}" for node_id in masked_node_ids]
     )
-    masked_properties_set = param_builder.read_map(properties_set)
+    masked_properties_set = param_builder.read_map(
+        properties_set, key_style=KeyStyle.PATH
+    )
 
     return (
         QueryBuilder()
@@ -549,7 +653,7 @@ def update_edge(
         >>> update_edge('a', 'r', edge, 'b',
         ...                  {"a.name": "Alice", "b.name": "Bob"},
         ...                  {"r.since": "1997"})
-        ('MATCH (a:Person)-[r:FRIEND_WITH]->(b:Person) WHERE id(a) = $0 AND id(b) = $1 SET r.since = $2',
+        ('MATCH (a:`Person`)-[r:`FRIEND_WITH`]->(b:`Person`) WHERE a.`name` = $0 AND b.`name` = $1 SET r.`since` = $2',
          {'0': 'Alice', '1': 'Bob', '2': '1997'})
     """
     # Initialize parameter map builder
@@ -563,8 +667,12 @@ def update_edge(
         qb = qb.relates(label=_escape_identifier(edge.label), ref_name=ref_name_edge)
     qb = _append_node(qb, param_builder, edge.node_dest, ref_name_des)
 
-    masked_where_filters = param_builder.read_map(where_filters)
-    masked_properties_set = param_builder.read_map(properties_set)
+    masked_where_filters = param_builder.read_map(
+        where_filters, key_style=KeyStyle.PATH
+    )
+    masked_properties_set = param_builder.read_map(
+        properties_set, key_style=KeyStyle.PATH
+    )
     qb = qb.where_multiple(masked_where_filters, escape=False).set(
         masked_properties_set, escape_values=False
     )
@@ -665,7 +773,9 @@ def bfs_query(
     # Initialize parameter map builder
     param_builder = ParameterMapBuilder()
 
-    masked_where_filters = param_builder.read_map(where_filters)
+    masked_where_filters = param_builder.read_map(
+        where_filters, key_style=KeyStyle.PATH
+    )
 
     bfs_params = f"{source_node}"
     if parameters:
@@ -714,7 +824,9 @@ def descendants_at_distance_query(
     # Initialize parameter map builder
     param_builder = ParameterMapBuilder()
 
-    masked_where_filters = param_builder.read_map(where_filters)
+    masked_where_filters = param_builder.read_map(
+        where_filters, key_style=KeyStyle.PATH
+    )
 
     distance_params = f"{source_node}"
     if parameters:
@@ -761,7 +873,9 @@ def bfs_layers_query(
     # Initialize parameter map builder
     param_builder = ParameterMapBuilder()
 
-    masked_where_filters = param_builder.read_map(where_in_filters)
+    masked_where_filters = param_builder.read_map(
+        where_in_filters, key_style=KeyStyle.PATH
+    )
 
     bfs_params = f"{source_node}"
     if parameters:
@@ -1210,7 +1324,7 @@ def _append_node(
     """
     # Mask node properties
     updated_parameters = node.properties
-    updated_parameters["`~id`"] = str(node.id)
+    updated_parameters["~id"] = str(node.id)
 
     # Mask node properties
     masked_properties = param_builder.read_map(updated_parameters)
@@ -1270,8 +1384,12 @@ def jaccard_coefficient_query(
     """
     param_builder = ParameterMapBuilder()
 
-    masked_first = param_builder.read_map({"id(n1)": first_node})
-    masked_second = param_builder.read_map({"id(n2)": second_node})
+    masked_first = param_builder.read_map(
+        {"id(n1)": first_node}, key_style=KeyStyle.PATH
+    )
+    masked_second = param_builder.read_map(
+        {"id(n2)": second_node}, key_style=KeyStyle.PATH
+    )
 
     jaccard_params = "n1, n2"
     if parameters:

--- a/tests/clients/test_opencypher_builder.py
+++ b/tests/clients/test_opencypher_builder.py
@@ -146,7 +146,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Person` {name : $2, `~id` : $3}) MERGE (a)-[r: `FRIEND_WITH`]->(b)",
+                " MERGE (a: `Person` {`name` : $0, `~id` : $1}) MERGE (b: `Person` {`name` : $2, `~id` : $3}) MERGE (a)-[r: `FRIEND_WITH`]->(b)",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             # Edge without properties
@@ -174,7 +174,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Person` {name : $2, `~id` : $3}) MERGE (a)-[r: `FRIEND_WITH` {since : $4}]->(b)",
+                " MERGE (a: `Person` {`name` : $0, `~id` : $1}) MERGE (b: `Person` {`name` : $2, `~id` : $3}) MERGE (a)-[r: `FRIEND_WITH` {`since` : $4}]->(b)",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456", "4": "2020"},
             ),
             # Edge between nodes with multiple labels
@@ -194,7 +194,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         properties={"name": "Bob"},
                     ),
                 ),
-                " MERGE (a: `Person`: `Employee` {name : $0, `~id` : $1}) MERGE (b: `Person`: `Manager` {name : $2, `~id` : $3}) MERGE (a)-[r: `REPORTS_TO`]->(b)",
+                " MERGE (a: `Person`: `Employee` {`name` : $0, `~id` : $1}) MERGE (b: `Person`: `Manager` {`name` : $2, `~id` : $3}) MERGE (a)-[r: `REPORTS_TO`]->(b)",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             # Edge with numeric property values
@@ -210,7 +210,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Product"], properties={"id": "1001"}
                     ),
                 ),
-                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Product` {id : $2, `~id` : $3}) MERGE (a)-[r: `PURCHASED` {quantity : $4, price : $5}]->(b)",
+                " MERGE (a: `Person` {`name` : $0, `~id` : $1}) MERGE (b: `Product` {`id` : $2, `~id` : $3}) MERGE (a)-[r: `PURCHASED` {`quantity` : $4, `price` : $5}]->(b)",
                 {"0": "Alice", "1": "123", "2": "1001", "3": "456", "4": 5, "5": 29.99},
             ),
             # Edge with boolean property values
@@ -226,7 +226,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Content"], properties={"id": "content-456"}
                     ),
                 ),
-                " MERGE (a: `User` {username : $0, `~id` : $1}) MERGE (b: `Content` {id : $2, `~id` : $3}) MERGE (a)-[r: `LIKED` {public : $4, notified : $5}]->(b)",
+                " MERGE (a: `User` {`username` : $0, `~id` : $1}) MERGE (b: `Content` {`id` : $2, `~id` : $3}) MERGE (a)-[r: `LIKED` {`public` : $4, `notified` : $5}]->(b)",
                 {
                     "0": "alice123",
                     "1": "123",
@@ -249,7 +249,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Company"], properties={"name": "ACME Inc"}
                     ),
                 ),
-                " MERGE (a: `Person` {name : $0, `~id` : $1}) MERGE (b: `Company` {name : $2, `~id` : $3}) MERGE (a)-[r: `WORKS_FOR` {role : $4}]->(b)",
+                " MERGE (a: `Person` {`name` : $0, `~id` : $1}) MERGE (b: `Company` {`name` : $2, `~id` : $3}) MERGE (a)-[r: `WORKS_FOR` {`role` : $4}]->(b)",
                 {
                     "0": "Alice",
                     "1": "123",
@@ -276,7 +276,7 @@ class TestOpencypherBuilder(unittest.TestCase):
             (
                 "Single label with properties",
                 Node(id="123", labels=["Person"], properties={"name": "Alice"}),
-                " CREATE (: `Person` {name : $0, `~id` : $1})",
+                " CREATE (: `Person` {`name` : $0, `~id` : $1})",
                 {"0": "Alice", "1": "123"},
             ),
             (
@@ -284,7 +284,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 Node(
                     id="456", labels=["Person", "Employee"], properties={"id": "12345"}
                 ),
-                " CREATE (: `Person`: `Employee` {id : $0, `~id` : $1})",
+                " CREATE (: `Person`: `Employee` {`id` : $0, `~id` : $1})",
                 {"0": "12345", "1": "456"},
             ),
             (
@@ -296,7 +296,7 @@ class TestOpencypherBuilder(unittest.TestCase):
             (
                 "No labels with properties",
                 Node(id="111", labels=[], properties={"name": "Alice"}),
-                " CREATE ( {name : $0, `~id` : $1})",
+                " CREATE ( {`name` : $0, `~id` : $1})",
                 {"0": "Alice", "1": "111"},
             ),
             (
@@ -306,7 +306,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["Product"],
                     properties={"price": 29.99, "stock": 100},
                 ),
-                " CREATE (: `Product` {price : $0, stock : $1, `~id` : $2})",
+                " CREATE (: `Product` {`price` : $0, `stock` : $1, `~id` : $2})",
                 {"0": 29.99, "1": 100, "2": "222"},
             ),
             (
@@ -316,7 +316,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["User"],
                     properties={"active": True, "verified": False},
                 ),
-                " CREATE (: `User` {active : $0, verified : $1, `~id` : $2})",
+                " CREATE (: `User` {`active` : $0, `verified` : $1, `~id` : $2})",
                 {"0": True, "1": False, "2": "333"},
             ),
         ]
@@ -346,7 +346,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.since": "2020"},
-                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.since = $4",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.`name` = $2 AND b.`name` = $3 SET r.`since` = $4",
                 {"0": "123", "1": "456", "2": "Alice", "3": "Bob", "4": "2020"},
             ),
             (
@@ -362,7 +362,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.since": "2020", "r.strength": "strong", "r.active": "true"},
-                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.since = $4, r.strength = $5, r.active = $6",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.`name` = $2 AND b.`name` = $3 SET r.`since` = $4, r.`strength` = $5, r.`active` = $6",
                 {
                     "0": "123",
                     "1": "456",
@@ -386,7 +386,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "ACME Inc"},
                 {"r.role": "Engineer", "r.startDate": "2022-01-15"},
-                " MATCH (a: `Person` {`~id` : $0})-[r: `WORKS_FOR`]->(b: `Company` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.role = $4, r.startDate = $5",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `WORKS_FOR`]->(b: `Company` {`~id` : $1}) WHERE a.`name` = $2 AND b.`name` = $3 SET r.`role` = $4, r.`startDate` = $5",
                 {
                     "0": "123",
                     "1": "456",
@@ -413,7 +413,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.strength": "very strong"},
-                " MATCH (a: `Person` {age : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {age : $2, `~id` : $3}) WHERE a.name = $4 AND b.name = $5 SET r.strength = $6",
+                " MATCH (a: `Person` {`age` : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {`age` : $2, `~id` : $3}) WHERE a.`name` = $4 AND b.`name` = $5 SET r.`strength` = $6",
                 {
                     "0": "30",
                     "1": "123",
@@ -441,7 +441,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.department": "Engineering"},
-                " MATCH (a: `Person`: `Employee` {`~id` : $0})-[r: `REPORTS_TO`]->(b: `Person`: `Manager` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.department = $4",
+                " MATCH (a: `Person`: `Employee` {`~id` : $0})-[r: `REPORTS_TO`]->(b: `Person`: `Manager` {`~id` : $1}) WHERE a.`name` = $2 AND b.`name` = $3 SET r.`department` = $4",
                 {"0": "123", "1": "456", "2": "Alice", "3": "Bob", "4": "Engineering"},
             ),
             (
@@ -463,7 +463,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     "r.since": "2018",
                 },
                 {"r.strength": "best friends"},
-                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND a.age = $3 AND b.name = $4 AND b.city = $5 AND r.since = $6 SET r.strength = $7",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.`name` = $2 AND a.`age` = $3 AND b.`name` = $4 AND b.`city` = $5 AND r.`since` = $6 SET r.`strength` = $7",
                 {
                     "0": "123",
                     "1": "456",
@@ -488,7 +488,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.id": "1001"},
                 {"r.quantity": 5, "r.price": 29.99},
-                " MATCH (a: `Person` {`~id` : $0})-[r: `PURCHASED`]->(b: `Product` {`~id` : $1}) WHERE a.name = $2 AND b.id = $3 SET r.quantity = $4, r.price = $5",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `PURCHASED`]->(b: `Product` {`~id` : $1}) WHERE a.`name` = $2 AND b.`id` = $3 SET r.`quantity` = $4, r.`price` = $5",
                 {"0": "123", "1": "456", "2": "Alice", "3": "1001", "4": 5, "5": 29.99},
             ),
             (
@@ -504,7 +504,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.username": "alice123", "b.id": "content-456"},
                 {"r.public": True, "r.notified": False},
-                " MATCH (a: `User` {`~id` : $0})-[r: `LIKED`]->(b: `Content` {`~id` : $1}) WHERE a.username = $2 AND b.id = $3 SET r.public = $4, r.notified = $5",
+                " MATCH (a: `User` {`~id` : $0})-[r: `LIKED`]->(b: `Content` {`~id` : $1}) WHERE a.`username` = $2 AND b.`id` = $3 SET r.`public` = $4, r.`notified` = $5",
                 {
                     "0": "123",
                     "1": "456",
@@ -527,7 +527,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "b",
                 {"a.name": "Alice", "b.name": "Bob"},
                 {"r.endDate": None},
-                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.name = $2 AND b.name = $3 SET r.endDate = $4",
+                " MATCH (a: `Person` {`~id` : $0})-[r: `FRIEND_WITH`]->(b: `Person` {`~id` : $1}) WHERE a.`name` = $2 AND b.`name` = $3 SET r.`endDate` = $4",
                 {"0": "123", "1": "456", "2": "Alice", "3": "Bob", "4": None},
             ),
             (
@@ -543,7 +543,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "actor",
                 {"movie.title": "The Matrix", "actor.name": "Keanu Reeves"},
                 {"role.character": "Neo"},
-                " MATCH (movie: `Movie` {`~id` : $0})-[role: `ACTED_IN`]->(actor: `Person` {`~id` : $1}) WHERE movie.title = $2 AND actor.name = $3 SET role.character = $4",
+                " MATCH (movie: `Movie` {`~id` : $0})-[role: `ACTED_IN`]->(actor: `Person` {`~id` : $1}) WHERE movie.`title` = $2 AND actor.`name` = $3 SET role.`character` = $4",
                 {
                     "0": "123",
                     "1": "456",
@@ -589,7 +589,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["Alice"],
                 {"a.age": "25"},
-                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.age = $1",
+                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.`age` = $1",
                 {"0": "Alice", "1": "25"},
             ),
             (
@@ -598,7 +598,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["12345"],
                 {"a.age": "30", "a.status": "Active", "a.updated": "true"},
-                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.age = $1, a.status = $2, a.updated = $3",
+                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.`age` = $1, a.`status` = $2, a.`updated` = $3",
                 {"0": "12345", "1": "30", "2": "Active", "3": "true"},
             ),
             (
@@ -607,7 +607,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["alice@example.com"],
                 {"a.department": "Engineering"},
-                " MATCH (a: `Person`: `Employee`) WHERE id(a)=$0 SET a.department = $1",
+                " MATCH (a: `Person`: `Employee`) WHERE id(a)=$0 SET a.`department` = $1",
                 {"0": "alice@example.com", "1": "Engineering"},
             ),
             (
@@ -616,7 +616,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["Alice", "Bob"],
                 {"a.lastLogin": "2023-04-01"},
-                " MATCH (a: `Person`) WHERE id(a)=$0 OR id(a)=$1 SET a.lastLogin = $2",
+                " MATCH (a: `Person`) WHERE id(a)=$0 OR id(a)=$1 SET a.`lastLogin` = $2",
                 {"0": "Alice", "1": "Bob", "2": "2023-04-01"},
             ),
             (
@@ -625,7 +625,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "p",
                 ["1001"],
                 {"p.price": 29.99, "p.stock": 100},
-                " MATCH (p: `Product`) WHERE id(p)=$0 SET p.price = $1, p.stock = $2",
+                " MATCH (p: `Product`) WHERE id(p)=$0 SET p.`price` = $1, p.`stock` = $2",
                 {"0": "1001", "1": 29.99, "2": 100},
             ),
             (
@@ -634,7 +634,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "u",
                 ["alice123"],
                 {"u.verified": True, "u.active": False},
-                " MATCH (u: `User`) WHERE id(u)=$0 SET u.verified = $1, u.active = $2",
+                " MATCH (u: `User`) WHERE id(u)=$0 SET u.`verified` = $1, u.`active` = $2",
                 {"0": "alice123", "1": True, "2": False},
             ),
             (
@@ -643,7 +643,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "a",
                 ["Alice"],
                 {"a.previousJob": None},
-                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.previousJob = $1",
+                " MATCH (a: `Person`) WHERE id(a)=$0 SET a.`previousJob` = $1",
                 {"0": "Alice", "1": None},
             ),
             (
@@ -652,7 +652,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 "movie",
                 ["The Matrix"],
                 {"movie.rating": 4.8},
-                " MATCH (movie: `Movie`) WHERE id(movie)=$0 SET movie.rating = $1",
+                " MATCH (movie: `Movie`) WHERE id(movie)=$0 SET movie.`rating` = $1",
                 {"0": "The Matrix", "1": 4.8},
             ),
         ]
@@ -682,7 +682,7 @@ class TestOpencypherBuilder(unittest.TestCase):
             (
                 "Single label with properties",
                 Node(id="123", labels=["Person"], properties={"name": "Alice"}),
-                " MATCH (n: `Person` {name : $0, `~id` : $1}) DELETE n",
+                " MATCH (n: `Person` {`name` : $0, `~id` : $1}) DELETE n",
                 {"0": "Alice", "1": "123"},
             ),
             (
@@ -690,7 +690,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                 Node(
                     id="456", labels=["Person", "Employee"], properties={"id": "12345"}
                 ),
-                " MATCH (n: `Person`: `Employee` {id : $0, `~id` : $1}) DELETE n",
+                " MATCH (n: `Person`: `Employee` {`id` : $0, `~id` : $1}) DELETE n",
                 {"0": "12345", "1": "456"},
             ),
             (
@@ -702,7 +702,7 @@ class TestOpencypherBuilder(unittest.TestCase):
             (
                 "No labels with properties",
                 Node(id="111", labels=[], properties={"name": "Alice"}),
-                " MATCH (n {name : $0, `~id` : $1}) DELETE n",
+                " MATCH (n {`name` : $0, `~id` : $1}) DELETE n",
                 {"0": "Alice", "1": "111"},
             ),
             (
@@ -712,7 +712,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["Product"],
                     properties={"price": 29.99, "stock": 100},
                 ),
-                " MATCH (n: `Product` {price : $0, stock : $1, `~id` : $2}) DELETE n",
+                " MATCH (n: `Product` {`price` : $0, `stock` : $1, `~id` : $2}) DELETE n",
                 {"0": 29.99, "1": 100, "2": "222"},
             ),
             (
@@ -722,13 +722,13 @@ class TestOpencypherBuilder(unittest.TestCase):
                     labels=["User"],
                     properties={"active": True, "verified": False},
                 ),
-                " MATCH (n: `User` {active : $0, verified : $1, `~id` : $2}) DELETE n",
+                " MATCH (n: `User` {`active` : $0, `verified` : $1, `~id` : $2}) DELETE n",
                 {"0": True, "1": False, "2": "333"},
             ),
             (
                 "Null property value",
                 Node(id="444", labels=["Person"], properties={"previousJob": None}),
-                " MATCH (n: `Person` {previousJob : $0, `~id` : $1}) DELETE n",
+                " MATCH (n: `Person` {`previousJob` : $0, `~id` : $1}) DELETE n",
                 {"0": None, "1": "444"},
             ),
         ]
@@ -757,7 +757,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {`name` : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {`name` : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             (
@@ -772,7 +772,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {`name` : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {`name` : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             (
@@ -798,7 +798,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Company"], properties={"name": "ACME Inc"}
                     ),
                 ),
-                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `WORKS_FOR`]->(b: `Company` {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {`name` : $0, `~id` : $1})-[r: `WORKS_FOR`]->(b: `Company` {`name` : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "ACME Inc", "3": "456"},
             ),
             (
@@ -817,7 +817,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         properties={"name": "Bob"},
                     ),
                 ),
-                " MATCH (a: `Person`: `Employee` {name : $0, `~id` : $1})-[r: `REPORTS_TO`]->(b: `Person`: `Manager` {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person`: `Employee` {`name` : $0, `~id` : $1})-[r: `REPORTS_TO`]->(b: `Person`: `Manager` {`name` : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
             (
@@ -832,7 +832,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Product"], properties={"id": "1001"}
                     ),
                 ),
-                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `PURCHASED`]->(b: `Product` {id : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {`name` : $0, `~id` : $1})-[r: `PURCHASED`]->(b: `Product` {`id` : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "1001", "3": "456"},
             ),
             (
@@ -847,7 +847,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Content"], properties={"id": "content-456"}
                     ),
                 ),
-                " MATCH (a: `User` {username : $0, `~id` : $1})-[r: `LIKED`]->(b: `Content` {id : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `User` {`username` : $0, `~id` : $1})-[r: `LIKED`]->(b: `Content` {`id` : $2, `~id` : $3}) DELETE r",
                 {"0": "alice123", "1": "123", "2": "content-456", "3": "456"},
             ),
             (
@@ -862,7 +862,7 @@ class TestOpencypherBuilder(unittest.TestCase):
                         id="456", labels=["Person"], properties={"name": "Bob"}
                     ),
                 ),
-                " MATCH (a: `Person` {name : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {name : $2, `~id` : $3}) DELETE r",
+                " MATCH (a: `Person` {`name` : $0, `~id` : $1})-[r: `FRIEND_WITH`]->(b: `Person` {`name` : $2, `~id` : $3}) DELETE r",
                 {"0": "Alice", "1": "123", "2": "Bob", "3": "456"},
             ),
         ]

--- a/tests/clients/test_opencypher_injection.py
+++ b/tests/clients/test_opencypher_injection.py
@@ -23,10 +23,13 @@ import pytest
 from nx_neptune.clients import Edge, Node
 from nx_neptune.clients.opencypher_builder import (
     _escape_identifier,
+    _escape_property_key,
+    _escape_property_path,
     _to_parameter_list,
     insert_edge,
     insert_node,
     pagerank_query,
+    update_edge,
     update_node,
     wcc_query,
 )
@@ -167,7 +170,6 @@ class TestLabelInjection:
         assert "`Person`" in query
 
     def test_update_node_match_label_escaped(self):
-        node = Node(id="a", labels=[], properties={})
         query, _ = update_node(IDENTIFIER_INJECTION_PAYLOAD, "a", ["a"], {"a.x": "1"})
         assert "`X``}) MATCH (m) DETACH DELETE m //`" in query
 
@@ -180,3 +182,99 @@ class TestEscapeIdentifierHelper:
     def test_rejects_non_string(self):
         with pytest.raises(ValueError):
             _escape_identifier(123)
+
+
+# A property KEY (attribute name) crafted to break out of the ``{key: $N}``
+# map and inject a destructive clause, with the trailing ``//`` swallowing the
+# rest of the generated query. This is the exact primitive from the finding.
+KEY_INJECTION_PAYLOAD = "x: 1}) MATCH (m) DETACH DELETE m //"
+
+
+class TestPropertyKeyInjection:
+    """Prove node/edge property KEYS cannot inject openCypher syntax.
+
+    Property values and node IDs are parameterized ($N); these tests cover the
+    remaining key (attribute name) side, at every singular write/update sink.
+    """
+
+    def test_insert_node_property_key_backtick_escaped(self):
+        node = Node(id="a", labels=["Person"], properties={KEY_INJECTION_PAYLOAD: 1})
+        query, _ = insert_node(node)
+        # The malicious key is confined inside a backtick identifier: the payload
+        # appears backtick-wrapped, and there is no bare `}) MATCH` breakout.
+        assert f"`{KEY_INJECTION_PAYLOAD}`" in query
+        assert "1}) MATCH (m) DETACH DELETE m //`" in query  # inside backticks
+        # The dangerous unquoted breakout must NOT appear.
+        assert "{x: 1}) MATCH (m) DETACH DELETE m //" not in query
+        # ~id is present and single-escaped (not double-escaped).
+        assert "`~id`" in query
+        assert "``~id``" not in query
+
+    def test_insert_edge_property_key_backtick_escaped(self):
+        src = Node(id="a", labels=["Person"], properties={})
+        dest = Node(id="b", labels=["Person"], properties={})
+        edge = Edge(
+            label="FRIEND_WITH",
+            properties={KEY_INJECTION_PAYLOAD: 1},
+            node_src=src,
+            node_dest=dest,
+        )
+        query, _ = insert_edge(edge)
+        assert f"`{KEY_INJECTION_PAYLOAD}`" in query
+        assert "{x: 1}) MATCH (m) DETACH DELETE m //" not in query
+
+    def test_update_node_set_key_escaped_ref_preserved(self):
+        # A dotted SET key: only the property segment is escaped, the code-
+        # generated reference prefix (``a``) stays bare so the SET is valid.
+        node_query = update_node(
+            "Person", "a", ["Alice"], {f"a.{KEY_INJECTION_PAYLOAD}": "1"}
+        )
+        query = node_query[0]
+        assert f"a.`{KEY_INJECTION_PAYLOAD}`" in query
+        assert "SET a.x: 1}) MATCH (m) DETACH DELETE m //" not in query
+
+    def test_update_edge_set_and_where_keys_escaped(self):
+        src = Node(id="a", labels=["Person"], properties={})
+        dest = Node(id="b", labels=["Person"], properties={})
+        edge = Edge(label="FRIEND_WITH", properties={}, node_src=src, node_dest=dest)
+        query, _ = update_edge(
+            "a",
+            "r",
+            edge,
+            "b",
+            {f"a.{KEY_INJECTION_PAYLOAD}": "Alice"},  # WHERE filter key
+            {f"r.{KEY_INJECTION_PAYLOAD}": "1"},  # SET key
+        )
+        assert f"a.`{KEY_INJECTION_PAYLOAD}`" in query
+        assert f"r.`{KEY_INJECTION_PAYLOAD}`" in query
+        assert "MATCH (m) DETACH DELETE m //}" not in query
+        assert "= 1}) MATCH (m) DETACH DELETE m //" not in query
+
+
+class TestEscapePropertyKeyHelpers:
+    def test_plain_key_wrapped_and_doubled(self):
+        assert _escape_property_key("name") == "`name`"
+        assert _escape_property_key("~id") == "`~id`"
+        # An embedded backtick is doubled so it can't terminate the identifier.
+        assert (
+            _escape_property_key("a`) DETACH DELETE n //")
+            == "`a``) DETACH DELETE n //`"
+        )
+
+    def test_path_escapes_only_property_segment(self):
+        assert _escape_property_path("a.age") == "a.`age`"
+        assert _escape_property_path("r.since") == "r.`since`"
+
+    def test_path_passes_through_structural_predicate(self):
+        # id(n) carries no property name — left intact so the WHERE stays valid.
+        assert _escape_property_path("id(n)") == "id(n)"
+
+    def test_path_neutralizes_malicious_predicate_lookalike(self):
+        # A key that merely starts like id(...) but carries a payload does NOT
+        # match the strict shape and is escaped wholesale.
+        payload = "id(n) }) MATCH (m) DETACH DELETE m //"
+        assert _escape_property_path(payload) == f"`{payload}`"
+
+    def test_path_neutralizes_malicious_bare_key(self):
+        payload = "x }) DETACH DELETE m //"
+        assert _escape_property_path(payload) == f"`{payload}`"

--- a/tests/clients/test_parameter_map_builder.py
+++ b/tests/clients/test_parameter_map_builder.py
@@ -27,8 +27,9 @@ class TestParameterMapBuilder:
 
         masked_params = builder.read_map(params)
 
-        # Check masked parameters
-        assert masked_params == {"name": "$0"}
+        # Keys are backtick-escaped at this choke point (injection guard);
+        # values are masked as $N placeholders.
+        assert masked_params == {"`name`": "$0"}
 
         # Check internal parameter values
         param_values = builder._param_values
@@ -44,8 +45,8 @@ class TestParameterMapBuilder:
 
         masked_params = builder.read_map(params)
 
-        # Check masked parameters
-        assert masked_params == {"name": "$0", "age": "$1", "city": "$2"}
+        # Keys are backtick-escaped; values masked as $N.
+        assert masked_params == {"`name`": "$0", "`age`": "$1", "`city`": "$2"}
 
         # Check internal parameter values
         param_values = builder._param_values
@@ -61,17 +62,17 @@ class TestParameterMapBuilder:
         # First read call
         params1 = {"name": "John"}
         masked_params1 = builder.read_map(params1)
-        assert masked_params1 == {"name": "$0"}
+        assert masked_params1 == {"`name`": "$0"}
 
         # Second read call
         params2 = {"age": 30}
         masked_params2 = builder.read_map(params2)
-        assert masked_params2 == {"age": "$1"}
+        assert masked_params2 == {"`age`": "$1"}
 
         # Third read call
         params3 = {"city": "Seattle"}
         masked_params3 = builder.read_map(params3)
-        assert masked_params3 == {"city": "$2"}
+        assert masked_params3 == {"`city`": "$2"}
 
         # Check all parameter values were accumulated
         param_values = builder.get_param_values()


### PR DESCRIPTION
 
**Summary**
  
  Extends the query builder's identifier-escaping to cover property keys (attribute names), completing the escaping already applied to labels, relationship types, and algorithm-parameter keys. Property values and IDs continue to be parameterized ($N); this rounds out consistent handling of the identifier side of the query.
  
**What changed**
  
  Previously ParameterMapBuilder.read_map masked values as $N but emitted keys as-is. Since openCypher has no parameter placeholder for identifier positions, keys are now backtick-escaped in the builder the same way labels already are — so any attribute name (including unusual ones with special characters) is emitted as a well-formed identifier.
  
  nx_neptune/clients/opencypher_builder.py:
  
  - Escape keys at the single read_map choke point.
  - New KeyStyle enum for the two key shapes the builder produces:
    - PLAIN (default) — bare property names (CREATE/MERGE maps): escaped wholesale.
    - PATH — SET/WHERE keys: a.age → a.`age` (escape only the property segment); id(n) predicates pass through unchanged; anything unexpected is escaped defensively.
  
  - Removed now-redundant `~id` pre-backticking (the choke point handles it).
  - Applied PATH at the reference/predicate callers (update_node/edge, bfs_query, descendants_*, bfs_layers_query, jaccard_*).
  
**Testing**
  
  - New TestPropertyKeyInjection + escaper-helper tests (test_opencypher_injection.py).
  - New integration test test_security_property_key_injection.py — round-trips unusual/edge-case attribute names against a real graph, with positive controls confirming plain keys, dotted
  ref.prop references, and id(n) predicates still behave correctly.
  - Updated expected-query fixtures (test_opencypher_builder.py, test_parameter_map_builder.py).
  - Full unit suite 443 passed; flake8 + black clean.
  
  